### PR TITLE
changing palette color from hsla to hex

### DIFF
--- a/.changeset/slow-radios-juggle.md
+++ b/.changeset/slow-radios-juggle.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Change color palette from HSLA to HEX

--- a/.changeset/slow-radios-juggle.md
+++ b/.changeset/slow-radios-juggle.md
@@ -1,5 +1,5 @@
 ---
-'@microsoft/atlas-css': minor
+'@microsoft/atlas-css': patch
 ---
 
 Change color palette from HSLA to HEX

--- a/css/src/tokens/palette.scss
+++ b/css/src/tokens/palette.scss
@@ -147,16 +147,16 @@ $palette-purple-opacity-70: #201843B3 !default;
 
 // Yellow
 
-$palette-yellow-10: #fff4ce hsla(47, 100%, 90%, 1) !default;
-$palette-yellow-20: #ffe79f hsla(45, 100%, 81%, 1) !default;
-$palette-yellow-30: #ffdf84 hsla(44, 100%, 76%, 1) !default;
-$palette-yellow-40: #ffcb3f hsla(44, 100%, 62%, 1) !default;
-$palette-yellow-50: #ffb900 hsla(44, 100%, 50%, 1) !default;
-$palette-yellow-60: #d19501 hsla(43, 99%, 41%, 1) !default;
-$palette-yellow-70: #966802 hsla(41, 97%, 30%, 1) !default;
-$palette-yellow-80: #6a4b16 hsla(38, 66%, 25%, 1) !default;
-$palette-yellow-90: #4f340e hsla(35, 70%, 18%, 1) !default;
-$palette-yellow-100: #2d1703 hsla(29, 88%, 9%, 1) !default;
+$palette-yellow-10: #fff4ce !default;
+$palette-yellow-20: #ffe79f !default;
+$palette-yellow-30: #ffdf84 !default;
+$palette-yellow-40: #ffcb3f !default;
+$palette-yellow-50: #ffb900 !default;
+$palette-yellow-60: #d19501 !default;
+$palette-yellow-70: #966802 !default;
+$palette-yellow-80: #6a4b16 !default;
+$palette-yellow-90: #4f340e !default;
+$palette-yellow-100: #2d1703 !default;
 
 $palette-yellow-opacity-30: #ffbb004D !default;
 $palette-yellow-opacity-70: #ffbb00B3 !default;

--- a/css/src/tokens/palette.scss
+++ b/css/src/tokens/palette.scss
@@ -9,111 +9,111 @@ Notes:
 // Monochrome
 
 $palette-grey-10: #fafafa !default;
-$palette-grey-20: #F2F2F2 !default;
-$palette-grey-30: #E6E6E6 !default;
-$palette-grey-40: #D2D2D2 !default;
-$palette-grey-50: #BCBCBC !default;
-$palette-grey-60: #A2A2A2 !default; 
-$palette-grey-70: #8E8E8E !default; 
-$palette-grey-80: #757575 !default; 
-$palette-grey-90: #505050 !default; 
+$palette-grey-20: #f2f2f2 !default;
+$palette-grey-30: #e6e6e6 !default;
+$palette-grey-40: #d2d2d2 !default;
+$palette-grey-50: #bcbcbc !default;
+$palette-grey-60: #a2a2a2 !default;
+$palette-grey-70: #8e8e8e !default;
+$palette-grey-80: #757575 !default;
+$palette-grey-90: #505050 !default;
 $palette-grey-100: #404040 !default;
-$palette-grey-110: #2F2F2F !default;
+$palette-grey-110: #2f2f2f !default;
 $palette-grey-120: #171717 !default;
 
 // Black
 
-$palette-black: #000000 !default;
+$palette-black: #000 !default;
 
-$palette-black-opacity-90: #000000E6 !default;
-$palette-black-opacity-80: #000000CC !default;
-$palette-black-opacity-70: #000000B3 !default;
-$palette-black-opacity-60: #00000099 !default;
+$palette-black-opacity-90: #000000e6 !default;
+$palette-black-opacity-80: #000c !default;
+$palette-black-opacity-70: #000000b3 !default;
+$palette-black-opacity-60: #0009 !default;
 $palette-black-opacity-50: #00000080 !default;
-$palette-black-opacity-40: #00000066 !default;
-$palette-black-opacity-30: #0000004D !default;
-$palette-black-opacity-20: #00000033 !default;
-$palette-black-opacity-10: #0000001A !default;
-$palette-black-opacity-0: #000000 !default;
+$palette-black-opacity-40: #0006 !default;
+$palette-black-opacity-30: #0000004d !default;
+$palette-black-opacity-20: #0003 !default;
+$palette-black-opacity-10: #0000001a !default;
+$palette-black-opacity-0: #000 !default;
 
 // White
 
