### PR TITLE
Downgrade node-sass back to 4.14.0

### DIFF
--- a/css/package.json
+++ b/css/package.json
@@ -50,7 +50,7 @@
 		"stylelint-config-prettier": "^8.0.2",
 		"stylelint-prettier": "^1.1.2",
 		"sass-extract": "^2.1.0",
-		"node-sass": "^5.0.0",
+		"node-sass": "^4.14.0",
 		"fs-extra": "^9.1.0",
 		"quicktype-core": "^6.0.70"
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,21 +24,21 @@
 		},
 		"css": {
 			"name": "@microsoft/atlas-css",
-			"version": "0.8.1",
+			"version": "0.8.2",
 			"license": "MIT",
 			"dependencies": {
 				"minireset.css": "^0.0.7",
-				"normalize.css": "^8.0.1"
+				"normalize.css": "^8.0.1",
+				"rfs": "^9.0.3"
 			},
 			"devDependencies": {
 				"@microsoft/stylelint-config-atlas": "3.0.0",
 				"@parcel/transformer-sass": "2.0.0-beta.2",
 				"fs-extra": "^9.1.0",
-				"node-sass": "^5.0.0",
+				"node-sass": "^4.14.0",
 				"parcel": "2.0.0-beta.2",
 				"prettier": "^2.2.1",
 				"quicktype-core": "^6.0.70",
-				"rfs": "^9.0.3",
 				"sass": "^1.32.8",
 				"sass-extract": "^2.1.0",
 				"stylelint": "^13.11.0",
@@ -28068,7 +28068,7 @@
 				"@parcel/transformer-sass": "2.0.0-beta.2",
 				"fs-extra": "^9.1.0",
 				"minireset.css": "^0.0.7",
-				"node-sass": "^5.0.0",
+				"node-sass": "^4.14.0",
 				"normalize.css": "^8.0.1",
 				"parcel": "2.0.0-beta.2",
 				"prettier": "^2.2.1",


### PR DESCRIPTION
Task: [task-414149](https://dev.azure.com/ceapex/Engineering/_boards/board/t/Fox%20Team/Stories/?workitem=414149)

Link: [preview-123](https://design.docs.microsoft.com/pulls/123/)

This PR downgrades the version of node-sass to 4.14.0 to potentially resolve an error.

## Testing

1. Visit the preview link above, should still work.
