### PR TITLE
update with very basic site layout

### DIFF
--- a/.changeset/five-plants-drum.md
+++ b/.changeset/five-plants-drum.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': minor
+---
+
+Update site layout on tablet and above.

--- a/css/src/atomics/typography.scss
+++ b/css/src/atomics/typography.scss
@@ -82,6 +82,10 @@
 	text-decoration: underline;
 }
 
+.text-decoration-none {
+	text-decoration: none;
+}
+
 //Letter Spacing
 
 .letter-spacing-wide {

--- a/css/src/atomics/typography.scss
+++ b/css/src/atomics/typography.scss
@@ -79,15 +79,15 @@
 }
 
 .text-decoration-underline {
-	text-decoration: underline;
+	text-decoration: underline !important;
 }
 
 .text-decoration-none {
-	text-decoration: none;
+	text-decoration: none !important;
 }
 
 //Letter Spacing
 
 .letter-spacing-wide {
-	letter-spacing: $letter-spacing-wide;
+	letter-spacing: $letter-spacing-wide !important;
 }

--- a/plugins/parcel-transformer-markdown-html/lib/index.js
+++ b/plugins/parcel-transformer-markdown-html/lib/index.js
@@ -40,7 +40,7 @@ const markedOptions = {
 			language in languageDisplayNames ? languageDisplayNames[language] : language;
 		return `
 			${elementExample}
-			<div class="code-block">
+			<div class="code-block margin-top-s">
 				<div class="code-block-header">
 					<span class="code-block-header-language" data-hljs-language="${language}">${displayName}</span>
 				</div>

--- a/site/src/scaffold/index.scss
+++ b/site/src/scaffold/index.scss
@@ -1,2 +1,3 @@
 @import '@microsoft/atlas-css/src/index.scss';
+@import './styles/layout.scss';
 @import './code-block.scss';

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -16,7 +16,7 @@
 		</header>
 
 		<main id="main">
-			<div class="layout-container">
+			<div class="layout-container padding-top-s">
 				{{{ body }}}
 			</div>
 		</main>

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -10,32 +10,40 @@
 		<meta name="color-scheme" content="light dark" />
 		<link rel="stylesheet" href="~/src/scaffold/index.scss">
 	</head>
-	<body>
-		<header class="padding-block-xs padding-inline-s font-weight-bold" style="border-bottom: 1px solid var(--theme-border)">
-			Atlas Design
+	<body id="body">
+		<header id="header" class="padding-block-xs padding-inline-s" style="border-bottom: 1px solid var(--theme-border)">
+			<a href="~/src/index.md" class="color-text text-decoration-none font-weight-bold">Atlas Design</a>
 		</header>
 
-		<main class="padding-s">
-			<div class="">
+		<main id="main">
+			<div class="layout-container">
 				{{{ body }}}
 			</div>
 		</main>
-		<aside class="padding-s margin-top-xs">
+		<nav id="nav" class="background-color-body-medium" style="border-right: 1px solid var(--theme-border)">
 			{{#toc}}
 			{{#entries}}
-						{{#isDirectory}}
-							<div class="margin-top-s">
-								<p>{{name}}</p>
-								{{#children}}
-									<a class="display-block color-primary" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
-								{{/children}}
-							</div>
-						{{/isDirectory}}
-						{{^children.0}}
-							<a class="display-block color-primary" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
-						{{/children.0}}
+					{{#isDirectory}}
+						<div class="margin-top-s">
+							<p>{{name}}</p>
+							{{#children}}
+								<a class="display-block color-primary" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+							{{/children}}
+						</div>
+					{{/isDirectory}}
+					{{^children.0}}
+						<a class="display-block color-primary" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+					{{/children.0}}
 				{{/entries}}
 			{{/toc}}
+		</nav>
+		<aside id="aside">
+			<div class="layout-container">
+			<!-- empty for now -->
+			</div>
 		</aside>
+		<footer id="footer">
+			<!-- empty for now -->
+		</footer>
 	</body>
 </html>

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -11,7 +11,7 @@
 		<link rel="stylesheet" href="~/src/scaffold/index.scss">
 	</head>
 	<body id="body">
-		<header id="header" class="padding-block-xs padding-inline-s" style="border-bottom: 1px solid var(--theme-border)">
+		<header id="header" style="border-bottom: 1px solid var(--theme-border)">
 			<a href="~/src/index.md" class="color-text text-decoration-none font-weight-bold">Atlas Design</a>
 		</header>
 

--- a/site/src/scaffold/styles/layout.scss
+++ b/site/src/scaffold/styles/layout.scss
@@ -1,0 +1,113 @@
+#body {
+	width: 100%;
+	height: 100%;
+	max-width: 100%;
+	overflow-x: hidden;
+
+	@include tablet {
+		display: grid;
+		grid-template: auto 1fr auto auto / auto 1fr auto; // [ rows / columns ]
+
+		grid-template-areas:
+			'header header header'
+			'nav main .'
+			'nav aside .'
+			'footer footer footer';
+	}
+
+	@include widescreen {
+		grid-template-areas:
+			'header header header'
+			'nav main aside'
+			'footer footer footer';
+	}
+}
+
+#header,
+#main,
+#nav,
+#aside,
+#footer {
+	overflow: hidden;
+	padding: $layout-2;
+}
+
+#header {
+	grid-area: header;
+}
+
+#main {
+	grid-area: main;
+	min-height: 90vh;
+}
+
+#nav {
+	grid-area: nav;
+}
+
+#aside {
+	grid-area: aside;
+}
+
+#footer {
+	grid-area: footer;
+}
+
+.layout-container {
+	max-width: 70ch;
+	margin: auto;
+	@include tablet {
+		padding-inline: $layout-3;
+	}
+}
+
+// For debugging layout purposes only
+
+@mixin debug($content) {
+	position: relative;
+	&::after {
+		padding: 4px 8px;
+		border-radius: 1px;
+		position: absolute;
+		top: 0;
+		left: 0;
+		background-color: red;
+		color: white;
+		font-size: 12px;
+		content: $content;
+	}
+}
+
+html.debug {
+	#header,
+	#main,
+	#nav,
+	#aside,
+	#footer {
+		border: 1px solid $border;
+	}
+
+	#header {
+		@include debug('header');
+	}
+
+	#main {
+		@include debug('main');
+	}
+
+	#nav {
+		@include debug('nav');
+	}
+
+	#aside {
+		@include debug('aside');
+	}
+
+	#footer {
+		@include debug('footer');
+	}
+
+	.content-container {
+		@include debug('reading-container');
+	}
+}

--- a/site/src/scaffold/styles/layout.scss
+++ b/site/src/scaffold/styles/layout.scss
@@ -29,7 +29,7 @@
 #aside,
 #footer {
 	overflow: hidden;
-	padding: $layout-2;
+	padding: $layout-1 $layout-2;
 }
 
 #header {
@@ -51,6 +51,7 @@
 
 #footer {
 	grid-area: footer;
+	background-color: $border;
 }
 
 .layout-container {

--- a/site/src/scaffold/token.html
+++ b/site/src/scaffold/token.html
@@ -15,7 +15,7 @@
 			<a href="~/src/index.md" class="color-text text-decoration-none font-weight-bold">Atlas Design</a>
 		</header>
 		<main id="main">
-			<div class="layout-container">
+			<div class="layout-container padding-top-s">
 				{{{ body }}}
 				
 				<div class="padding-block-m">

--- a/site/src/scaffold/token.html
+++ b/site/src/scaffold/token.html
@@ -10,37 +10,50 @@
 		<meta name="color-scheme" content="light dark" />
 		<link rel="stylesheet" href="~/src/scaffold/index.scss"
 	</head>
-	<body>
-		<header class="padding-block-xs padding-inline-s font-weight-bold" style="border-bottom: 1px solid var(--theme-border)">
-			Atlas Design
+	<body id="body">
+		<header id="header" class="padding-block-xs padding-inline-s font-weight-bold" style="border-bottom: 1px solid var(--theme-border)">
+			<a href="~/src/index.md" class="color-text text-decoration-none font-weight-bold">Atlas Design</a>
 		</header>
-		<main class="padding-s">
-			<div class="markdown">
+		<main id="main">
+			<div class="layout-container">
 				{{{ body }}}
-			</div>
-			
-			<div class="padding-block-m">
-				<a href="https://github.com/microsoft/atlas-design/tree/main{{cssTokenSource}}">View on Github</a>
-			</div>
-			<pre><code>{{#tokens}}{{name}}: {{value}}
+				
+				<div class="padding-block-m">
+					<a href="https://github.com/microsoft/atlas-design/tree/main{{cssTokenSource}}">View on Github</a>
+				</div>
+				<div class="code-block">
+					<div class="code-block-body">
+					<pre><code>{{#tokens}}{{name}}: {{value}}
 {{/tokens}}</code></pre>
+					</div>
+
+				</div>
+			</div>
 		</main>
-		<aside class="padding-s">
+		<nav id="nav" class="background-color-body-medium" style="border-right: 1px solid var(--theme-border)">
 			{{#toc}}
 				{{#entries}}
-						{{#isDirectory}}
-							<div class="margin-top-s">
-								<p>{{name}}</p>
-								{{#children}}
-									<a class="display-block color-primary" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
-								{{/children}}
-							</div>
-						{{/isDirectory}}
-						{{^children.0}}
-							<a class="display-block color-primary" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
-						{{/children.0}}
+					{{#isDirectory}}
+						<div class="margin-top-s">
+							<p>{{name}}</p>
+							{{#children}}
+								<a class="display-block color-primary" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+							{{/children}}
+						</div>
+					{{/isDirectory}}
+					{{^children.0}}
+						<a class="display-block color-primary" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+					{{/children.0}}
 				{{/entries}}
 			{{/toc}}
+		</nav>
+		<aside id="aside">
+			<div class="layout-container">
+			<!-- empty for now -->
+			</div>
 		</aside>
+		<footer id="footer">
+			<!-- empty for now -->
+		</footer>
 	</body>
 </html>


### PR DESCRIPTION
task-414294 

This PR puts up a site layout. It is likely that this isn't going to be the layout forever. But it's simple, and does the trick. It also provides a little extra room looking forward. It includes all the major elements that most info-based sites would want.

- header
- main - houses the content
- aside (empty for now)
- nav - left hand nav
- footer (empty for now)

Testing:

Pop open the preview link.

[standard page](https://design.docs.microsoft.com/pulls/101/components/markdown.html)
[tokens page](https://design.docs.microsoft.com/pulls/101/tokens/colors.html)

preview-101

Test the layout with some labels and borders

```js
document.documentElement.classList.add('debug');
```

Test with some content in the `<aside>`

```js
document.getElementById('aside').innerHTML = document.getElementById('nav').innerHTML;
```