-$palette-white:#FFFFFF !default;
+$palette-white: #fff !default;
 
-$palette-white-opacity-0: #ffffff00;
-$palette-white-opacity-10:#ffffff1A;
-$palette-white-opacity-20:#ffffff33;
-$palette-white-opacity-30: #ffffff4D;
-$palette-white-opacity-40: #ffffff66;
+$palette-white-opacity-0: #fff0;
+$palette-white-opacity-10: #ffffff1a;
+$palette-white-opacity-20: #fff3;
+$palette-white-opacity-30: #ffffff4d;
+$palette-white-opacity-40: #fff6;
 $palette-white-opacity-50: #ffffff80;
-$palette-white-opacity-60: #ffffff99;
-$palette-white-opacity-70: #ffffffB3;
-$palette-white-opacity-80: #ffffffCC;
-$palette-white-opacity-90: #ffffffE6;
+$palette-white-opacity-60: #fff9;
+$palette-white-opacity-70: #ffffffb3;
+$palette-white-opacity-80: #fffc;
+$palette-white-opacity-90: #ffffffe6;
 
 // Values used for shadows
 
-$palette-black-opacity-108: #0000001C !default;
+$palette-black-opacity-108: #0000001c !default;
 $palette-black-opacity-132: #00000021 !default;
 
 $palette-black-opacity-22: #00000038 !default;
-$palette-black-opacity-18: #0000002E !default;
+$palette-black-opacity-18: #0000002e !default;
 
-$palette-white-opacity-108: #ffffff1C !default;
+$palette-white-opacity-108: #ffffff1c !default;
 $palette-white-opacity-132: #ffffff21 !default;
 
 $palette-white-opacity-22: #ffffff38 !default;
-$palette-white-opacity-18: #ffffff2E !default;
+$palette-white-opacity-18: #ffffff2e !default;
 
 // Blue
 
-$palette-blue-10:#D7EAF8 !default;
-$palette-blue-20: #9CCBEE !default;
-$palette-blue-30: #75B6E7 !default;
-$palette-blue-40: #278CDA !default;
-$palette-blue-50: #0078D4 !default;
-$palette-blue-60: #0065B3 !default;
-$palette-blue-70: #00579A !default;
+$palette-blue-10: #d7eaf8 !default;
+$palette-blue-20: #9ccbee !default;
+$palette-blue-30: #75b6e7 !default;
+$palette-blue-40: #278cda !default;
+$palette-blue-50: #0078d4 !default;
+$palette-blue-60: #0065b3 !default;
+$palette-blue-70: #00579a !default;
 $palette-blue-80: #004173 !default;
-$palette-blue-90: #002B4D !default;
-$palette-blue-100: #000A13 !default;
+$palette-blue-90: #002b4d !default;
+$palette-blue-100: #000a13 !default;
 
-$palette-blue-opacity-30: #0065B34D ;
-$palette-blue-opacity-70: #0065B3B3 ;
+$palette-blue-opacity-30: #0065b34d;
+$palette-blue-opacity-70: #0065b3b3;
 
 // Navy
 
-$palette-navy-10: #DFE5EE !default;
-$palette-navy-20: #C1CBDC !default;
-$palette-navy-30: #A4B2C9 !default;
-$palette-navy-40: #899AB5 !default;
-$palette-navy-50: #70819F !default;
-$palette-navy-60: #4A5D7E !default;
-$palette-navy-70: #243A5E !default;
-$palette-navy-80: #14294C !default;
+$palette-navy-10: #dfe5ee !default;
+$palette-navy-20: #c1cbdc !default;
+$palette-navy-30: #a4b2c9 !default;
+$palette-navy-40: #899ab5 !default;
+$palette-navy-50: #70819f !default;
+$palette-navy-60: #4a5d7e !default;
+$palette-navy-70: #243a5e !default;
+$palette-navy-80: #14294c !default;
 $palette-navy-90: #061329 !default;
 $palette-navy-100: #000910 !default;
 
-$palette-navy-opacity-30:#26173F4D !default;
-$palette-navy-opacity-70: #26173FB3 !default;
+$palette-navy-opacity-30: #26173f4d !default;
+$palette-navy-opacity-70: #26173fb3 !default;
 
 // Turqoise
 
-$palette-turqoise-10: #E9FBFF !default;
-$palette-turqoise-20: #BDF5FF !default;
-$palette-turqoise-30: #7BECFF !default;
-$palette-turqoise-40: #50E6FF !default;
-$palette-turqoise-50: #41B9CF !default;
-$palette-turqoise-60: #328E9F !default;
-$palette-turqoise-70: #28727F !default;
-$palette-turqoise-80: #19474F !default;
-$palette-turqoise-90: #0F2A2F !default;
-$palette-turqoise-100: #050E0F !default;
+$palette-turqoise-10: #e9fbff !default;
+$palette-turqoise-20: #bdf5ff !default;
+$palette-turqoise-30: #7becff !default;
+$palette-turqoise-40: #50e6ff !default;
+$palette-turqoise-50: #41b9cf !default;
+$palette-turqoise-60: #328e9f !default;
+$palette-turqoise-70: #28727f !default;
+$palette-turqoise-80: #19474f !default;
+$palette-turqoise-90: #0f2a2f !default;
+$palette-turqoise-100: #050e0f !default;
 
