### PR TITLE
Try replacing prepublish script with prepublishOnly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      - uses: jitterbit/get-changed-files@v1
+        id: abc
+        with:
+          format: space-delimited
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js 15.7.X
         uses: actions/setup-node@v2
@@ -53,3 +58,10 @@ jobs:
       - name: Build site
         run: |
           npm run build:site;
+
+      - name: Check output
+        run: |
+          echo "All:"
+          echo "${{ steps.abc.outputs.all }}"
+          echo "Added:"
+          echo "${{ steps.abc.outputs.added }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,11 +26,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      - uses: jitterbit/get-changed-files@v1
-        id: abc
-        with:
-          format: space-delimited
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js 15.7.X
         uses: actions/setup-node@v2
@@ -58,10 +53,3 @@ jobs:
       - name: Build site
         run: |
           npm run build:site;
-
-      - name: Check output
-        run: |
-          echo "All:"
-          echo "${{ steps.abc.outputs.all }}"
-          echo "Added:"
-          echo "${{ steps.abc.outputs.added }}"

--- a/css/package.json
+++ b/css/package.json
@@ -11,7 +11,7 @@
 		"build": "npm run build:css && npm run tokens",
 		"build:css": "parcel build src/index.scss --no-cache --no-autoinstall",
 		"tokens": "node ./tokens/index.js",
-		"prepare": "npm run lint && npm run build"
+		"prepublishOnly": "npm run lint && npm run build"
 	},
 	"homepage": "https://github.com/microsoft/atlas-design",
 	"repository": {

--- a/css/package.json
+++ b/css/package.json
@@ -11,7 +11,7 @@
 		"build": "npm run build:css && npm run tokens",
 		"build:css": "parcel build src/index.scss --no-cache --no-autoinstall",
 		"tokens": "node ./tokens/index.js",
-		"prepublish": "npm run lint && npm run build"
+		"prepare": "npm run lint && npm run build"
 	},
 	"homepage": "https://github.com/microsoft/atlas-design",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"pretty-quick": "pretty-quick --staged --pattern \"**/*.{scss,ts,js,json,yml}\"",
 		"prestart": "npm run build:tokens",
 		"prebuild:site": "npm run build:tokens",
-		"release": "npm changeset publish"
+		"release": "npx changeset publish"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Task: task-[417815](https://dev.azure.com/ceapex/Engineering/_workitems/edit/417845)

Link: preview-[125](https://design.docs.microsoft.com/pulls/125)

It appears that after the `Yarn` to `Npm` migration, the `dist` folder is no longer included in the published package. This PR tests whether using the Npm `prepublishOnly` script makes a difference. 

My hypothesis is that there could be a difference between Yarn's `prepublish` and Npm's `prepublish` lifecycle script.
https://docs.npmjs.com/cli/v7/using-npm/scripts#examples 

The idea is that the `prepublishOnly` script runs before the package is packed and published, so if the dist folder wasn't already created for some reason, the `prepublishOnly` script would force its creation before publishing. 

Pre-migration version 0.8.1
https://unpkg.com/browse/@microsoft/atlas-css@0.8.1/

Post-migration version 0.8.2
https://unpkg.com/browse/@microsoft/atlas-css@0.8.2/

## Testing

1. The only way to test this is to publish a new package version.
