### PR TITLE
implement toc generation with some configuration

### DIFF
--- a/.changeset/smooth-avocados-think.md
+++ b/.changeset/smooth-avocados-think.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': patch
+---
+
+Add table of contents generation.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,11 @@ jobs:
           mkdir ./css/dist;
           yarn build:css;
 
+      # Run build for website
+      - name: Build build site
+        run: |
+          yarn build:site;
+
       # If the version has been incremented (with `yarn changeset version`), publish package
       - name: Publish on version increment
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .cache
 .parcel-cache
 *.log
+toc.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ node_modules
 dist
 .cache
 .parcel-cache
+standard.html

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"serve:css": "yarn workspace @microsoft/atlas-css start",
 		"build:css": "yarn workspace @microsoft/atlas-css build",
 		"build:site": "yarn workspace @microsoft/atlas-site build",
+		"toc": "yarn workspace @microsoft/atlas-site toc",
 		"prettier": "prettier --write \"**/*.{scss,ts,js,json,yml,md}\"",
 		"prettier-check": "prettier --check \"**/*.{scss,ts,js,json,yml}\" --loglevel debug",
 		"pretty-quick": "pretty-quick --staged --pattern \"**/*.{scss,ts,js,json,yml}\""

--- a/plugins/parcel-transformer-markdown-html/lib/index.js
+++ b/plugins/parcel-transformer-markdown-html/lib/index.js
@@ -62,7 +62,7 @@ module.exports = new Transformer({
 			const templateLocation = path.resolve(basePath, `${attributes.template}.html`);
 
 			const template = await options.inputFS.readFile(templateLocation, 'utf-8');
-			const tocPages = tocPath
+			const tocEntries = tocPath
 				? await options.inputFS.readFile(tocPath, 'utf-8').then(r => JSON.parse(r))
 				: null;
 
@@ -73,7 +73,7 @@ module.exports = new Transformer({
 			asset.setCode(
 				mustache.render(template, {
 					body: parsedCode,
-					toc: { name: 'TOC', pages: tocPages },
+					toc: { name: 'TOC', entries: tocEntries },
 					...attributes
 				})
 			);

--- a/plugins/parcel-transformer-markdown-html/lib/index.js
+++ b/plugins/parcel-transformer-markdown-html/lib/index.js
@@ -66,9 +66,13 @@ module.exports = new Transformer({
 				? await options.inputFS.readFile(tocPath, 'utf-8').then(r => JSON.parse(r))
 				: null;
 
-			asset.addIncludedFile({
-				filePath: templateLocation
-			});
+			// asset.addIncludedFile({
+			// 	filePath: tocEntries
+			// });
+
+			// asset.addIncludedFile({
+			// 	filePath: templateLocation
+			// });
 
 			asset.setCode(
 				mustache.render(template, {

--- a/plugins/parcel-transformer-markdown-html/lib/index.js
+++ b/plugins/parcel-transformer-markdown-html/lib/index.js
@@ -66,13 +66,13 @@ module.exports = new Transformer({
 				? await options.inputFS.readFile(tocPath, 'utf-8').then(r => JSON.parse(r))
 				: null;
 
-			// asset.addIncludedFile({
-			// 	filePath: tocEntries
-			// });
+			asset.addIncludedFile({
+				filePath: tocEntries
+			});
 
-			// asset.addIncludedFile({
-			// 	filePath: templateLocation
-			// });
+			asset.addIncludedFile({
+				filePath: templateLocation
+			});
 
 			asset.setCode(
 				mustache.render(template, {

--- a/plugins/parcel-transformer-markdown-html/lib/index.js
+++ b/plugins/parcel-transformer-markdown-html/lib/index.js
@@ -58,9 +58,13 @@ module.exports = new Transformer({
 				config.filePath.replace('.scaffoldrc', ''),
 				config.contents.templatePath
 			);
+			const tocPath = config.contents.tocPath || '';
 			const templateLocation = path.resolve(basePath, `${attributes.template}.html`);
 
 			const template = await options.inputFS.readFile(templateLocation, 'utf-8');
+			const tocPages = tocPath
+				? await options.inputFS.readFile(tocPath, 'utf-8').then(r => JSON.parse(r))
+				: null;
 
 			asset.addIncludedFile({
 				filePath: templateLocation
@@ -69,6 +73,7 @@ module.exports = new Transformer({
 			asset.setCode(
 				mustache.render(template, {
 					body: parsedCode,
+					toc: { name: 'TOC', pages: tocPages },
 					...attributes
 				})
 			);

--- a/plugins/parcel-transformer-markdown-html/lib/index.js
+++ b/plugins/parcel-transformer-markdown-html/lib/index.js
@@ -61,10 +61,12 @@ module.exports = new Transformer({
 			const tocPath = config.contents.tocPath || '';
 			const templateLocation = path.resolve(basePath, `${attributes.template}.html`);
 
-			const template = await options.inputFS.readFile(templateLocation, 'utf-8');
-			const tocEntries = tocPath
-				? await options.inputFS.readFile(tocPath, 'utf-8').then(r => JSON.parse(r))
-				: null;
+			const [template, tocEntries] = await Promise.all([
+				options.inputFS.readFile(templateLocation, 'utf-8'),
+				tocPath
+					? options.inputFS.readFile(tocPath, 'utf-8').then(r => JSON.parse(r))
+					: Promise.resolve(null)
+			]);
 
 			asset.addIncludedFile({
 				filePath: tocEntries

--- a/site/.scaffoldrc
+++ b/site/.scaffoldrc
@@ -1,3 +1,4 @@
 {
-	"templatePath": "src/scaffold/"
+	"templatePath": "src/scaffold/",
+	"tocPath": "src/scaffold/toc.json"
 }

--- a/site/package.json
+++ b/site/package.json
@@ -6,8 +6,8 @@
 	"scripts": {
 		"prebuild": "node toc.js",
 		"prestart": "node toc.js",
-		"start": "parcel './src/**/*.md' --port 1111 --open --no-cache",
-		"build": "parcel build './src/**/*.md'  --no-cache",
+		"start": "parcel \"./src/**/*.md\" --port 1111 --open --no-cache --log-level=verbose",
+		"build": "parcel build \"./src/**/*.md\" --no-cache",
 		"toc": "node toc.js"
 	},
 	"devDependencies": {

--- a/site/package.json
+++ b/site/package.json
@@ -6,8 +6,8 @@
 	"scripts": {
 		"prebuild": "node toc.js",
 		"prestart": "node toc.js",
-		"start": "parcel ./src/**/*.md --port 1111 --open --no-cache",
-		"build": "parcel build ./src/**/*.md  --no-cache",
+		"start": "parcel './src/**/*.md' --port 1111 --open --no-cache",
+		"build": "parcel build './src/**/*.md'  --no-cache",
 		"toc": "node toc.js"
 	},
 	"devDependencies": {

--- a/site/package.json
+++ b/site/package.json
@@ -4,12 +4,17 @@
 	"license": "MIT",
 	"private": true,
 	"scripts": {
-		"start": "parcel src/**/*.md --port 1111 --open",
-		"build": "parcel build src/**/*.md"
+		"prebuild": "node toc.js",
+		"prestart": "node toc.js",
+		"start": "parcel src/**/*.md --port 1111 --open --no-cache",
+		"build": "parcel build src/**/*.md",
+		"toc": "node toc.js"
 	},
 	"devDependencies": {
 		"@microsoft/atlas-css": "^0.3.0",
 		"parcel": "next",
-		"@microsoft/parcel-transformer-markdown-html": "^2.0.0-alpha.3.1"
+		"@microsoft/parcel-transformer-markdown-html": "^2.0.0-alpha.3.1",
+		"fs-extra": "^9.1.0",
+		"front-matter": "^4.0.2"
 	}
 }

--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"prebuild": "node toc.js",
 		"prestart": "node toc.js",
-		"start": "parcel \"./src/**/*.md\" --port 1111 --open --no-cache --log-level=verbose",
+		"start": "parcel \"./src/**/*.md\" --port 1111 --open --no-cache",
 		"build": "parcel build \"./src/**/*.md\" --no-cache",
 		"toc": "node toc.js"
 	},

--- a/site/package.json
+++ b/site/package.json
@@ -6,8 +6,8 @@
 	"scripts": {
 		"prebuild": "node toc.js",
 		"prestart": "node toc.js",
-		"start": "parcel ~/src/*.md --port 1111 --open --no-cache",
-		"build": "parcel build src/**/*.md  --no-cache",
+		"start": "parcel ./src/**/*.md --port 1111 --open --no-cache",
+		"build": "parcel build ./src/**/*.md  --no-cache",
 		"toc": "node toc.js"
 	},
 	"devDependencies": {

--- a/site/package.json
+++ b/site/package.json
@@ -7,7 +7,7 @@
 		"prebuild": "node toc.js",
 		"prestart": "node toc.js",
 		"start": "parcel ~/src/*.md --port 1111 --open --no-cache",
-		"build": "parcel build src/*.md  --no-cache",
+		"build": "parcel build src/**/*.md  --no-cache",
 		"toc": "node toc.js"
 	},
 	"devDependencies": {

--- a/site/package.json
+++ b/site/package.json
@@ -6,8 +6,8 @@
 	"scripts": {
 		"prebuild": "node toc.js",
 		"prestart": "node toc.js",
-		"start": "parcel src/**/*.md --port 1111 --open --no-cache",
-		"build": "parcel build src/**/*.md",
+		"start": "parcel ~/src/*.md --port 1111 --open --no-cache",
+		"build": "parcel build src/*.md  --no-cache",
 		"toc": "node toc.js"
 	},
 	"devDependencies": {

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -24,12 +24,12 @@
 							<p>{{name}}</p>
 							<div style="border: 1px solid aliceblue; margin-inline-start: 1rem;">
 								{{#children}}
-									<a style="margin-top: 1rem" href="{{{}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+									<a style="margin-top: 1rem" href="{{filePath}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
 								{{/children}}
 							</div>
 						{{/isDirectory}}
 						{{^children.0}}
-							<a href="{{{filePath}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+							<a href="{{filePath}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
 						{{/children.0}}
 				{{/entries}}
 			{{/toc}}

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -19,17 +19,17 @@
 		<main>{{{ body }}}</main>
 		<aside style="padding: 1rem;">
 			{{#toc}}
-				{{#entries}}
+			{{#entries}}
 						{{#isDirectory}}
 							<p>{{name}}</p>
 							<div style="border: 1px solid aliceblue; margin-inline-start: 1rem;">
 								{{#children}}
-									<a style="margin-top: 1rem" href="{{sitePath}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+									<a style="margin-top: 1rem" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
 								{{/children}}
 							</div>
 						{{/isDirectory}}
 						{{^children.0}}
-							<a href="{{sitePath}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+							<a href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
 						{{/children.0}}
 				{{/entries}}
 			{{/toc}}

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -19,7 +19,7 @@
 		<div>{{{ body }}}</div>
 		<aside style="padding: 1rem;">
 			{{#toc}}
-				{{#pages}}
+				{{#entries}}
 					{{^isHidden}}
 						{{#isDirectory}}
 							<p>{{name}}</p>
@@ -33,7 +33,7 @@
 							<a href="{{{href}}}">{{name}}</a>
 						{{/children.0}}
 					{{/isHidden}}
-				{{/pages}}
+				{{/entries}}
 			{{/toc}}
 		</aside>
 	</body>

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -5,7 +5,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
 		<title>{{title}} | Atlas Design | Microsoft</title>
-		<meta property="og:title" content="{{title}} | Atlas Design | Microsoft" />
+		<meta property="og:title" content="{{title}}" />
 		<meta property="og:type" content="website" />
 		<meta name="color-scheme" content="light dark" />
 		<link rel="stylesheet" href="~/src/scaffold/index.scss"
@@ -16,7 +16,25 @@
 		>
 			Atlas Design
 		</header>
-
-		{{{ body }}}
+		<div>{{{ body }}}</div>
+		<aside style="padding: 1rem;">
+			{{#toc}}
+				{{#pages}}
+					{{^isHidden}}
+						{{#isDirectory}}
+							<p>{{name}}</p>
+							<div style="border: 1px solid aliceblue; margin-inline-start: 1rem;">
+								{{#children}}
+									<a style="margin-top: 1rem" href="{{{href}}}">{{name}}</a>
+								{{/children}}
+							</div>
+						{{/isDirectory}}
+						{{^children.0}}
+							<a href="{{{href}}}">{{name}}</a>
+						{{/children.0}}
+					{{/isHidden}}
+				{{/pages}}
+			{{/toc}}
+		</aside>
 	</body>
 </html>

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -16,7 +16,7 @@
 		>
 			Atlas Design
 		</header>
-		<div>{{{ body }}}</div>
+		<main>{{{ body }}}</main>
 		<aside style="padding: 1rem;">
 			{{#toc}}
 				{{#entries}}

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -24,12 +24,12 @@
 							<p>{{name}}</p>
 							<div style="border: 1px solid aliceblue; margin-inline-start: 1rem;">
 								{{#children}}
-									<a style="margin-top: 1rem" href="{{href}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+									<a style="margin-top: 1rem" href="{{sitePath}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
 								{{/children}}
 							</div>
 						{{/isDirectory}}
 						{{^children.0}}
-							<a href="{{href}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+							<a href="{{sitePath}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
 						{{/children.0}}
 				{{/entries}}
 			{{/toc}}

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -20,19 +20,17 @@
 		<aside style="padding: 1rem;">
 			{{#toc}}
 				{{#entries}}
-					{{^isHidden}}
 						{{#isDirectory}}
 							<p>{{name}}</p>
 							<div style="border: 1px solid aliceblue; margin-inline-start: 1rem;">
 								{{#children}}
-									<a style="margin-top: 1rem" href="{{{href}}}">{{name}}</a>
+									<a style="margin-top: 1rem" href="{{{}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
 								{{/children}}
 							</div>
 						{{/isDirectory}}
 						{{^children.0}}
-							<a href="{{{href}}}">{{name}}</a>
+							<a href="{{{filePath}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
 						{{/children.0}}
-					{{/isHidden}}
 				{{/entries}}
 			{{/toc}}
 		</aside>

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -24,12 +24,12 @@
 							<p>{{name}}</p>
 							<div style="border: 1px solid aliceblue; margin-inline-start: 1rem;">
 								{{#children}}
-									<a style="margin-top: 1rem" href="{{filePath}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+									<a style="margin-top: 1rem" href="{{href}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
 								{{/children}}
 							</div>
 						{{/isDirectory}}
 						{{^children.0}}
-							<a href="{{filePath}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+							<a href="{{href}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
 						{{/children.0}}
 				{{/entries}}
 			{{/toc}}

--- a/site/toc.js
+++ b/site/toc.js
@@ -89,8 +89,8 @@ async function createToc(subDir) {
 			isDirectory = (await fs.stat(location)).isDirectory();
 		}
 
-		// Only add markdown files and directories, except scaffold
-		if (parsed.name === 'scaffold' || (!isDirectory && !isMarkdown)) {
+		// Only add markdown files and directories, except ignored files
+		if (parsed.name in settings.ignore || (!isDirectory && !isMarkdown)) {
 			continue;
 		}
 

--- a/site/toc.js
+++ b/site/toc.js
@@ -101,7 +101,6 @@ async function createToc(subDir) {
 		const entry = {
 			name: name,
 			href: srcPath,
-			filePath: path.join('~/src', srcPath),
 			isDirectory,
 			isHidden: name === '[hide]'
 		};

--- a/site/toc.js
+++ b/site/toc.js
@@ -4,6 +4,7 @@ const fs = require('fs-extra');
 const frontMatter = require('front-matter');
 
 const siteDir = path.join(process.cwd(), '/src/');
+console.log(siteDir);
 
 const settings = normalizePaths({
 	/**

--- a/site/toc.js
+++ b/site/toc.js
@@ -101,6 +101,7 @@ async function createToc(subDir) {
 		const entry = {
 			name: name,
 			href: srcPath,
+			filePath: path.join('~/src', srcPath),
 			isDirectory,
 			isHidden: name === '[hide]'
 		};

--- a/site/toc.js
+++ b/site/toc.js
@@ -1,0 +1,133 @@
+// @ts-nocheck
+const path = require('path');
+const fs = require('fs-extra');
+const frontMatter = require('front-matter');
+
+const siteDir = path.join(process.cwd(), '/src/');
+
+const settings = normalizePaths({
+	/**
+	 * Folders to ignore
+	 */
+	ignore: { scaffold: true },
+	/**
+	 * Output location
+	 */
+	outFile: path.resolve(siteDir, 'scaffold', 'toc.json'),
+	/**
+	 * Names to transform, start with `/`, which mean `src/<here>`
+	 * key: filepath to match exactly
+	 * value: new displayed in toc. You may use '[hide]' to hide it from the toc.
+	 */
+	names: {
+		'/index.md': '[hide]',
+		'/tokens': 'Tokens!',
+		'/tokens/colors.md': 'Colors renamed!'
+	}
+});
+
+createToc().then(toc => {
+	const saveTo = settings.outFile;
+	fs.writeFile(saveTo, JSON.stringify(toc));
+});
+
+/**
+ * Ensure settings will work regardless of operating system
+ */
+function normalizePaths(settings) {
+	for (const key in settings.names) {
+		const normalized = path.normalize(key);
+		const clone = JSON.parse(JSON.stringify(settings.names[key]));
+		delete settings.names[key];
+		settings.names[normalized] = clone;
+	}
+	return settings;
+}
+
+async function createToc(subDir) {
+	subDir = subDir || '';
+	/**
+	 * The current working directory.
+	 * Uses articlesSrcPath so things can easily stay relative.
+	 */
+	const directory = path.join(siteDir, subDir);
+	/**
+	 * All the items in the directory.
+	 */
+	const items = await fs.readdir(directory);
+	/**
+	 * A data structure to make building things to HTML relatively straightforward.
+	 */
+	const scaffold = [];
+
+	// get stats on everything in this folder
+	for (const item of items) {
+		/**
+		 * A path relative to the root of the articles folder.
+		 */
+		const srcPath = path.normalize(`${subDir}/${item}`);
+		/**
+		 * Parse the item's name
+		 */
+		const parsed = path.parse(item);
+		/**
+		 * The absolute path of directory we're in now.
+		 * Could be a subdirectory of articles.
+		 */
+		const location = path.join(siteDir, srcPath);
+		/**
+		 * Whether where on a folder.
+		 */
+		let isDirectory = false;
+		/**
+		 * Whether the entry is a markdown file.
+		 */
+		const isMarkdown = parsed.ext === '.md';
+
+		// If it's not markdown, determine if it's a directory
+		if (!isMarkdown) {
+			isDirectory = (await fs.stat(location)).isDirectory();
+		}
+
+		// Only add markdown files and directories, except scaffold
+		if (parsed.name === 'scaffold' || (!isDirectory && !isMarkdown)) {
+			continue;
+		}
+
+		const name = await getName(settings, srcPath, isMarkdown, location, parsed);
+		/**
+		 * The data structure
+		 */
+		const entry = {
+			name: name,
+			href: srcPath,
+			isDirectory,
+			isHidden: name === '[hide]'
+		};
+
+		if (entry.isDirectory) {
+			entry.children = await createToc(srcPath);
+		}
+
+		scaffold.push(entry);
+	}
+
+	return scaffold;
+}
+
+async function getName(settings, srcPath, isMarkdown, location, parsed) {
+	if (settings.names && srcPath in settings.names) {
+		return settings.names[srcPath];
+	}
+
+	if (isMarkdown) {
+		const contents = await fs.readFile(location, 'utf-8');
+		const { attributes } = frontMatter(contents);
+
+		if (attributes.title) {
+			return attributes.title;
+		}
+	}
+
+	return parsed.name;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2169,6 +2169,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
 atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
@@ -3813,6 +3818,16 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -4807,6 +4822,15 @@ jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -7612,6 +7636,11 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
task-392672

Implements automatic generated of a table of contents.

## How it works

- finds folders and markdown files in the site's src folder
- ignores entries specified in `settings` object
- `settings.names` => allows us to re-write the names of folders and files
- if no entry matches in `settings.names`, parse the yaml front matter to get the title.
- builds a file into `scaffold/toc.json`.
- this file is gotten by the markdown-html parcel extension and rendered. see template in standard.html.

## Test steps

```
gh pr checkout 33
yarn install;
yarn serve:site
```