-$palette-navy-opacity-30: #0F2A2F4D !default;
-$palette-navy-opacity-70: #0F2A2FB3 !default;
+$palette-navy-opacity-30: #0f2a2f4d !default;
+$palette-navy-opacity-70: #0f2a2fb3 !default;
 
-// Green 
+// Green
 
 $palette-green-10: #dff6dd !default;
 $palette-green-20: #acd7aa !default;
@@ -126,10 +126,10 @@ $palette-green-80: #054b16 !default;
 $palette-green-90: #05350c !default;
 $palette-green-100: #061a00 !default;
 
-$palette-green-opacity-30: 	#489D484D !default;
-$palette-green-opacity-70: 	#489D48B3 !default;
+$palette-green-opacity-30: #489d484d !default;
+$palette-green-opacity-70: #489d48b3 !default;
 
-// Purple 
+// Purple
 
 $palette-purple-10: #efd9fd !default;
 $palette-purple-20: #e0b7fe !default;
@@ -142,8 +142,8 @@ $palette-purple-80: #3b2e58 !default;
 $palette-purple-90: #201843 !default;
 $palette-purple-100: #03002c !default;
 
-$palette-purple-opacity-30: #2018434D !default;
-$palette-purple-opacity-70: #201843B3 !default;
+$palette-purple-opacity-30: #2018434d !default;
+$palette-purple-opacity-70: #201843b3 !default;
 
 // Yellow
 
@@ -158,27 +158,27 @@ $palette-yellow-80: #6a4b16 !default;
 $palette-yellow-90: #4f340e !default;
 $palette-yellow-100: #2d1703 !default;
 
-$palette-yellow-opacity-30: #ffbb004D !default;
-$palette-yellow-opacity-70: #ffbb00B3 !default;
+$palette-yellow-opacity-30: #ffbb004d !default;
+$palette-yellow-opacity-70: #ffbb00b3 !default;
 
 // Red COMPLETE
 
-$palette-red-10: #FDE7E9 !default;
-$palette-red-20: #E5A7A8 !default;
-$palette-red-30: #D4797A !default;
-$palette-red-40: #C54F4F !default;
-$palette-red-50: #B62626 !default;
-$palette-red-60: #A80000 !default;
+$palette-red-10: #fde7e9 !default;
+$palette-red-20: #e5a7a8 !default;
+$palette-red-30: #d4797a !default;
+$palette-red-40: #c54f4f !default;
+$palette-red-50: #b62626 !default;
+$palette-red-60: #a80000 !default;
 $palette-red-70: #870000 !default;
 $palette-red-80: #630001 !default;
 $palette-red-90: #470001 !default;
 $palette-red-100: #290001 !default;
 
-$palette-red-opacity-30: #a800004D !default;
-$palette-red-opacity-70: #a80000B3 !default;
+$palette-red-opacity-30: #a800004d !default;
+$palette-red-opacity-70: #a80000b3 !default;
 
 // High Contrast
 
-$palette-yellow-high-contrast: #FFFF00FF !default;
-$palette-yellow-high-contrast-hover: #FFFF33FF !default;
-$palette-visited-high-contrast:	#3CFF00FF !default;
+$palette-yellow-high-contrast: #ff0 !default;
+$palette-yellow-high-contrast-hover: #ff3 !default;
+$palette-visited-high-contrast: #3cff00ff !default;

--- a/css/src/tokens/palette.scss
+++ b/css/src/tokens/palette.scss
@@ -53,17 +53,17 @@ $palette-white-opacity-90: #ffffffE6;
 
 // Values used for shadows
 
-$palette-black-opacity-108: hsla(0, 0%, 0%, 0.11) !default;
-$palette-black-opacity-132: hsla(0, 0%, 0%, 0.13) !default;
+$palette-black-opacity-108: #0000001C !default;
+$palette-black-opacity-132: #00000021 !default;
 
-$palette-black-opacity-22: hsla(0, 0%, 0%, 0.22) !default;
-$palette-black-opacity-18: hsla(0, 0%, 0%, 0.18) !default;
+$palette-black-opacity-22: #00000038 !default;
+$palette-black-opacity-18: #0000002E !default;
 
