### PR TITLE
Add sass validation for themes object

### DIFF
--- a/css/src/core/themes.scss
+++ b/css/src/core/themes.scss
@@ -3,12 +3,40 @@
 $root-theme: 'light' !default;
 $print-theme: 'light' !default;
 
+// Ensure that the root theme exists
 @if map.has-key($themes, $root-theme) != true {
 	@error "Cannot build themes because $root-theme (#{$root-theme}) is set to a theme that does not exist in $themes map.";
 }
 
+// Ensure that the print theme exists
 @if map.has-key($themes, $print-theme) != true {
 	@error "Cannot build themes because $print-theme (#{$print-theme}) is set to a theme that does not exist in $themes map.";
+}
+
+$theme-names: map.keys($themes);
+
+// Validation: ensure that all values in the root theme are in the other themes too
+@each $root-color-name, $val in map.get($themes, $root-theme) {
+	@each $theme-name in $theme-names {
+		@if $theme-name != $root-theme {
+			@if map.has-key(map.get($themes, $theme-name), $root-color-name) != true {
+				@error '#{$root-color-name} from #{$root-theme} does not exist in theme: #{$theme-name}.';
+			}
+		}
+	}
+}
+
+// Validation: ensure all properties in non-root themes exist root
+@each $theme-name in $theme-names {
+	$theme: map.get($themes, $theme-name);
+	@if $theme-name != $root-theme {
+		$root: map.get($themes, $root-theme);
+		@each $color-name, $val in $theme {
+			@if map.has-key($root, $color-name) != true {
+				@error '#{$color-name} from #{$theme-name} does not exist in theme: #{$theme-name}.';
+			}
+		}
+	}
 }
 
 @each $key, $value in $themes {

--- a/css/src/core/themes.scss
+++ b/css/src/core/themes.scss
@@ -26,7 +26,7 @@ $theme-names: map.keys($themes);
 	}
 }
 
-// Validation: ensure all properties in non-root themes exist root
+// Validation: ensure all properties in non-root themes exist in root
 @each $theme-name in $theme-names {
 	$theme: map.get($themes, $theme-name);
 	@if $theme-name != $root-theme {


### PR DESCRIPTION
task-378379

Add some validation to ensure theme map property names are all matching across different themes.

## Testing

1. Checkout branch.
2. Run `yarn build:css`. Should pass.
3. Add a new property in the light theme (but not in the others). Run `yarn build:css`. Should fail with a helpful error.
4. Add a new property in the dark or high-contrast theme, Run `yarn build:css`. Should fail with a helpful error.

No changeset needed.