### PR TITLE
Create Github Action to sensibility check PRs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: Pull Request
 
 # Controls when the action will run.
 on:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,46 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a set of commands using the runners shell
+      - name: Go to workspace
+        run: cd "${{github.workspace}}";
+
+      # Monorepo installation
+      - name: Yarn install
+        run: yarn install;
+
+      # Run formatting check
+      - name: Check formatting
+        run: yarn prettier-check;
+
+      # Run lint
+      - name: Run lint
+        run: yarn lint;
+
+      # Run Dart Sass build
+      - name: Build CSS
+        run: |
+          mkdir ./css/dist;
+          yarn build:css;

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,11 +2,11 @@
 
 name: CI
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
task-378389

Similar to #20, but without a publish step and will run when a PR opens. Needs to wait on #20.

Example run: https://github.com/microsoft/atlas-design/pull/21/checks?check_run_id=2088457660