-$palette-white-opacity-108: hsla(0, 0%, 100%, 0.11) !default;
-$palette-white-opacity-132: hsla(0, 0%, 100%, 0.13) !default;
+$palette-white-opacity-108: #ffffff1C !default;
+$palette-white-opacity-132: #ffffff21 !default;
 
-$palette-white-opacity-22: hsla(0, 0%, 100%, 0.22) !default;
-$palette-white-opacity-18: hsla(0, 0%, 100%, 0.18) !default;
+$palette-white-opacity-22: #ffffff38 !default;
+$palette-white-opacity-18: #ffffff2E !default;
 
 // Blue
 

--- a/css/src/tokens/palette.scss
+++ b/css/src/tokens/palette.scss
@@ -25,31 +25,31 @@ $palette-grey-120: #171717 !default;
 
 $palette-black: #000000 !default;
 
-$palette-black-opacity-90: hsla(0, 0%, 0%, 0.9) !default;
-$palette-black-opacity-80: hsla(0, 0%, 0%, 0.8) !default;
-$palette-black-opacity-70: hsla(0, 0%, 0%, 0.7) !default;
-$palette-black-opacity-60: hsla(0, 0%, 0%, 0.6) !default;
-$palette-black-opacity-50: hsla(0, 0%, 0%, 0.5) !default;
-$palette-black-opacity-40: hsla(0, 0%, 0%, 0.4) !default;
-$palette-black-opacity-30: hsla(0, 0%, 0%, 0.3) !default;
-$palette-black-opacity-20: hsla(0, 0%, 0%, 0.2) !default;
-$palette-black-opacity-10: hsla(0, 0%, 0%, 0.1) !default;
-$palette-black-opacity-0: hsla(0, 0%, 0%, 0) !default;
+$palette-black-opacity-90: #000000E6 !default;
+$palette-black-opacity-80: #000000CC !default;
+$palette-black-opacity-70: #000000B3 !default;
+$palette-black-opacity-60: #00000099 !default;
+$palette-black-opacity-50: #00000080 !default;
+$palette-black-opacity-40: #00000066 !default;
+$palette-black-opacity-30: #0000004D !default;
+$palette-black-opacity-20: #00000033 !default;
+$palette-black-opacity-10: #0000001A !default;
+$palette-black-opacity-0: #000000 !default;
 
 // White
 
 $palette-white:#FFFFFF !default;
 
-$palette-white-opacity-0: hsla(0, 0%, 100%, 0);
-$palette-white-opacity-10: hsla(0, 0%, 100%, 0.1);
-$palette-white-opacity-20: hsla(0, 0%, 100%, 0.2);
-$palette-white-opacity-30: hsla(0, 0%, 100%, 0.3);
-$palette-white-opacity-40: hsla(0, 0%, 100%, 0.4);
-$palette-white-opacity-50: hsla(0, 0%, 100%, 0.5);
-$palette-white-opacity-60: hsla(0, 0%, 100%, 0.6);
-$palette-white-opacity-70: hsla(0, 0%, 100%, 0.7);
-$palette-white-opacity-80: hsla(0, 0%, 100%, 0.8);
-$palette-white-opacity-90: hsla(0, 0%, 100%, 0.9);
+$palette-white-opacity-0: #ffffff00;
+$palette-white-opacity-10:#ffffff1A;
+$palette-white-opacity-20:#ffffff33;
+$palette-white-opacity-30: #ffffff4D;
+$palette-white-opacity-40: #ffffff66;
+$palette-white-opacity-50: #ffffff80;
+$palette-white-opacity-60: #ffffff99;
+$palette-white-opacity-70: #ffffffB3;
+$palette-white-opacity-80: #ffffffCC;
+$palette-white-opacity-90: #ffffffE6;
 
 // Values used for shadows
 
@@ -78,8 +78,8 @@ $palette-blue-80: #004173 !default;
 $palette-blue-90: #002B4D !default;
 $palette-blue-100: #000A13 !default;
 
-$palette-blue-opacity-30: hsla(206, 100%, 35%, 0.3);
-$palette-blue-opacity-70: hsla(206, 100%, 35%, 0.7);
+$palette-blue-opacity-30: #0065B34D ;
+$palette-blue-opacity-70: #0065B3B3 ;
 
 // Navy
 
@@ -94,8 +94,8 @@ $palette-navy-80: #14294C !default;
 $palette-navy-90: #061329 !default;
 $palette-navy-100: #000910 !default;
 
-$palette-navy-opacity-30: hsla(262, 46%, 17%, 0.3) !default;
-$palette-navy-opacity-70: hsla(262, 46%, 17%, 0.7) !default;
+$palette-navy-opacity-30:#26173F4D !default;
+$palette-navy-opacity-70: #26173FB3 !default;
 
 // Turqoise
 
@@ -110,10 +110,10 @@ $palette-turqoise-80: #19474F !default;
 $palette-turqoise-90: #0F2A2F !default;
 $palette-turqoise-100: #050E0F !default;
 
