### PR TITLE
Add spacing tokens

### DIFF
--- a/.changeset/nine-frogs-smoke.md
+++ b/.changeset/nine-frogs-smoke.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Adding tokens for spacing

--- a/css/src/tokens/index.scss
+++ b/css/src/tokens/index.scss
@@ -1,5 +1,6 @@
 @import './palette';
 @import './colors';
 @import './shadow';
+@import './spacing';
 @import './themes';
 @import './z-index';

--- a/css/src/tokens/spacing.scss
+++ b/css/src/tokens/spacing.scss
@@ -17,11 +17,11 @@ $spacer-13: 8rem !default; // 128px;
 $spacer-14: 10rem !default; // 160px;
 
 //layout spacing sizes
-$layout-0: 0rem !default; // 0
-$layout-1: 1rem !default; // 16px
-$layout-2: 1.5rem !default; // 24px
-$layout-3: 2rem !default; // 32px
-$layout-4: 3rem !default; // 48px
-$layout-5: 4rem !default; // 64px
-$layout-6: 6rem !default; // 96px
-$layout-7: 8rem !default; // 128px
+$layout-0: $spacer-0 !default; // 0
+$layout-1: $spacer-5 !default; // 16px
+$layout-2: $spacer-7 !default; // 24px
+$layout-3: $spacer-8 !default; // 32px
+$layout-4: $spacer-10 !default; // 48px
+$layout-5: $spacer-11 !default; // 64px
+$layout-6: $spacer-12 !default; // 96px
+$layout-7: $spacer-13 !default; // 128px

--- a/css/src/tokens/spacing.scss
+++ b/css/src/tokens/spacing.scss
@@ -1,0 +1,27 @@
+// spacing related sizes
+
+$spacer-0: 0 !default; // 0
+$spacer-1: 0.125rem !default; // 2px
+$spacer-2: 0.25rem !default; // 4px
+$spacer-3: 0.5rem !default; // 8px
+$spacer-4: 0.75rem !default; // 12px
+$spacer-5: 1rem !default; // 16px
+$spacer-6: 1.25rem !default; // 20px;
+$spacer-7: 1.5rem !default; // 24px;
+$spacer-8: 2rem !default; // 32px;
+$spacer-9: 2.5rem !default; // 40px;
+$spacer-10: 3rem !default; // 48px;
+$spacer-11: 4rem !default; // 64px;
+$spacer-12: 6rem !default; // 96px;
+$spacer-13: 8rem !default; // 128px;
+$spacer-14: 10rem !default; // 160px;
+
+//layout spacing sizes
+$layout-0: 0rem !default; // 0
+$layout-1: 1rem !default; // 16px
+$layout-2: 1.5rem !default; // 24px
+$layout-3: 2rem !default; // 32px
+$layout-4: 3rem !default; // 48px
+$layout-5: 4rem !default; // 64px
+$layout-6: 6rem !default; // 96px
+$layout-7: 8rem !default; // 128px


### PR DESCRIPTION
task-378370

Create _spacing.scss_ to store spacing and layout spacing tokens. 

See https://github.com/microsoft/atlas-design/blob/ming/spacing-ramp/spacing-ramp.md for tables displaying the mapping from current values to new values.
