### PR TITLE
Add font stack

### DIFF
--- a/.changeset/warm-brooms-float.md
+++ b/.changeset/warm-brooms-float.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Add font stack"

--- a/css/src/core/font-stack.scss
+++ b/css/src/core/font-stack.scss
@@ -12,7 +12,6 @@ samp {
 	font-family: $monospace-font-stack !important;
 	-moz-osx-font-smoothing: auto;
 	-webkit-font-smoothing: auto;
-	line-height: 1.1875;
 }
 
 code {

--- a/css/src/core/font-stack.scss
+++ b/css/src/core/font-stack.scss
@@ -12,7 +12,7 @@ samp {
 	font-family: $monospace-font-stack !important;
 	-moz-osx-font-smoothing: auto;
 	-webkit-font-smoothing: auto;
-	line-height: 19px;
+	line-height: 1.1875;
 }
 
 code {

--- a/css/src/core/font-stack.scss
+++ b/css/src/core/font-stack.scss
@@ -1,0 +1,25 @@
+html,
+body {
+	font-family: $normal-font-stack;
+	-webkit-font-smoothing: antialiased;
+	font-weight: $weight-normal;
+	text-rendering: optimizeLegibility;
+}
+
+kbd,
+pre,
+samp {
+	font-family: $monospace-font-stack !important;
+	-moz-osx-font-smoothing: auto;
+	-webkit-font-smoothing: auto;
+	line-height: 19px;
+}
+
+code {
+	direction: ltr;
+	font-family: $monospace-font-stack;
+}
+
+a > code {
+	font-family: $normal-font-stack;
+}

--- a/css/src/core/index.scss
+++ b/css/src/core/index.scss
@@ -1,3 +1,4 @@
 @import 'normalize.css';
 @import 'minireset.css';
 @import 'themes.scss';
+@import 'font-stack.scss';

--- a/css/src/tokens/font-stack.scss
+++ b/css/src/tokens/font-stack.scss
@@ -1,6 +1,6 @@
 $monospace-font-stack: 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', 'Courier',
-	monospace;
+	monospace !default;
 $normal-font-stack: -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
 	'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif,
-	'Apple Color Emoji', 'Segoe UI Emoji';
+	'Apple Color Emoji', 'Segoe UI Emoji' !default;
 $quote-font-stack: 'Arial', 'Helvetica Neue', 'Helvetica', sans-serif !default;

--- a/css/src/tokens/font-stack.scss
+++ b/css/src/tokens/font-stack.scss
@@ -1,0 +1,6 @@
+$monospace-font-stack: 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', 'Courier',
+	monospace;
+$normal-font-stack: -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+	'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif,
+	'Apple Color Emoji', 'Segoe UI Emoji';
+$quote-font-stack: 'Arial', 'Helvetica Neue', 'Helvetica', sans-serif !default;

--- a/css/src/tokens/index.scss
+++ b/css/src/tokens/index.scss
@@ -3,6 +3,7 @@
 @import './colors.scss';
 @import './direction.scss';
 @import './focus.scss';
+@import './font-stack.scss';
 @import './layout.scss';
 @import './radius.scss';
 @import './shadow.scss';


### PR DESCRIPTION
task-[378382]

This PR adds the default, monospace, and quote font stack. The font stack replicates the one used by Bulma, which is a comprehensive font stack that covers different type of devices. I also moved two emoji fonts from existing font face rule into the stack. 
- https://github.com/jgthms/bulma/blob/master/sass/utilities/initial-variables.sass
  - -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif

For reference, this page includes a table that lists out the devices targeted for each font. 
- https://www.wpmediamastery.com/why-and-how-to-use-a-system-font-stack/
  - How To Implement A System Font Stack

The page describes the thought process for Github's font stack, which is a more simple font stack. The post mentions some previous issues with 'Roboto' and other fonts. However, the post was written a few years ago and I haven't found much evidence that it's still a problem today. 
- https://markdotto.com/2018/02/07/github-system-fonts/
  - -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,sans-serif, Apple Color Emoji, Segoe UI Emoji

stylelint is requiring non-keywords to be lower case, so I added quotes to the font names. I think this is okay as it makes a clear distinction between font family names and generic font families (monospace, etc). We could add a list of exceptions to the "value-keyword-case" rule, but it seems hard to maintain.

## Testing

1. Review changes.