-$palette-navy-opacity-30: hsla(189, 52%, 12%, 0.3) !default;
-$palette-navy-opacity-70: hsla(189, 52%, 12%, 0.7) !default;
+$palette-navy-opacity-30: #0F2A2F4D !default;
+$palette-navy-opacity-70: #0F2A2FB3 !default;
 
-// Green
+// Green 
 
 $palette-green-10: #dff6dd !default;
 $palette-green-20: #acd7aa !default;
@@ -126,10 +126,10 @@ $palette-green-80: #054b16 !default;
 $palette-green-90: #05350c !default;
 $palette-green-100: #061a00 !default;
 
-$palette-green-opacity-30: hsla(120, 37%, 45%, 0.3) !default;
-$palette-green-opacity-70: hsla(120, 37%, 45%, 0.7) !default;
+$palette-green-opacity-30: 	#489D484D !default;
+$palette-green-opacity-70: 	#489D48B3 !default;
 
-// Purple
+// Purple 
 
 $palette-purple-10: #efd9fd !default;
 $palette-purple-20: #e0b7fe !default;
@@ -142,8 +142,8 @@ $palette-purple-80: #3b2e58 !default;
 $palette-purple-90: #201843 !default;
 $palette-purple-100: #03002c !default;
 
-$palette-purple-opacity-30: hsla(251, 47%, 18%, 0.3) !default;
-$palette-purple-opacity-70: hsla(251, 47%, 18%, 0.7) !default;
+$palette-purple-opacity-30: #2018434D !default;
+$palette-purple-opacity-70: #201843B3 !default;
 
 // Yellow
 
@@ -158,10 +158,10 @@ $palette-yellow-80: #6a4b16 hsla(38, 66%, 25%, 1) !default;
 $palette-yellow-90: #4f340e hsla(35, 70%, 18%, 1) !default;
 $palette-yellow-100: #2d1703 hsla(29, 88%, 9%, 1) !default;
 
-$palette-yellow-opacity-30: hsla(44, 100%, 50%, 0.3) !default;
-$palette-yellow-opacity-70: hsla(44, 100%, 50%, 0.7) !default;
+$palette-yellow-opacity-30: #ffbb004D !default;
+$palette-yellow-opacity-70: #ffbb00B3 !default;
 
-// Red
+// Red COMPLETE
 
 $palette-red-10: #FDE7E9 !default;
 $palette-red-20: #E5A7A8 !default;
@@ -174,11 +174,11 @@ $palette-red-80: #630001 !default;
 $palette-red-90: #470001 !default;
 $palette-red-100: #290001 !default;
 
-$palette-red-opacity-30: hsla(0, 100%, 33%, 0.3) !default;
-$palette-red-opacity-70: hsla(0, 100%, 33%, 0.7) !default;
+$palette-red-opacity-30: #a800004D !default;
+$palette-red-opacity-70: #a80000B3 !default;
 
 // High Contrast
 
-$palette-yellow-high-contrast: hsla(60, 100%, 50%, 1) !default;
-$palette-yellow-high-contrast-hover: hsla(60, 100%, 60%, 1) !default;
-$palette-visited-high-contrast: hsla(106, 100%, 50%, 1) !default;
+$palette-yellow-high-contrast: #FFFF00FF !default;
+$palette-yellow-high-contrast-hover: #FFFF33FF !default;
+$palette-visited-high-contrast:	#3CFF00FF !default;

--- a/css/src/tokens/palette.scss
+++ b/css/src/tokens/palette.scss
@@ -8,22 +8,22 @@ Notes:
 
 // Monochrome
 
-$palette-grey-10: hsla(0, 0%, 98%, 1) !default; // #F2F2F2
-$palette-grey-20: hsla(0, 0%, 95%, 1) !default; // #F2F2F2
-$palette-grey-30: hsla(0, 0%, 90%, 1) !default; // #E6E6E6
-$palette-grey-40: hsla(0, 0%, 82%, 1) !default; // #D2D2D2
-$palette-grey-50: hsla(0, 0%, 74%, 1) !default; // #BCBCBC
-$palette-grey-60: hsla(0, 0%, 64%, 1) !default; // #A2A2A2
-$palette-grey-70: hsla(0, 0%, 56%, 1) !default; // #8E8E8E
-$palette-grey-80: hsla(0, 0%, 46%, 1) !default; // #757575
-$palette-grey-90: hsla(0, 0%, 31%, 1) !default; // #505050
-$palette-grey-100: hsla(0, 0%, 25%, 1) !default; // #404040
-$palette-grey-110: hsla(0, 0%, 18%, 1) !default; // #2F2F2F
-$palette-grey-120: hsla(0, 0%, 9%, 1) !default; // #171717
+$palette-grey-10: #fafafa !default;
+$palette-grey-20: #F2F2F2 !default;
+$palette-grey-30: #E6E6E6 !default;
+$palette-grey-40: #D2D2D2 !default;
+$palette-grey-50: #BCBCBC !default;
+$palette-grey-60: #A2A2A2 !default; 
+$palette-grey-70: #8E8E8E !default; 
+$palette-grey-80: #757575 !default; 
+$palette-grey-90: #505050 !default; 
+$palette-grey-100: #404040 !default;
+$palette-grey-110: #2F2F2F !default;
+$palette-grey-120: #171717 !default;
 
 // Black
 
