### PR TITLE
Focus styles

### DIFF
--- a/.changeset/tiny-windows-wonder.md
+++ b/.changeset/tiny-windows-wonder.md
@@ -2,4 +2,4 @@
 '@microsoft/atlas-css': minor
 ---
 
-Add default focus styles"
+"Add default focus styles"

--- a/.changeset/tiny-windows-wonder.md
+++ b/.changeset/tiny-windows-wonder.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Add default focus styles"

--- a/css/src/core/focus.scss
+++ b/css/src/core/focus.scss
@@ -1,4 +1,4 @@
-@if ($focus-visible-polyfill) {
+@if ($focus-visible-use-polyfill) {
 	.js-focus-visible .has-default-focus *:focus:not(.focus-visible) {
 		outline: none;
 	}

--- a/css/src/core/focus.scss
+++ b/css/src/core/focus.scss
@@ -13,8 +13,8 @@
 			@include focus();
 
 			&.has-inner-focus {
-				outline-offset: -$focus-outline-offset;
 				outline-color: currentColor;
+				outline-offset: -$focus-outline-offset;
 			}
 		}
 	}
@@ -23,8 +23,8 @@
 		@include focus();
 
 		&.has-inner-focus {
-			outline-offset: -$focus-outline-offset;
 			outline-color: currentColor;
+			outline-offset: -$focus-outline-offset;
 		}
 	}
 }

--- a/css/src/core/focus.scss
+++ b/css/src/core/focus.scss
@@ -1,0 +1,30 @@
+@if ($focus-visible-polyfill) {
+	.js-focus-visible .has-default-focus *:focus:not(.focus-visible) {
+		outline: none;
+	}
+
+	.focus-visible.has-inner-focus {
+		outline-offset: -$focus-outline-offset;
+	}
+
+	.has-default-focus {
+		.is-focused,
+		.focus-visible {
+			@include focus();
+
+			&.has-inner-focus {
+				outline-offset: -$focus-outline-offset;
+				outline-color: currentColor;
+			}
+		}
+	}
+} @else {
+	*:focus-visible {
+		@include focus();
+
+		&.has-inner-focus {
+			outline-offset: -$focus-outline-offset;
+			outline-color: currentColor;
+		}
+	}
+}

--- a/css/src/core/focus.scss
+++ b/css/src/core/focus.scss
@@ -10,7 +10,7 @@
 	.has-default-focus {
 		.is-focused,
 		.focus-visible {
-			@include focus();
+			@extend %focus;
 
 			&.has-inner-focus {
 				outline-color: currentColor;
@@ -19,8 +19,8 @@
 		}
 	}
 } @else {
-	*:focus-visible {
-		@include focus();
+	.has-default-focus *:focus-visible {
+		@extend %focus;
 
 		&.has-inner-focus {
 			outline-color: currentColor;

--- a/css/src/core/index.scss
+++ b/css/src/core/index.scss
@@ -2,3 +2,4 @@
 @import 'minireset.css';
 @import 'themes.scss';
 @import 'font-stack.scss';
+@import 'focus.scss';

--- a/css/src/mixins/focus.scss
+++ b/css/src/mixins/focus.scss
@@ -1,0 +1,10 @@
+@mixin focus() {
+	outline-color: inherit;
+	outline-offset: $focus-outline-offset;
+	outline-style: $focus-style;
+	outline-width: $focus-width;
+}
+
+%focus {
+	@include focus();
+}

--- a/css/src/mixins/index.scss
+++ b/css/src/mixins/index.scss
@@ -1,1 +1,2 @@
 @import 'media-queries.scss';
+@import 'focus.scss';

--- a/css/src/tokens/focus.scss
+++ b/css/src/tokens/focus.scss
@@ -2,4 +2,4 @@
 $focus-width: 0.125rem !default;
 $focus-style: dashed !default;
 $focus-outline-offset: 0.125rem !default;
-$focus-visible-use-polyfill: true;
+$focus-visible-use-polyfill: false;

--- a/css/src/tokens/focus.scss
+++ b/css/src/tokens/focus.scss
@@ -2,3 +2,4 @@
 $focus-width: 0.125rem !default;
 $focus-style: dashed !default;
 $focus-outline-offset: 0.125rem !default;
+$focus-visible-polyfill: true;

--- a/css/src/tokens/focus.scss
+++ b/css/src/tokens/focus.scss
@@ -2,4 +2,4 @@
 $focus-width: 0.125rem !default;
 $focus-style: dashed !default;
 $focus-outline-offset: 0.125rem !default;
-$focus-visible-polyfill: true;
+$focus-visible-use-polyfill: true;

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -8,7 +8,7 @@
 		<meta property="og:title" content="{{title}}" />
 		<meta property="og:type" content="website" />
 		<meta name="color-scheme" content="light dark" />
-		<link rel="stylesheet" href="~/src/scaffold/index.scss"
+		<link rel="stylesheet" href="~/src/scaffold/index.scss">
 	</head>
 	<body>
 		<header


### PR DESCRIPTION
task-[378385](https://dev.azure.com/ceapex/Engineering/_workitems/edit/378385/)

This PR adds focus styles to Atlas. The value of `focus-visible-use-polyfill` token can be used to activate the focus styles for the [focus-visible polyfill](https://github.com/WICG/focus-visible). It's currently set to true because we still need to use the polyfill for IE (which doesn't support the `:focus-visible` pseudo-class). Once support for IE is dropped, we can set the token to false and allow the usage of the `focus-visible` pseudo class instead. 
- `has-default-focus` is being kept to allow compatibility with Docs-ui. 

## Testing

1. In Atlas, run `git checkout ming/focus-styles`. 
2. In Docs-ui, check out the `atlas-test-3-23` branch. Follow the steps in its description if you haven't already done so. Run `yarn develop`.
3. Pull up a page http://localhost:3000/en-us/test/docs/conceptual/cloud-shell . Interact with the page by clicking on links, buttons, etc. There should be no change (you shouldn't see a visible focus ring except the input in the navbar). Tab through the page and you should see a dashed focus ring on the focused item as expected.
4. In Atlas, go to `atlas-design/css/src/tokens/focus.scss`. Change the value of `focus-visible-use-polyfill` from `true` to `false`.
5. Return to the page and repeat what you did in step 3. There should be no change in behavior. 
6. To make it easier to discern between which rule is being applied, in Atlas you can go to `css/src/core/focus.scss`. On line 14, add `outline-color: red` and on line 24, add `outline-color: green`. When the polyfill is in effect, the dashed focus ring should be red. When the `:focus-visible` pseudo class is in effect, it should be green. You might also need to comment out the focus styles in Docs-ui so it doesn't override the Atlas ones.
7. You can also test with the test site in Atlas. 
- In `standard.html`, add `has-default-focus` class to the body. Add some elements that has the `focus-visible` pseudo class. 
```
<input/>
<button>Button</button>
<a href="#">Link</a>
``` 
- In the head, add this script `<script src="../../node_modules/focus-visible/dist/focus-visible.min.js"></script>`
- In `node_modules`, copy the `focus-visible` folder. Paste it in `site/node_modules`. I tried installing the package with yarn, but it doesn't show up for some reason. Perhaps there's a trick.
- Run `yarn build:css; yarn build:site; yarn serve:site;`. A page should appear in the browser. If not, visit http://localhost:1111/ . Repeat previous test steps.