-$palette-black: hsla(0, 0%, 0%, 1) !default; // #000000
+$palette-black: #000000 !default;
 
 $palette-black-opacity-90: hsla(0, 0%, 0%, 0.9) !default;
 $palette-black-opacity-80: hsla(0, 0%, 0%, 0.8) !default;
@@ -38,7 +38,7 @@ $palette-black-opacity-0: hsla(0, 0%, 0%, 0) !default;
 
 // White
 
-$palette-white: hsla(0, 0%, 100%, 1) !default; // #FFFFFF
+$palette-white:#FFFFFF !default;
 
 $palette-white-opacity-0: hsla(0, 0%, 100%, 0);
 $palette-white-opacity-10: hsla(0, 0%, 100%, 0.1);
@@ -67,112 +67,112 @@ $palette-white-opacity-18: hsla(0, 0%, 100%, 0.18) !default;
 
 // Blue
 
-$palette-blue-10: hsla(205, 70%, 91%, 1) !default; // #D7EAF8
-$palette-blue-20: hsla(206, 71%, 77%, 1) !default; // #9CCBEE
-$palette-blue-30: hsla(206, 70%, 68%, 1) !default; // #75B6E7
-$palette-blue-40: hsla(206, 100%, 50%, 1) !default; // #278CDA
-$palette-blue-50: hsla(206, 100%, 41.6%, 1) !default; // #0078D4 // lightness 41.6%
-$palette-blue-60: hsla(206, 100%, 35%, 1) !default; // #0065B3
-$palette-blue-70: hsla(206, 100%, 30%, 1) !default; // #00579A
-$palette-blue-80: hsla(206, 100%, 23%, 1) !default; // #004173
-$palette-blue-90: hsla(206, 100%, 15%, 1) !default; // #002B4D
-$palette-blue-100: hsla(208, 100%, 4%, 1) !default; // #000A13
+$palette-blue-10:#D7EAF8 !default;
+$palette-blue-20: #9CCBEE !default;
+$palette-blue-30: #75B6E7 !default;
+$palette-blue-40: #278CDA !default;
+$palette-blue-50: #0078D4 !default;
+$palette-blue-60: #0065B3 !default;
+$palette-blue-70: #00579A !default;
+$palette-blue-80: #004173 !default;
+$palette-blue-90: #002B4D !default;
+$palette-blue-100: #000A13 !default;
 
 $palette-blue-opacity-30: hsla(206, 100%, 35%, 0.3);
 $palette-blue-opacity-70: hsla(206, 100%, 35%, 0.7);
 
 // Navy
 
-$palette-navy-10: hsla(216, 31%, 90%, 1) !default; // #DFE5EE
-$palette-navy-20: hsla(218, 28%, 81%, 1) !default; // #C1CBDC
-$palette-navy-30: hsla(217, 26%, 72%, 1) !default; // #A4B2C9
-$palette-navy-40: hsla(217, 23%, 62%, 1) !default; // #899AB5
-$palette-navy-50: hsla(218, 20%, 53%, 1) !default; // #70819F
-$palette-navy-60: hsla(218, 26%, 39%, 1) !default; // #4A5D7E
-$palette-navy-70: hsla(217, 45%, 25%, 1) !default; // #243A5E
-$palette-navy-80: hsla(218, 58%, 19%, 1) !default; // #14294C
-$palette-navy-90: hsla(218, 74%, 9%, 1) !default; // #061329
-$palette-navy-100: hsla(206, 100%, 3%, 1) !default; // #000910
+$palette-navy-10: #DFE5EE !default;
+$palette-navy-20: #C1CBDC !default;
+$palette-navy-30: #A4B2C9 !default;
+$palette-navy-40: #899AB5 !default;
+$palette-navy-50: #70819F !default;
+$palette-navy-60: #4A5D7E !default;
+$palette-navy-70: #243A5E !default;
+$palette-navy-80: #14294C !default;
+$palette-navy-90: #061329 !default;
+$palette-navy-100: #000910 !default;
 
 $palette-navy-opacity-30: hsla(262, 46%, 17%, 0.3) !default;
 $palette-navy-opacity-70: hsla(262, 46%, 17%, 0.7) !default;
 
 // Turqoise
 
-$palette-turqoise-10: hsla(191, 100%, 96%, 1) !default; // #E9FBFF
-$palette-turqoise-20: hsla(189, 100%, 87%, 1) !default; // #BDF5FF
-$palette-turqoise-30: hsla(189, 100%, 74%, 1) !default; // #7BECFF
-$palette-turqoise-40: hsla(189, 100%, 66%, 1) !default; // #50E6FF
-$palette-turqoise-50: hsla(189, 60%, 53%, 1) !default; // #41B9CF
-$palette-turqoise-60: hsla(189, 52%, 41%, 1) !default; // #328E9F
-$palette-turqoise-70: hsla(189, 52%, 33%, 1) !default; // #28727F
-$palette-turqoise-80: hsla(189, 52%, 20%, 1) !default; // #19474F
-$palette-turqoise-90: hsla(189, 52%, 12%, 1) !default; // #0F2A2F
-$palette-turqoise-100: hsla(186, 50%, 4%, 1) !default; // #050E0F
+$palette-turqoise-10: #E9FBFF !default;
+$palette-turqoise-20: #BDF5FF !default;
+$palette-turqoise-30: #7BECFF !default;
+$palette-turqoise-40: #50E6FF !default;
+$palette-turqoise-50: #41B9CF !default;
+$palette-turqoise-60: #328E9F !default;
+$palette-turqoise-70: #28727F !default;
+$palette-turqoise-80: #19474F !default;
+$palette-turqoise-90: #0F2A2F !default;
+$palette-turqoise-100: #050E0F !default;
 
 $palette-navy-opacity-30: hsla(189, 52%, 12%, 0.3) !default;
 $palette-navy-opacity-70: hsla(189, 52%, 12%, 0.7) !default;
 
 // Green
 
-$palette-green-10: hsla(115, 58%, 92%, 1) !default; // #dff6dd
-$palette-green-20: hsla(117, 36%, 75%, 1) !default; // #acd7aa
-$palette-green-30: hsla(119, 32%, 61%, 1) !default; // #7cbb7b
-$palette-green-40: hsla(120, 37%, 45%, 1) !default; // #489d48
-$palette-green-50: hsla(120, 54%, 35%, 1) !default; // #2a8b2a
-$palette-green-60: hsla(120, 77%, 27%, 1) !default; // #107c10
-$palette-green-70: hsla(125, 80%, 22%, 1) !default; // #0b6413
-$palette-green-80: hsla(135, 88%, 16%, 1) !default; // #054b16
-$palette-green-90: hsla(129, 83%, 11%, 1) !default; // #05350c
-$palette-green-100: hsla(106, 100%, 5%, 1) !default; // #061a00
+$palette-green-10: #dff6dd !default;
+$palette-green-20: #acd7aa !default;
+$palette-green-30: #7cbb7b !default;
+$palette-green-40: #489d48 !default;
+$palette-green-50: #2a8b2a !default;
+$palette-green-60: #107c10 !default;
+$palette-green-70: #0b6413 !default;
+$palette-green-80: #054b16 !default;
+$palette-green-90: #05350c !default;
+$palette-green-100: #061a00 !default;
 
 $palette-green-opacity-30: hsla(120, 37%, 45%, 0.3) !default;
 $palette-green-opacity-70: hsla(120, 37%, 45%, 0.7) !default;
 
 // Purple
 
-$palette-purple-10: hsla(277, 90%, 92%, 1) !default; // #efd9fd
-$palette-purple-20: hsla(275, 97%, 86%, 1) !default; // #e0b7fe
-$palette-purple-30: hsla(274, 100%, 81%, 1) !default; // #d59dff
-$palette-purple-40: hsla(268, 62%, 69%, 1) !default; // #ac7ee1
-$palette-purple-50: hsla(265, 53%, 63%, 1) !default; // #9970d3
-$palette-purple-60: hsla(262, 46%, 58%, 1) !default; // #8661c5
-$palette-purple-70: hsla(261, 33%, 43%, 1) !default; // #624991
-$palette-purple-80: hsla(259, 31%, 26%, 1) !default; // #3b2e58
-$palette-purple-90: hsla(251, 47%, 18%, 1) !default; // #201843
-$palette-purple-100: hsla(244, 100%, 9%, 1) !default; // #03002c
+$palette-purple-10: #efd9fd !default;
+$palette-purple-20: #e0b7fe !default;
+$palette-purple-30: #d59dff !default;
+$palette-purple-40: #ac7ee1 !default;
+$palette-purple-50: #9970d3 !default;
+$palette-purple-60: #8661c5 !default;
+$palette-purple-70: #624991 !default;
+$palette-purple-80: #3b2e58 !default;
+$palette-purple-90: #201843 !default;
+$palette-purple-100: #03002c !default;
 
 $palette-purple-opacity-30: hsla(251, 47%, 18%, 0.3) !default;
 $palette-purple-opacity-70: hsla(251, 47%, 18%, 0.7) !default;
 
 // Yellow
 
-$palette-yellow-10: hsla(47, 100%, 90%, 1) !default; // #fff4ce
-$palette-yellow-20: hsla(45, 100%, 81%, 1) !default; // #ffe79f
-$palette-yellow-30: hsla(44, 100%, 76%, 1) !default; // #ffdf84
-$palette-yellow-40: hsla(44, 100%, 62%, 1) !default; // #ffcb3f
-$palette-yellow-50: hsla(44, 100%, 50%, 1) !default; // #ffb900
-$palette-yellow-60: hsla(43, 99%, 41%, 1) !default; // #d19501
-$palette-yellow-70: hsla(41, 97%, 30%, 1) !default; // #966802
-$palette-yellow-80: hsla(38, 66%, 25%, 1) !default; // #6a4b16
-$palette-yellow-90: hsla(35, 70%, 18%, 1) !default; // #4f340e
-$palette-yellow-100: hsla(29, 88%, 9%, 1) !default; // #2d1703
+$palette-yellow-10: #fff4ce hsla(47, 100%, 90%, 1) !default;
+$palette-yellow-20: #ffe79f hsla(45, 100%, 81%, 1) !default;
+$palette-yellow-30: #ffdf84 hsla(44, 100%, 76%, 1) !default;
+$palette-yellow-40: #ffcb3f hsla(44, 100%, 62%, 1) !default;
+$palette-yellow-50: #ffb900 hsla(44, 100%, 50%, 1) !default;
+$palette-yellow-60: #d19501 hsla(43, 99%, 41%, 1) !default;
+$palette-yellow-70: #966802 hsla(41, 97%, 30%, 1) !default;
+$palette-yellow-80: #6a4b16 hsla(38, 66%, 25%, 1) !default;
+$palette-yellow-90: #4f340e hsla(35, 70%, 18%, 1) !default;
+$palette-yellow-100: #2d1703 hsla(29, 88%, 9%, 1) !default;
 
 $palette-yellow-opacity-30: hsla(44, 100%, 50%, 0.3) !default;
 $palette-yellow-opacity-70: hsla(44, 100%, 50%, 0.7) !default;
 
 // Red
 
-$palette-red-10: hsla(355, 85%, 95%, 1) !default; // #FDE7E9
-$palette-red-20: hsla(359, 54%, 78%, 1) !default; // #E5A7A8
-$palette-red-30: hsla(359, 51%, 65%, 1) !default; // #D4797A
-$palette-red-40: hsla(0, 50%, 54%, 1) !default; // #C54F4F
-$palette-red-50: hsla(0, 100%, 33%, 1) !default; // #B62626
-$palette-red-60: hsla(0, 100%, 33%, 1) !default; // #A80000
-$palette-red-70: hsla(0, 100%, 26%, 1) !default; // #870000
-$palette-red-80: hsla(359, 100%, 19%, 1) !default; // #630001
-$palette-red-90: hsla(359, 100%, 14%, 1) !default; // #470001
-$palette-red-100: hsla(359, 100%, 8%, 1) !default; // #290001
+$palette-red-10: #FDE7E9 !default;
+$palette-red-20: #E5A7A8 !default;
+$palette-red-30: #D4797A !default;
+$palette-red-40: #C54F4F !default;
+$palette-red-50: #B62626 !default;
+$palette-red-60: #A80000 !default;
+$palette-red-70: #870000 !default;
+$palette-red-80: #630001 !default;
+$palette-red-90: #470001 !default;
+$palette-red-100: #290001 !default;
 
 $palette-red-opacity-30: hsla(0, 100%, 33%, 0.3) !default;
 $palette-red-opacity-70: hsla(0, 100%, 33%, 0.7) !default;

--- a/css/src/tokens/palette.scss
+++ b/css/src/tokens/palette.scss
@@ -161,7 +161,7 @@ $palette-yellow-100: #2d1703 !default;
 $palette-yellow-opacity-30: #ffbb004d !default;
 $palette-yellow-opacity-70: #ffbb00b3 !default;
 
-// Red COMPLETE
+// Red
 
 $palette-red-10: #fde7e9 !default;
 $palette-red-20: #e5a7a8 !default;


### PR DESCRIPTION
task-404280

Changing Color Palette Value from HSLA to Hex . 

All hex value from 100% to 0% alpha for opacity :
https://gist.github.com/lopspower/03fb1cc0ac9f32ef38f4

Main Opacity Value -

100% — FF

90% — E6

80% — CC

70% — B3

60% — 99

50% — 80

40% — 66

30% — 4D

20% — 33

10% — 1A

0% — 00