### PR TITLE
[bug] Change spacing atomics output order

### DIFF
--- a/.changeset/chilly-emus-reflect.md
+++ b/.changeset/chilly-emus-reflect.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Adjust spacing output based on specificity.

--- a/css/src/atomics/spacing.scss
+++ b/css/src/atomics/spacing.scss
@@ -5,14 +5,14 @@ $inlineKey: 'inline';
 $blockKey: 'block';
 
 $layout-sizes: (
+	('none', $layout-0),
 	('xs', $layout-1),
 	('s', $layout-2),
 	('m', $layout-3),
 	('l', $layout-4),
 	('xl', $layout-5),
 	('xxl', $layout-6),
-	('xxxl', $layout-7),
-	('none', $layout-0)
+	('xxxl', $layout-7)
 );
 
 @function sizeValue($key, $value) {

--- a/css/src/atomics/spacing.scss
+++ b/css/src/atomics/spacing.scss
@@ -5,14 +5,14 @@ $inlineKey: 'inline';
 $blockKey: 'block';
 
 $layout-sizes: (
-	('none', $layout-0),
 	('xs', $layout-1),
 	('s', $layout-2),
 	('m', $layout-3),
 	('l', $layout-4),
 	('xl', $layout-5),
 	('xxl', $layout-6),
-	('xxxl', $layout-7)
+	('xxxl', $layout-7),
+	('none', $layout-0)
 );
 
 @function sizeValue($key, $value) {
@@ -52,8 +52,13 @@ $layout-sizes: (
 		margin-top: sizeValue($sizeKey, $sizeValue) !important;
 		margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
 	}
+}
 
-	@include tablet {
+@include tablet {
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
+
 		.#{$marginKey}#{$separator}#{$sizeKey}-tablet {
 			margin: sizeValue($sizeKey, $sizeValue) !important;
 		}
@@ -78,8 +83,13 @@ $layout-sizes: (
 			margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
 		}
 	}
+}
 
-	@include desktop {
+@include desktop {
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
+
 		.#{$marginKey}#{$separator}#{$sizeKey}-desktop {
 			margin: sizeValue($sizeKey, $sizeValue) !important;
 		}
@@ -104,8 +114,13 @@ $layout-sizes: (
 			margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
 		}
 	}
+}
 
-	@include widescreen {
+@include widescreen {
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
+
 		.#{$marginKey}#{$separator}#{$sizeKey}-widescreen {
 			margin: sizeValue($sizeKey, $sizeValue) !important;
 		}
@@ -162,8 +177,13 @@ $layout-sizes: (
 		padding-top: sizeValue($sizeKey, $sizeValue) !important;
 		padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
 	}
+}
 
-	@include tablet {
+@include tablet {
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
+
 		.#{$paddingKey}#{$separator}#{$sizeKey}-tablet {
 			padding: sizeValue($sizeKey, $sizeValue) !important;
 		}
@@ -186,8 +206,13 @@ $layout-sizes: (
 			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
 		}
 	}
+}
 
-	@include desktop {
+@include desktop {
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
+
 		.#{$paddingKey}#{$separator}#{$sizeKey}-desktop {
 			padding: sizeValue($sizeKey, $sizeValue) !important;
 		}
@@ -210,8 +235,13 @@ $layout-sizes: (
 			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
 		}
 	}
+}
 
-	@include widescreen {
+@include widescreen {
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
+
 		.#{$paddingKey}#{$separator}#{$sizeKey}-widescreen {
 			padding: sizeValue($sizeKey, $sizeValue) !important;
 		}

--- a/css/src/atomics/spacing.scss
+++ b/css/src/atomics/spacing.scss
@@ -15,16 +15,24 @@ $layout-sizes: (
 	('none', $layout-0)
 );
 
+@function sizeValue($key, $value) {
+	@return if($key == 'none', 0, $value);
+}
+
 // Pattern: <cssproperty>-<value>-<screen>
 
-// margin
 @each $size in $layout-sizes {
 	$sizeKey: nth($size, 1);
 	$sizeValue: nth($size, 2);
 
 	// .margin-<value>
 	.#{$marginKey}#{$separator}#{$sizeKey} {
-		margin: $sizeValue !important;
+		margin: sizeValue($sizeKey, $sizeValue) !important;
+	}
+
+	// .padding-<value>
+	.#{$paddingKey}#{$separator}#{$sizeKey} {
+		padding: sizeValue($sizeKey, $sizeValue) !important;
 	}
 }
 
@@ -35,7 +43,12 @@ $layout-sizes: (
 
 		// .margin-<side>-<value>
 		.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey} {
-			margin-#{$direction}: $sizeValue !important;
+			margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+		}
+
+		// .padding-<side>-<value>
+		.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey} {
+			padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
 		}
 	}
 }
@@ -44,27 +57,36 @@ $layout-sizes: (
 	$sizeKey: nth($size, 1);
 	$sizeValue: nth($size, 2);
 
-	// margin-inline property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
+	// margin/padding-inline property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
 
 	// .margin-inline-<value>
 	.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey} {
 		// Replace with margin-inline property when possible
-		margin-right: $sizeValue !important;
-		margin-left: $sizeValue !important;
+		margin-right: sizeValue($sizeKey, $sizeValue) !important;
+		margin-left: sizeValue($sizeKey, $sizeValue) !important;
 	}
-}
 
-@each $size in $layout-sizes {
-	$sizeKey: nth($size, 1);
-	$sizeValue: nth($size, 2);
+	// .padding-inline-<value>
+	.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey} {
+		// Replace with padding-inline property when possible
+		padding-right: sizeValue($sizeKey, $sizeValue) !important;
+		padding-left: sizeValue($sizeKey, $sizeValue) !important;
+	}
 
-	// margin-block property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
+	// margin/padding-block property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
 
 	// .margin-block-<value>
 	.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey} {
 		// Replace with margin-block property when possible
-		margin-top: $sizeValue !important;
-		margin-bottom: $sizeValue !important;
+		margin-top: sizeValue($sizeKey, $sizeValue) !important;
+		margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
+	}
+
+	// .padding-block-<value>
+	.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey} {
+		// Replace with padding-block property when possible
+		padding-top: sizeValue($sizeKey, $sizeValue) !important;
+		padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
 	}
 }
 
@@ -74,7 +96,11 @@ $layout-sizes: (
 		$sizeValue: nth($size, 2);
 
 		.#{$marginKey}#{$separator}#{$sizeKey}#{$separator}tablet {
-			margin: $sizeValue !important;
+			margin: sizeValue($sizeKey, $sizeValue) !important;
+		}
+
+		.#{$paddingKey}#{$separator}#{$sizeKey}#{$separator}tablet {
+			padding: sizeValue($sizeKey, $sizeValue) !important;
 		}
 	}
 
@@ -84,7 +110,11 @@ $layout-sizes: (
 			$sizeValue: nth($size, 2);
 
 			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}#{$separator}tablet {
-				margin-#{$direction}: $sizeValue !important;
+				margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+			}
+
+			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}#{$separator}tablet {
+				padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
 			}
 		}
 	}
@@ -95,19 +125,26 @@ $layout-sizes: (
 
 		.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}#{$separator}tablet {
 			// Replace with margin-inline property when possible
-			margin-right: $sizeValue !important;
-			margin-left: $sizeValue !important;
+			margin-right: sizeValue($sizeKey, $sizeValue) !important;
+			margin-left: sizeValue($sizeKey, $sizeValue) !important;
 		}
-	}
 
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
+		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}#{$separator}tablet {
+			// Replace with padding-inline property when possible
+			padding-right: sizeValue($sizeKey, $sizeValue) !important;
+			padding-left: sizeValue($sizeKey, $sizeValue) !important;
+		}
 
 		.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}#{$separator}tablet {
 			// Replace with margin-block property when possible
-			margin-top: $sizeValue !important;
-			margin-bottom: $sizeValue !important;
+			margin-top: sizeValue($sizeKey, $sizeValue) !important;
+			margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
+		}
+
+		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}#{$separator}tablet {
+			// Replace with padding-block property when possible
+			padding-top: sizeValue($sizeKey, $sizeValue) !important;
+			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
 		}
 	}
 }
@@ -118,7 +155,11 @@ $layout-sizes: (
 		$sizeValue: nth($size, 2);
 
 		.#{$marginKey}#{$separator}#{$sizeKey}#{$separator}desktop {
-			margin: $sizeValue !important;
+			margin: sizeValue($sizeKey, $sizeValue) !important;
+		}
+
+		.#{$paddingKey}#{$separator}#{$sizeKey}#{$separator}desktop {
+			padding: sizeValue($sizeKey, $sizeValue) !important;
 		}
 	}
 
@@ -128,7 +169,11 @@ $layout-sizes: (
 			$sizeValue: nth($size, 2);
 
 			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}#{$separator}desktop {
-				margin-#{$direction}: $sizeValue !important;
+				margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+			}
+
+			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}#{$separator}desktop {
+				padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
 			}
 		}
 	}
@@ -139,19 +184,26 @@ $layout-sizes: (
 
 		.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}#{$separator}desktop {
 			// Replace with margin-inline property when possible
-			margin-right: $sizeValue !important;
-			margin-left: $sizeValue !important;
+			margin-right: sizeValue($sizeKey, $sizeValue) !important;
+			margin-left: sizeValue($sizeKey, $sizeValue) !important;
 		}
-	}
 
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
+		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}#{$separator}desktop {
+			// Replace with padding-inline property when possible
+			padding-right: sizeValue($sizeKey, $sizeValue) !important;
+			padding-left: sizeValue($sizeKey, $sizeValue) !important;
+		}
 
 		.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}#{$separator}desktop {
 			// Replace with margin-block property when possible
-			margin-top: $sizeValue !important;
-			margin-bottom: $sizeValue !important;
+			margin-top: sizeValue($sizeKey, $sizeValue) !important;
+			margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
+		}
+
+		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}#{$separator}desktop {
+			// Replace with padding-block property when possible
+			padding-top: sizeValue($sizeKey, $sizeValue) !important;
+			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
 		}
 	}
 }
@@ -162,7 +214,11 @@ $layout-sizes: (
 		$sizeValue: nth($size, 2);
 
 		.#{$marginKey}#{$separator}#{$sizeKey}#{$separator}widescreen {
-			margin: $sizeValue !important;
+			margin: sizeValue($sizeKey, $sizeValue) !important;
+		}
+
+		.#{$paddingKey}#{$separator}#{$sizeKey}#{$separator}widescreen {
+			padding: sizeValue($sizeKey, $sizeValue) !important;
 		}
 	}
 
@@ -172,7 +228,11 @@ $layout-sizes: (
 			$sizeValue: nth($size, 2);
 
 			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}#{$separator}widescreen {
-				margin-#{$direction}: $sizeValue !important;
+				margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+			}
+
+			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}#{$separator}widescreen {
+				padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
 			}
 		}
 	}
@@ -183,202 +243,26 @@ $layout-sizes: (
 
 		.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}#{$separator}widescreen {
 			// Replace with margin-inline property when possible
-			margin-right: $sizeValue !important;
-			margin-left: $sizeValue !important;
+			margin-right: sizeValue($sizeKey, $sizeValue) !important;
+			margin-left: sizeValue($sizeKey, $sizeValue) !important;
 		}
-	}
 
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
+		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}#{$separator}widescreen {
+			// Replace with padding-inline property when possible
+			padding-right: sizeValue($sizeKey, $sizeValue) !important;
+			padding-left: sizeValue($sizeKey, $sizeValue) !important;
+		}
 
 		.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}#{$separator}widescreen {
 			// Replace with margin-block property when possible
-			margin-top: $sizeValue !important;
-			margin-bottom: $sizeValue !important;
+			margin-top: sizeValue($sizeKey, $sizeValue) !important;
+			margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
 		}
-	}
-}
 
-// padding
-@each $size in $layout-sizes {
-	$sizeKey: nth($size, 1);
-	$sizeValue: nth($size, 2);
-
-	// .padding-<value>
-	.#{$paddingKey}#{$separator}#{$sizeKey} {
-		padding: $sizeValue !important;
-	}
-}
-
-@each $position-key, $direction in $directions {
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
-		// .padding-<side>-<value>
-		.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey} {
-			padding-#{$direction}: $sizeValue !important;
-		}
-	}
-}
-
-@each $size in $layout-sizes {
-	$sizeKey: nth($size, 1);
-	$sizeValue: nth($size, 2);
-
-	// padding-inline property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
-
-	// .padding-inline-<value>
-	.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey} {
-		// Replace with margin-inline property when possible
-		padding-right: $sizeValue !important;
-		padding-left: $sizeValue !important;
-	}
-}
-
-@each $size in $layout-sizes {
-	$sizeKey: nth($size, 1);
-	$sizeValue: nth($size, 2);
-
-	// padding-block property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
-
-	// .padding-block-<value>
-	.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey} {
-		// Replace with padding-block property when possible
-		padding-top: $sizeValue !important;
-		padding-bottom: $sizeValue !important;
-	}
-}
-
-@include tablet {
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
-		.#{$paddingKey}#{$separator}#{$sizeKey}-tablet {
-			padding: $sizeValue !important;
-		}
-	}
-
-	@each $position-key, $direction in $directions {
-		@each $size in $layout-sizes {
-			$sizeKey: nth($size, 1);
-			$sizeValue: nth($size, 2);
-
-			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-tablet {
-				padding-#{$direction}: $sizeValue !important;
-			}
-		}
-	}
-
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
-		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}-tablet {
-			// Replace with padding-inline property when possible
-			padding-right: $sizeValue !important;
-			padding-left: $sizeValue !important;
-		}
-	}
-
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
-		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-tablet {
+		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}#{$separator}widescreen {
 			// Replace with padding-block property when possible
-			padding-top: $sizeValue !important;
-			padding-bottom: $sizeValue !important;
-		}
-	}
-}
-
-@include desktop {
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
-		.#{$paddingKey}#{$separator}#{$sizeKey}-desktop {
-			padding: $sizeValue !important;
-		}
-	}
-
-	@each $position-key, $direction in $directions {
-		@each $size in $layout-sizes {
-			$sizeKey: nth($size, 1);
-			$sizeValue: nth($size, 2);
-
-			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-desktop {
-				padding-#{$direction}: $sizeValue !important;
-			}
-		}
-	}
-
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
-		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}-desktop {
-			// Replace with padding-inline property when possible
-			padding-right: $sizeValue !important;
-			padding-left: $sizeValue !important;
-		}
-	}
-
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
-		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-desktop {
-			// Replace with padding-block property when possible
-			padding-top: $sizeValue !important;
-			padding-bottom: $sizeValue !important;
-		}
-	}
-}
-
-@include widescreen {
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
-		.#{$paddingKey}#{$separator}#{$sizeKey}-widescreen {
-			padding: $sizeValue !important;
-		}
-	}
-
-	@each $position-key, $direction in $directions {
-		@each $size in $layout-sizes {
-			$sizeKey: nth($size, 1);
-			$sizeValue: nth($size, 2);
-
-			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-widescreen {
-				padding-#{$direction}: $sizeValue !important;
-			}
-		}
-	}
-
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
-		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}-widescreen {
-			// Replace with padding-inline property when possible
-			padding-right: $sizeValue !important;
-			padding-left: $sizeValue !important;
-		}
-	}
-
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
-		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-widescreen {
-			// Replace with padding-block property when possible
-			padding-top: $sizeValue !important;
-			padding-bottom: $sizeValue !important;
+			padding-top: sizeValue($sizeKey, $sizeValue) !important;
+			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
 		}
 	}
 }

--- a/css/src/atomics/spacing.scss
+++ b/css/src/atomics/spacing.scss
@@ -21,15 +21,12 @@ $layout-sizes: (
 // Pattern: <cssproperty>-<value>-<screen>
 
 @each $property in $spacing-properties {
-	// iterates through margin, margin-inline, margin-block, etc
 	@each $size in $layout-sizes {
-		// iterates over values 'xs', 's', 'l' ... 'none'
 		$sizeKey: nth($size, 1);
 		$sizeValue: nth($size, 2);
 
 		// .<property>-<value>
 		.#{$property}#{$separator}#{$sizeKey} {
-			// margin-xs, margin-s, etc.
 			#{$property}: sizeValue($sizeKey, $sizeValue) !important;
 		}
 	}
@@ -37,15 +34,11 @@ $layout-sizes: (
 
 @include tablet {
 	@each $property in $spacing-properties {
-		// iterates through margin, margin-inline, margin-block, etc
 		@each $size in $layout-sizes {
-			// iterates over values 'xs', 's', 'l' ... 'none'
 			$sizeKey: nth($size, 1);
 			$sizeValue: nth($size, 2);
 
-			// .<property>-<value>-tablet
 			.#{$property}#{$separator}#{$sizeKey}#{$separator}tablet {
-				// margin-xs-tablet, margin-s-tablet, etc.
 				#{$property}: $sizeValue !important;
 			}
 		}
@@ -54,15 +47,11 @@ $layout-sizes: (
 
 @include desktop {
 	@each $property in $spacing-properties {
-		// iterates through margin, margin-inline, margin-block, etc
 		@each $size in $layout-sizes {
-			// iterates over values 'xs', 's', 'l' ... 'none'
 			$sizeKey: nth($size, 1);
 			$sizeValue: nth($size, 2);
 
-			// .<property>-<value>-desktop
 			.#{$property}#{$separator}#{$sizeKey}#{$separator}desktop {
-				// margin-xs-desktop, margin-s-desktop, etc.
 				#{$property}: $sizeValue !important;
 			}
 		}
@@ -71,15 +60,11 @@ $layout-sizes: (
 
 @include widescreen {
 	@each $property in $spacing-properties {
-		// iterates through margin, margin-inline, margin-block, etc
 		@each $size in $layout-sizes {
-			// iterates over values 'xs', 's', 'l' ... 'none'
 			$sizeKey: nth($size, 1);
 			$sizeValue: nth($size, 2);
 
-			// .<property>-<value>-widescreen
 			.#{$property}#{$separator}#{$sizeKey}#{$separator}widescreen {
-				// margin-xs-widescreen, margin-s-widescreen, etc.
 				#{$property}: $sizeValue !important;
 			}
 		}

--- a/css/src/atomics/spacing.scss
+++ b/css/src/atomics/spacing.scss
@@ -11,47 +11,82 @@ $layout-sizes: (
 	('l', $layout-4),
 	('xl', $layout-5),
 	('xxl', $layout-6),
-	('xxxl', $layout-7),
-	('none', $layout-0)
+	('xxxl', $layout-7)
 );
-
-@function sizeValue($key, $value) {
-	@return if($key == 'none', 0, $value);
-}
 
 // Pattern: <cssproperty>-<value>-<screen>
 
+// margin
 @each $size in $layout-sizes {
 	$sizeKey: nth($size, 1);
 	$sizeValue: nth($size, 2);
 
 	// .margin-<value>
 	.#{$marginKey}#{$separator}#{$sizeKey} {
-		margin: sizeValue($sizeKey, $sizeValue) !important;
+		margin: $sizeValue !important;
 	}
+}
 
-	@each $position-key, $direction in $directions {
+@each $position-key, $direction in $directions {
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
+
 		// .margin-<side>-<value>
 		.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey} {
-			margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+			margin-#{$direction}: $sizeValue !important;
 		}
 	}
+}
 
-	// margin-inline and margin-block property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
+@each $size in $layout-sizes {
+	$sizeKey: nth($size, 1);
+	$sizeValue: nth($size, 2);
+
+	// margin-inline property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
 
 	// .margin-inline-<value>
 	.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey} {
 		// Replace with margin-inline property when possible
-		margin-right: sizeValue($sizeKey, $sizeValue) !important;
-		margin-left: sizeValue($sizeKey, $sizeValue) !important;
+		margin-right: $sizeValue !important;
+		margin-left: $sizeValue !important;
 	}
+}
+
+@each $size in $layout-sizes {
+	$sizeKey: nth($size, 1);
+	$sizeValue: nth($size, 2);
+
+	// margin-block property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
 
 	// .margin-block-<value>
 	.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey} {
 		// Replace with margin-block property when possible
-		margin-top: sizeValue($sizeKey, $sizeValue) !important;
-		margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
+		margin-top: $sizeValue !important;
+		margin-bottom: $sizeValue !important;
 	}
+}
+
+.#{$marginKey}#{$separator}none {
+	margin: 0 !important;
+}
+
+@each $position-key, $direction in $directions {
+	.#{$marginKey}#{$separator}#{$position-key}#{$separator}none {
+		margin-#{$direction}: 0 !important;
+	}
+}
+
+.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}none {
+	// Replace with margin-inline property when possible
+	margin-right: 0 !important;
+	margin-left: 0 !important;
+}
+
+.#{$marginKey}#{$separator}#{$blockKey}#{$separator}none {
+	// Replace with margin-block property when possible
+	margin-top: 0 !important;
+	margin-bottom: 0 !important;
 }
 
 @include tablet {
@@ -59,29 +94,64 @@ $layout-sizes: (
 		$sizeKey: nth($size, 1);
 		$sizeValue: nth($size, 2);
 
-		.#{$marginKey}#{$separator}#{$sizeKey}-tablet {
-			margin: sizeValue($sizeKey, $sizeValue) !important;
+		.#{$marginKey}#{$separator}#{$sizeKey}#{$separator}tablet {
+			margin: $sizeValue !important;
 		}
+	}
 
-		@each $position-key, $direction in $directions {
-			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-tablet {
-				margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+	@each $position-key, $direction in $directions {
+		@each $size in $layout-sizes {
+			$sizeKey: nth($size, 1);
+			$sizeValue: nth($size, 2);
+
+			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}#{$separator}tablet {
+				margin-#{$direction}: $sizeValue !important;
 			}
 		}
+	}
 
-		// margin-inline and margin-block property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
 
-		.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}-tablet {
+		.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}#{$separator}tablet {
 			// Replace with margin-inline property when possible
-			margin-right: sizeValue($sizeKey, $sizeValue) !important;
-			margin-left: sizeValue($sizeKey, $sizeValue) !important;
+			margin-right: $sizeValue !important;
+			margin-left: $sizeValue !important;
 		}
+	}
 
-		.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-tablet {
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
+
+		.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}#{$separator}tablet {
 			// Replace with margin-block property when possible
-			margin-top: sizeValue($sizeKey, $sizeValue) !important;
-			margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
+			margin-top: $sizeValue !important;
+			margin-bottom: $sizeValue !important;
 		}
+	}
+
+	.#{$marginKey}#{$separator}none#{$separator}tablet {
+		margin: 0 !important;
+	}
+
+	@each $position-key, $direction in $directions {
+		.#{$marginKey}#{$separator}#{$position-key}#{$separator}none#{$separator}tablet {
+			margin-#{$direction}: 0 !important;
+		}
+	}
+
+	.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}none#{$separator}tablet {
+		// Replace with margin-inline property when possible
+		margin-right: 0 !important;
+		margin-left: 0 !important;
+	}
+
+	.#{$marginKey}#{$separator}#{$blockKey}#{$separator}none#{$separator}tablet {
+		// Replace with margin-block property when possible
+		margin-top: 0 !important;
+		margin-bottom: 0 !important;
 	}
 }
 
@@ -90,29 +160,64 @@ $layout-sizes: (
 		$sizeKey: nth($size, 1);
 		$sizeValue: nth($size, 2);
 
-		.#{$marginKey}#{$separator}#{$sizeKey}-desktop {
-			margin: sizeValue($sizeKey, $sizeValue) !important;
+		.#{$marginKey}#{$separator}#{$sizeKey}#{$separator}desktop {
+			margin: $sizeValue !important;
 		}
+	}
 
-		@each $position-key, $direction in $directions {
-			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-desktop {
-				margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+	@each $position-key, $direction in $directions {
+		@each $size in $layout-sizes {
+			$sizeKey: nth($size, 1);
+			$sizeValue: nth($size, 2);
+
+			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}#{$separator}desktop {
+				margin-#{$direction}: $sizeValue !important;
 			}
 		}
+	}
 
-		// margin-inline and margin-block property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
 
-		.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}-desktop {
+		.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}#{$separator}desktop {
 			// Replace with margin-inline property when possible
-			margin-right: sizeValue($sizeKey, $sizeValue) !important;
-			margin-left: sizeValue($sizeKey, $sizeValue) !important;
+			margin-right: $sizeValue !important;
+			margin-left: $sizeValue !important;
 		}
+	}
 
-		.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-desktop {
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
+
+		.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}#{$separator}desktop {
 			// Replace with margin-block property when possible
-			margin-top: sizeValue($sizeKey, $sizeValue) !important;
-			margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
+			margin-top: $sizeValue !important;
+			margin-bottom: $sizeValue !important;
 		}
+	}
+
+	.#{$marginKey}#{$separator}none#{$separator}desktop {
+		margin: 0 !important;
+	}
+
+	@each $position-key, $direction in $directions {
+		.#{$marginKey}#{$separator}#{$position-key}#{$separator}none#{$separator}desktop {
+			margin-#{$direction}: 0 !important;
+		}
+	}
+
+	.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}none#{$separator}desktop {
+		// Replace with margin-inline property when possible
+		margin-right: 0 !important;
+		margin-left: 0 !important;
+	}
+
+	.#{$marginKey}#{$separator}#{$blockKey}#{$separator}none#{$separator}desktop {
+		// Replace with margin-block property when possible
+		margin-top: 0 !important;
+		margin-bottom: 0 !important;
 	}
 }
 
@@ -121,28 +226,86 @@ $layout-sizes: (
 		$sizeKey: nth($size, 1);
 		$sizeValue: nth($size, 2);
 
-		.#{$marginKey}#{$separator}#{$sizeKey}-widescreen {
-			margin: sizeValue($sizeKey, $sizeValue) !important;
+		.#{$marginKey}#{$separator}#{$sizeKey}#{$separator}widescreen {
+			margin: $sizeValue !important;
 		}
+	}
 
-		@each $position-key, $direction in $directions {
-			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-widescreen {
-				margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+	@each $position-key, $direction in $directions {
+		@each $size in $layout-sizes {
+			$sizeKey: nth($size, 1);
+			$sizeValue: nth($size, 2);
+
+			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}#{$separator}widescreen {
+				margin-#{$direction}: $sizeValue !important;
 			}
 		}
+	}
 
-		// margin-inline and margin-block property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
 
-		.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}-widescreen {
+		.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}#{$separator}widescreen {
 			// Replace with margin-inline property when possible
-			margin-right: sizeValue($sizeKey, $sizeValue) !important;
-			margin-left: sizeValue($sizeKey, $sizeValue) !important;
+			margin-right: $sizeValue !important;
+			margin-left: $sizeValue !important;
 		}
+	}
 
-		.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-widescreen {
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
+
+		.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}#{$separator}widescreen {
 			// Replace with margin-block property when possible
-			margin-top: sizeValue($sizeKey, $sizeValue) !important;
-			margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
+			margin-top: $sizeValue !important;
+			margin-bottom: $sizeValue !important;
+		}
+	}
+
+	.#{$marginKey}#{$separator}none#{$separator}widescreen {
+		margin: 0 !important;
+	}
+
+	@each $position-key, $direction in $directions {
+		.#{$marginKey}#{$separator}#{$position-key}#{$separator}none#{$separator}widescreen {
+			margin-#{$direction}: 0 !important;
+		}
+	}
+
+	.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}none#{$separator}widescreen {
+		// Replace with margin-inline property when possible
+		margin-right: 0 !important;
+		margin-left: 0 !important;
+	}
+
+	.#{$marginKey}#{$separator}#{$blockKey}#{$separator}none#{$separator}widescreen {
+		// Replace with margin-block property when possible
+		margin-top: 0 !important;
+		margin-bottom: 0 !important;
+	}
+}
+
+// padding
+@each $size in $layout-sizes {
+	$sizeKey: nth($size, 1);
+	$sizeValue: nth($size, 2);
+
+	// .padding-<value>
+	.#{$paddingKey}#{$separator}#{$sizeKey} {
+		padding: $sizeValue !important;
+	}
+}
+
+@each $position-key, $direction in $directions {
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
+
+		// .padding-<side>-<value>
+		.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey} {
+			padding-#{$direction}: $sizeValue !important;
 		}
 	}
 }
@@ -151,32 +314,50 @@ $layout-sizes: (
 	$sizeKey: nth($size, 1);
 	$sizeValue: nth($size, 2);
 
-	// .padding-<value>
-	.#{$paddingKey}#{$separator}#{$sizeKey} {
-		padding: sizeValue($sizeKey, $sizeValue) !important;
-	}
+	// padding-inline property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
 
-	@each $position-key, $direction in $directions {
-		// .padding-<side>-<value>
-		.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey} {
-			padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
-		}
-	}
-
-	// padding-inline and padding-block property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
 	// .padding-inline-<value>
 	.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey} {
-		// Replace with padding-inline property when possible
-		padding-right: sizeValue($sizeKey, $sizeValue) !important;
-		padding-left: sizeValue($sizeKey, $sizeValue) !important;
+		// Replace with margin-inline property when possible
+		padding-right: $sizeValue !important;
+		padding-left: $sizeValue !important;
 	}
+}
+
+@each $size in $layout-sizes {
+	$sizeKey: nth($size, 1);
+	$sizeValue: nth($size, 2);
+
+	// padding-block property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
 
 	// .padding-block-<value>
 	.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey} {
 		// Replace with padding-block property when possible
-		padding-top: sizeValue($sizeKey, $sizeValue) !important;
-		padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
+		padding-top: $sizeValue !important;
+		padding-bottom: $sizeValue !important;
 	}
+}
+
+.#{$paddingKey}#{$separator}none {
+	padding: 0 !important;
+}
+
+@each $position-key, $direction in $directions {
+	.#{$paddingKey}#{$separator}#{$position-key}#{$separator}none {
+		padding-#{$direction}: 0 !important;
+	}
+}
+
+.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}none {
+	// Replace with padding-inline property when possible
+	padding-right: 0 !important;
+	padding-left: 0 !important;
+}
+
+.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}none {
+	// Replace with padding-block property when possible
+	padding-top: 0 !important;
+	padding-bottom: 0 !important;
 }
 
 @include tablet {
@@ -185,26 +366,63 @@ $layout-sizes: (
 		$sizeValue: nth($size, 2);
 
 		.#{$paddingKey}#{$separator}#{$sizeKey}-tablet {
-			padding: sizeValue($sizeKey, $sizeValue) !important;
+			padding: $sizeValue !important;
 		}
+	}
 
-		@each $position-key, $direction in $directions {
+	@each $position-key, $direction in $directions {
+		@each $size in $layout-sizes {
+			$sizeKey: nth($size, 1);
+			$sizeValue: nth($size, 2);
+
 			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-tablet {
-				padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+				padding-#{$direction}: $sizeValue !important;
 			}
 		}
+	}
+
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
 
 		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}-tablet {
 			// Replace with padding-inline property when possible
-			padding-right: sizeValue($sizeKey, $sizeValue) !important;
-			padding-left: sizeValue($sizeKey, $sizeValue) !important;
+			padding-right: $sizeValue !important;
+			padding-left: $sizeValue !important;
 		}
+	}
+
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
 
 		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-tablet {
 			// Replace with padding-block property when possible
-			padding-top: sizeValue($sizeKey, $sizeValue) !important;
-			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
+			padding-top: $sizeValue !important;
+			padding-bottom: $sizeValue !important;
 		}
+	}
+
+	.#{$paddingKey}#{$separator}none#{$separator}tablet {
+		padding: 0 !important;
+	}
+
+	@each $position-key, $direction in $directions {
+		.#{$paddingKey}#{$separator}#{$position-key}#{$separator}none#{$separator}tablet {
+			padding-#{$direction}: 0 !important;
+		}
+	}
+
+	.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}none#{$separator}tablet {
+		// Replace with padding-inline property when possible
+		padding-right: 0 !important;
+		padding-left: 0 !important;
+	}
+
+	.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}none#{$separator}tablet {
+		// Replace with padding-block property when possible
+		padding-top: 0 !important;
+		padding-bottom: 0 !important;
 	}
 }
 
@@ -214,26 +432,63 @@ $layout-sizes: (
 		$sizeValue: nth($size, 2);
 
 		.#{$paddingKey}#{$separator}#{$sizeKey}-desktop {
-			padding: sizeValue($sizeKey, $sizeValue) !important;
+			padding: $sizeValue !important;
 		}
+	}
 
-		@each $position-key, $direction in $directions {
+	@each $position-key, $direction in $directions {
+		@each $size in $layout-sizes {
+			$sizeKey: nth($size, 1);
+			$sizeValue: nth($size, 2);
+
 			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-desktop {
-				padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+				padding-#{$direction}: $sizeValue !important;
 			}
 		}
+	}
+
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
 
 		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}-desktop {
 			// Replace with padding-inline property when possible
-			padding-right: sizeValue($sizeKey, $sizeValue) !important;
-			padding-left: sizeValue($sizeKey, $sizeValue) !important;
+			padding-right: $sizeValue !important;
+			padding-left: $sizeValue !important;
 		}
+	}
+
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
 
 		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-desktop {
 			// Replace with padding-block property when possible
-			padding-top: sizeValue($sizeKey, $sizeValue) !important;
-			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
+			padding-top: $sizeValue !important;
+			padding-bottom: $sizeValue !important;
 		}
+	}
+
+	.#{$paddingKey}#{$separator}none#{$separator}desktop {
+		padding: 0 !important;
+	}
+
+	@each $position-key, $direction in $directions {
+		.#{$paddingKey}#{$separator}#{$position-key}#{$separator}none#{$separator}desktop {
+			padding-#{$direction}: 0 !important;
+		}
+	}
+
+	.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}none#{$separator}desktop {
+		// Replace with padding-inline property when possible
+		padding-right: 0 !important;
+		padding-left: 0 !important;
+	}
+
+	.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}none#{$separator}desktop {
+		// Replace with padding-block property when possible
+		padding-top: 0 !important;
+		padding-bottom: 0 !important;
 	}
 }
 
@@ -243,25 +498,62 @@ $layout-sizes: (
 		$sizeValue: nth($size, 2);
 
 		.#{$paddingKey}#{$separator}#{$sizeKey}-widescreen {
-			padding: sizeValue($sizeKey, $sizeValue) !important;
+			padding: $sizeValue !important;
 		}
+	}
 
-		@each $position-key, $direction in $directions {
+	@each $position-key, $direction in $directions {
+		@each $size in $layout-sizes {
+			$sizeKey: nth($size, 1);
+			$sizeValue: nth($size, 2);
+
 			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-widescreen {
-				padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+				padding-#{$direction}: $sizeValue !important;
 			}
 		}
+	}
+
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
 
 		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}-widescreen {
 			// Replace with padding-inline property when possible
-			padding-right: sizeValue($sizeKey, $sizeValue) !important;
-			padding-left: sizeValue($sizeKey, $sizeValue) !important;
+			padding-right: $sizeValue !important;
+			padding-left: $sizeValue !important;
 		}
+	}
+
+	@each $size in $layout-sizes {
+		$sizeKey: nth($size, 1);
+		$sizeValue: nth($size, 2);
 
 		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-widescreen {
 			// Replace with padding-block property when possible
-			padding-top: sizeValue($sizeKey, $sizeValue) !important;
-			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
+			padding-top: $sizeValue !important;
+			padding-bottom: $sizeValue !important;
 		}
+	}
+
+	.#{$paddingKey}#{$separator}none#{$separator}widescreen {
+		padding: 0 !important;
+	}
+
+	@each $position-key, $direction in $directions {
+		.#{$paddingKey}#{$separator}#{$position-key}#{$separator}none#{$separator}widescreen {
+			padding-#{$direction}: 0 !important;
+		}
+	}
+
+	.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}none#{$separator}widescreen {
+		// Replace with padding-inline property when possible
+		padding-right: 0 !important;
+		padding-left: 0 !important;
+	}
+
+	.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}none#{$separator}widescreen {
+		// Replace with padding-block property when possible
+		padding-top: 0 !important;
+		padding-bottom: 0 !important;
 	}
 }

--- a/css/src/atomics/spacing.scss
+++ b/css/src/atomics/spacing.scss
@@ -1,8 +1,7 @@
-$marginKey: 'margin';
-$paddingKey: 'padding';
 $separator: '-';
-$inlineKey: 'inline';
-$blockKey: 'block';
+$spacing-properties: 'margin', 'margin-inline', 'margin-block', 'margin-top', 'margin-bottom',
+	'margin-left', 'margin-right', 'padding', 'padding-inline', 'padding-block', 'padding-top',
+	'padding-bottom', 'padding-left', 'padding-right' !default;
 
 $layout-sizes: (
 	('xs', $layout-1),
@@ -21,248 +20,67 @@ $layout-sizes: (
 
 // Pattern: <cssproperty>-<value>-<screen>
 
-@each $size in $layout-sizes {
-	$sizeKey: nth($size, 1);
-	$sizeValue: nth($size, 2);
-
-	// .margin-<value>
-	.#{$marginKey}#{$separator}#{$sizeKey} {
-		margin: sizeValue($sizeKey, $sizeValue) !important;
-	}
-
-	// .padding-<value>
-	.#{$paddingKey}#{$separator}#{$sizeKey} {
-		padding: sizeValue($sizeKey, $sizeValue) !important;
-	}
-}
-
-@each $position-key, $direction in $directions {
+@each $property in $spacing-properties {
+	// iterates through margin, margin-inline, margin-block, etc
 	@each $size in $layout-sizes {
+		// iterates over values 'xs', 's', 'l' ... 'none'
 		$sizeKey: nth($size, 1);
 		$sizeValue: nth($size, 2);
 
-		// .margin-<side>-<value>
-		.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey} {
-			margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+		// .<property>-<value>
+		.#{$property}#{$separator}#{$sizeKey} {
+			// margin-xs, margin-s, etc.
+			#{$property}: sizeValue($sizeKey, $sizeValue) !important;
 		}
-
-		// .padding-<side>-<value>
-		.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey} {
-			padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
-		}
-	}
-}
-
-@each $size in $layout-sizes {
-	$sizeKey: nth($size, 1);
-	$sizeValue: nth($size, 2);
-
-	// margin/padding-inline property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
-
-	// .margin-inline-<value>
-	.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey} {
-		// Replace with margin-inline property when possible
-		margin-right: sizeValue($sizeKey, $sizeValue) !important;
-		margin-left: sizeValue($sizeKey, $sizeValue) !important;
-	}
-
-	// .padding-inline-<value>
-	.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey} {
-		// Replace with padding-inline property when possible
-		padding-right: sizeValue($sizeKey, $sizeValue) !important;
-		padding-left: sizeValue($sizeKey, $sizeValue) !important;
-	}
-
-	// margin/padding-block property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
-
-	// .margin-block-<value>
-	.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey} {
-		// Replace with margin-block property when possible
-		margin-top: sizeValue($sizeKey, $sizeValue) !important;
-		margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
-	}
-
-	// .padding-block-<value>
-	.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey} {
-		// Replace with padding-block property when possible
-		padding-top: sizeValue($sizeKey, $sizeValue) !important;
-		padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
 	}
 }
 
 @include tablet {
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
-		.#{$marginKey}#{$separator}#{$sizeKey}#{$separator}tablet {
-			margin: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
-		.#{$paddingKey}#{$separator}#{$sizeKey}#{$separator}tablet {
-			padding: sizeValue($sizeKey, $sizeValue) !important;
-		}
-	}
-
-	@each $position-key, $direction in $directions {
+	@each $property in $spacing-properties {
+		// iterates through margin, margin-inline, margin-block, etc
 		@each $size in $layout-sizes {
+			// iterates over values 'xs', 's', 'l' ... 'none'
 			$sizeKey: nth($size, 1);
 			$sizeValue: nth($size, 2);
 
-			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}#{$separator}tablet {
-				margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+			// .<property>-<value>-tablet
+			.#{$property}#{$separator}#{$sizeKey}#{$separator}tablet {
+				// margin-xs-tablet, margin-s-tablet, etc.
+				#{$property}: $sizeValue !important;
 			}
-
-			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}#{$separator}tablet {
-				padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
-			}
-		}
-	}
-
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
-		.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}#{$separator}tablet {
-			// Replace with margin-inline property when possible
-			margin-right: sizeValue($sizeKey, $sizeValue) !important;
-			margin-left: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
-		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}#{$separator}tablet {
-			// Replace with padding-inline property when possible
-			padding-right: sizeValue($sizeKey, $sizeValue) !important;
-			padding-left: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
-		.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}#{$separator}tablet {
-			// Replace with margin-block property when possible
-			margin-top: sizeValue($sizeKey, $sizeValue) !important;
-			margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
-		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}#{$separator}tablet {
-			// Replace with padding-block property when possible
-			padding-top: sizeValue($sizeKey, $sizeValue) !important;
-			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
 		}
 	}
 }
 
 @include desktop {
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
-		.#{$marginKey}#{$separator}#{$sizeKey}#{$separator}desktop {
-			margin: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
-		.#{$paddingKey}#{$separator}#{$sizeKey}#{$separator}desktop {
-			padding: sizeValue($sizeKey, $sizeValue) !important;
-		}
-	}
-
-	@each $position-key, $direction in $directions {
+	@each $property in $spacing-properties {
+		// iterates through margin, margin-inline, margin-block, etc
 		@each $size in $layout-sizes {
+			// iterates over values 'xs', 's', 'l' ... 'none'
 			$sizeKey: nth($size, 1);
 			$sizeValue: nth($size, 2);
 
-			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}#{$separator}desktop {
-				margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+			// .<property>-<value>-desktop
+			.#{$property}#{$separator}#{$sizeKey}#{$separator}desktop {
+				// margin-xs-desktop, margin-s-desktop, etc.
+				#{$property}: $sizeValue !important;
 			}
-
-			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}#{$separator}desktop {
-				padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
-			}
-		}
-	}
-
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
-		.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}#{$separator}desktop {
-			// Replace with margin-inline property when possible
-			margin-right: sizeValue($sizeKey, $sizeValue) !important;
-			margin-left: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
-		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}#{$separator}desktop {
-			// Replace with padding-inline property when possible
-			padding-right: sizeValue($sizeKey, $sizeValue) !important;
-			padding-left: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
-		.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}#{$separator}desktop {
-			// Replace with margin-block property when possible
-			margin-top: sizeValue($sizeKey, $sizeValue) !important;
-			margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
-		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}#{$separator}desktop {
-			// Replace with padding-block property when possible
-			padding-top: sizeValue($sizeKey, $sizeValue) !important;
-			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
 		}
 	}
 }
-
 @include widescreen {
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
-		.#{$marginKey}#{$separator}#{$sizeKey}#{$separator}widescreen {
-			margin: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
-		.#{$paddingKey}#{$separator}#{$sizeKey}#{$separator}widescreen {
-			padding: sizeValue($sizeKey, $sizeValue) !important;
-		}
-	}
-
-	@each $position-key, $direction in $directions {
+	@each $property in $spacing-properties {
+		// iterates through margin, margin-inline, margin-block, etc
 		@each $size in $layout-sizes {
+			// iterates over values 'xs', 's', 'l' ... 'none'
 			$sizeKey: nth($size, 1);
 			$sizeValue: nth($size, 2);
 
-			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}#{$separator}widescreen {
-				margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+			// .<property>-<value>-widescreen
+			.#{$property}#{$separator}#{$sizeKey}#{$separator}widescreen {
+				// margin-xs-widescreen, margin-s-widescreen, etc.
+				#{$property}: $sizeValue !important;
 			}
-
-			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}#{$separator}widescreen {
-				padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
-			}
-		}
-	}
-
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
-		.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}#{$separator}widescreen {
-			// Replace with margin-inline property when possible
-			margin-right: sizeValue($sizeKey, $sizeValue) !important;
-			margin-left: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
-		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}#{$separator}widescreen {
-			// Replace with padding-inline property when possible
-			padding-right: sizeValue($sizeKey, $sizeValue) !important;
-			padding-left: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
-		.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}#{$separator}widescreen {
-			// Replace with margin-block property when possible
-			margin-top: sizeValue($sizeKey, $sizeValue) !important;
-			margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
-		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}#{$separator}widescreen {
-			// Replace with padding-block property when possible
-			padding-top: sizeValue($sizeKey, $sizeValue) !important;
-			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
 		}
 	}
 }

--- a/css/src/atomics/spacing.scss
+++ b/css/src/atomics/spacing.scss
@@ -30,9 +30,11 @@ $layout-sizes: (
 		margin: sizeValue($sizeKey, $sizeValue) !important;
 	}
 
-	// .padding-<value>
-	.#{$paddingKey}#{$separator}#{$sizeKey} {
-		padding: sizeValue($sizeKey, $sizeValue) !important;
+	@each $position-key, $direction in $directions {
+		// .margin-<side>-<value>
+		.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey} {
+			margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+		}
 	}
 
 	// margin-inline and margin-block property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
@@ -44,13 +46,6 @@ $layout-sizes: (
 		margin-left: sizeValue($sizeKey, $sizeValue) !important;
 	}
 
-	// .padding-inline-<value>
-	.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey} {
-		// Replace with margin-inline property when possible
-		padding-right: sizeValue($sizeKey, $sizeValue) !important;
-		padding-left: sizeValue($sizeKey, $sizeValue) !important;
-	}
-
 	// .margin-block-<value>
 	.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey} {
 		// Replace with margin-block property when possible
@@ -58,37 +53,15 @@ $layout-sizes: (
 		margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
 	}
 
-	// .padding-block-<value>
-	.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey} {
-		// Replace with margin-block property when possible
-		padding-top: sizeValue($sizeKey, $sizeValue) !important;
-		padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
-	}
-
-	@each $position-key, $direction in $directions {
-		// .margin-<side>-<value>
-		.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey} {
-			margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
-		// .padding-<side>-<value>
-		.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey} {
-			padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
-		}
-	}
-}
-
-@include tablet {
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
+	@include tablet {
 		.#{$marginKey}#{$separator}#{$sizeKey}-tablet {
 			margin: sizeValue($sizeKey, $sizeValue) !important;
 		}
 
-		.#{$paddingKey}#{$separator}#{$sizeKey}-tablet {
-			padding: sizeValue($sizeKey, $sizeValue) !important;
+		@each $position-key, $direction in $directions {
+			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-tablet {
+				margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+			}
 		}
 
 		// margin-inline and margin-block property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
@@ -99,47 +72,22 @@ $layout-sizes: (
 			margin-left: sizeValue($sizeKey, $sizeValue) !important;
 		}
 
-		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}-tablet {
-			// Replace with margin-inline property when possible
-			padding-right: sizeValue($sizeKey, $sizeValue) !important;
-			padding-left: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
 		.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-tablet {
 			// Replace with margin-block property when possible
 			margin-top: sizeValue($sizeKey, $sizeValue) !important;
 			margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
 		}
-
-		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-tablet {
-			// Replace with margin-block property when possible
-			padding-top: sizeValue($sizeKey, $sizeValue) !important;
-			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
-		@each $position-key, $direction in $directions {
-			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-tablet {
-				margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
-			}
-
-			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-tablet {
-				padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
-			}
-		}
 	}
-}
 
-@include desktop {
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
+	@include desktop {
 		.#{$marginKey}#{$separator}#{$sizeKey}-desktop {
 			margin: sizeValue($sizeKey, $sizeValue) !important;
 		}
 
-		.#{$paddingKey}#{$separator}#{$sizeKey}-desktop {
-			padding: sizeValue($sizeKey, $sizeValue) !important;
+		@each $position-key, $direction in $directions {
+			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-desktop {
+				margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+			}
 		}
 
 		// margin-inline and margin-block property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
@@ -150,47 +98,22 @@ $layout-sizes: (
 			margin-left: sizeValue($sizeKey, $sizeValue) !important;
 		}
 
-		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}-desktop {
-			// Replace with margin-inline property when possible
-			padding-right: sizeValue($sizeKey, $sizeValue) !important;
-			padding-left: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
 		.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-desktop {
 			// Replace with margin-block property when possible
 			margin-top: sizeValue($sizeKey, $sizeValue) !important;
 			margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
 		}
-
-		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-desktop {
-			// Replace with margin-block property when possible
-			padding-top: sizeValue($sizeKey, $sizeValue) !important;
-			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
-		@each $position-key, $direction in $directions {
-			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-desktop {
-				margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
-			}
-
-			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-desktop {
-				padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
-			}
-		}
 	}
-}
 
-@include widescreen {
-	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
-
+	@include widescreen {
 		.#{$marginKey}#{$separator}#{$sizeKey}-widescreen {
 			margin: sizeValue($sizeKey, $sizeValue) !important;
 		}
 
-		.#{$paddingKey}#{$separator}#{$sizeKey}-widescreen {
-			padding: sizeValue($sizeKey, $sizeValue) !important;
+		@each $position-key, $direction in $directions {
+			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-widescreen {
+				margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+			}
 		}
 
 		// margin-inline and margin-block property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
@@ -201,32 +124,114 @@ $layout-sizes: (
 			margin-left: sizeValue($sizeKey, $sizeValue) !important;
 		}
 
-		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}-widescreen {
-			// Replace with margin-inline property when possible
-			padding-right: sizeValue($sizeKey, $sizeValue) !important;
-			padding-left: sizeValue($sizeKey, $sizeValue) !important;
-		}
-
 		.#{$marginKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-widescreen {
 			// Replace with margin-block property when possible
 			margin-top: sizeValue($sizeKey, $sizeValue) !important;
 			margin-bottom: sizeValue($sizeKey, $sizeValue) !important;
 		}
+	}
+}
 
-		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-widescreen {
-			// Replace with margin-block property when possible
-			padding-top: sizeValue($sizeKey, $sizeValue) !important;
-			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
+@each $size in $layout-sizes {
+	$sizeKey: nth($size, 1);
+	$sizeValue: nth($size, 2);
+
+	// .padding-<value>
+	.#{$paddingKey}#{$separator}#{$sizeKey} {
+		padding: sizeValue($sizeKey, $sizeValue) !important;
+	}
+
+	@each $position-key, $direction in $directions {
+		// .padding-<side>-<value>
+		.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey} {
+			padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+		}
+	}
+
+	// padding-inline and padding-block property isn't supported by IE, Edge, and Safari yet (as of Apr 2021)
+	// .padding-inline-<value>
+	.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey} {
+		// Replace with padding-inline property when possible
+		padding-right: sizeValue($sizeKey, $sizeValue) !important;
+		padding-left: sizeValue($sizeKey, $sizeValue) !important;
+	}
+
+	// .padding-block-<value>
+	.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey} {
+		// Replace with padding-block property when possible
+		padding-top: sizeValue($sizeKey, $sizeValue) !important;
+		padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
+	}
+
+	@include tablet {
+		.#{$paddingKey}#{$separator}#{$sizeKey}-tablet {
+			padding: sizeValue($sizeKey, $sizeValue) !important;
 		}
 
 		@each $position-key, $direction in $directions {
-			.#{$marginKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-widescreen {
-				margin-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-tablet {
+				padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
 			}
+		}
 
+		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}-tablet {
+			// Replace with padding-inline property when possible
+			padding-right: sizeValue($sizeKey, $sizeValue) !important;
+			padding-left: sizeValue($sizeKey, $sizeValue) !important;
+		}
+
+		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-tablet {
+			// Replace with padding-block property when possible
+			padding-top: sizeValue($sizeKey, $sizeValue) !important;
+			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
+		}
+	}
+
+	@include desktop {
+		.#{$paddingKey}#{$separator}#{$sizeKey}-desktop {
+			padding: sizeValue($sizeKey, $sizeValue) !important;
+		}
+
+		@each $position-key, $direction in $directions {
+			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-desktop {
+				padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
+			}
+		}
+
+		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}-desktop {
+			// Replace with padding-inline property when possible
+			padding-right: sizeValue($sizeKey, $sizeValue) !important;
+			padding-left: sizeValue($sizeKey, $sizeValue) !important;
+		}
+
+		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-desktop {
+			// Replace with padding-block property when possible
+			padding-top: sizeValue($sizeKey, $sizeValue) !important;
+			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
+		}
+	}
+
+	@include widescreen {
+		.#{$paddingKey}#{$separator}#{$sizeKey}-widescreen {
+			padding: sizeValue($sizeKey, $sizeValue) !important;
+		}
+
+		@each $position-key, $direction in $directions {
 			.#{$paddingKey}#{$separator}#{$position-key}#{$separator}#{$sizeKey}-widescreen {
 				padding-#{$direction}: sizeValue($sizeKey, $sizeValue) !important;
 			}
+		}
+
+		.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}#{$sizeKey}-widescreen {
+			// Replace with padding-inline property when possible
+			padding-right: sizeValue($sizeKey, $sizeValue) !important;
+			padding-left: sizeValue($sizeKey, $sizeValue) !important;
+		}
+
+		.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}#{$sizeKey}-widescreen {
+			// Replace with padding-block property when possible
+			padding-top: sizeValue($sizeKey, $sizeValue) !important;
+			padding-bottom: sizeValue($sizeKey, $sizeValue) !important;
 		}
 	}
 }

--- a/css/src/atomics/spacing.scss
+++ b/css/src/atomics/spacing.scss
@@ -11,7 +11,8 @@ $layout-sizes: (
 	('l', $layout-4),
 	('xl', $layout-5),
 	('xxl', $layout-6),
-	('xxxl', $layout-7)
+	('xxxl', $layout-7),
+	('none', $layout-0)
 );
 
 // Pattern: <cssproperty>-<value>-<screen>
@@ -67,28 +68,6 @@ $layout-sizes: (
 	}
 }
 
-.#{$marginKey}#{$separator}none {
-	margin: 0 !important;
-}
-
-@each $position-key, $direction in $directions {
-	.#{$marginKey}#{$separator}#{$position-key}#{$separator}none {
-		margin-#{$direction}: 0 !important;
-	}
-}
-
-.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}none {
-	// Replace with margin-inline property when possible
-	margin-right: 0 !important;
-	margin-left: 0 !important;
-}
-
-.#{$marginKey}#{$separator}#{$blockKey}#{$separator}none {
-	// Replace with margin-block property when possible
-	margin-top: 0 !important;
-	margin-bottom: 0 !important;
-}
-
 @include tablet {
 	@each $size in $layout-sizes {
 		$sizeKey: nth($size, 1);
@@ -130,28 +109,6 @@ $layout-sizes: (
 			margin-top: $sizeValue !important;
 			margin-bottom: $sizeValue !important;
 		}
-	}
-
-	.#{$marginKey}#{$separator}none#{$separator}tablet {
-		margin: 0 !important;
-	}
-
-	@each $position-key, $direction in $directions {
-		.#{$marginKey}#{$separator}#{$position-key}#{$separator}none#{$separator}tablet {
-			margin-#{$direction}: 0 !important;
-		}
-	}
-
-	.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}none#{$separator}tablet {
-		// Replace with margin-inline property when possible
-		margin-right: 0 !important;
-		margin-left: 0 !important;
-	}
-
-	.#{$marginKey}#{$separator}#{$blockKey}#{$separator}none#{$separator}tablet {
-		// Replace with margin-block property when possible
-		margin-top: 0 !important;
-		margin-bottom: 0 !important;
 	}
 }
 
@@ -197,28 +154,6 @@ $layout-sizes: (
 			margin-bottom: $sizeValue !important;
 		}
 	}
-
-	.#{$marginKey}#{$separator}none#{$separator}desktop {
-		margin: 0 !important;
-	}
-
-	@each $position-key, $direction in $directions {
-		.#{$marginKey}#{$separator}#{$position-key}#{$separator}none#{$separator}desktop {
-			margin-#{$direction}: 0 !important;
-		}
-	}
-
-	.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}none#{$separator}desktop {
-		// Replace with margin-inline property when possible
-		margin-right: 0 !important;
-		margin-left: 0 !important;
-	}
-
-	.#{$marginKey}#{$separator}#{$blockKey}#{$separator}none#{$separator}desktop {
-		// Replace with margin-block property when possible
-		margin-top: 0 !important;
-		margin-bottom: 0 !important;
-	}
 }
 
 @include widescreen {
@@ -262,28 +197,6 @@ $layout-sizes: (
 			margin-top: $sizeValue !important;
 			margin-bottom: $sizeValue !important;
 		}
-	}
-
-	.#{$marginKey}#{$separator}none#{$separator}widescreen {
-		margin: 0 !important;
-	}
-
-	@each $position-key, $direction in $directions {
-		.#{$marginKey}#{$separator}#{$position-key}#{$separator}none#{$separator}widescreen {
-			margin-#{$direction}: 0 !important;
-		}
-	}
-
-	.#{$marginKey}#{$separator}#{$inlineKey}#{$separator}none#{$separator}widescreen {
-		// Replace with margin-inline property when possible
-		margin-right: 0 !important;
-		margin-left: 0 !important;
-	}
-
-	.#{$marginKey}#{$separator}#{$blockKey}#{$separator}none#{$separator}widescreen {
-		// Replace with margin-block property when possible
-		margin-top: 0 !important;
-		margin-bottom: 0 !important;
 	}
 }
 
@@ -338,28 +251,6 @@ $layout-sizes: (
 	}
 }
 
-.#{$paddingKey}#{$separator}none {
-	padding: 0 !important;
-}
-
-@each $position-key, $direction in $directions {
-	.#{$paddingKey}#{$separator}#{$position-key}#{$separator}none {
-		padding-#{$direction}: 0 !important;
-	}
-}
-
-.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}none {
-	// Replace with padding-inline property when possible
-	padding-right: 0 !important;
-	padding-left: 0 !important;
-}
-
-.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}none {
-	// Replace with padding-block property when possible
-	padding-top: 0 !important;
-	padding-bottom: 0 !important;
-}
-
 @include tablet {
 	@each $size in $layout-sizes {
 		$sizeKey: nth($size, 1);
@@ -401,28 +292,6 @@ $layout-sizes: (
 			padding-top: $sizeValue !important;
 			padding-bottom: $sizeValue !important;
 		}
-	}
-
-	.#{$paddingKey}#{$separator}none#{$separator}tablet {
-		padding: 0 !important;
-	}
-
-	@each $position-key, $direction in $directions {
-		.#{$paddingKey}#{$separator}#{$position-key}#{$separator}none#{$separator}tablet {
-			padding-#{$direction}: 0 !important;
-		}
-	}
-
-	.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}none#{$separator}tablet {
-		// Replace with padding-inline property when possible
-		padding-right: 0 !important;
-		padding-left: 0 !important;
-	}
-
-	.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}none#{$separator}tablet {
-		// Replace with padding-block property when possible
-		padding-top: 0 !important;
-		padding-bottom: 0 !important;
 	}
 }
 
@@ -468,28 +337,6 @@ $layout-sizes: (
 			padding-bottom: $sizeValue !important;
 		}
 	}
-
-	.#{$paddingKey}#{$separator}none#{$separator}desktop {
-		padding: 0 !important;
-	}
-
-	@each $position-key, $direction in $directions {
-		.#{$paddingKey}#{$separator}#{$position-key}#{$separator}none#{$separator}desktop {
-			padding-#{$direction}: 0 !important;
-		}
-	}
-
-	.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}none#{$separator}desktop {
-		// Replace with padding-inline property when possible
-		padding-right: 0 !important;
-		padding-left: 0 !important;
-	}
-
-	.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}none#{$separator}desktop {
-		// Replace with padding-block property when possible
-		padding-top: 0 !important;
-		padding-bottom: 0 !important;
-	}
 }
 
 @include widescreen {
@@ -533,27 +380,5 @@ $layout-sizes: (
 			padding-top: $sizeValue !important;
 			padding-bottom: $sizeValue !important;
 		}
-	}
-
-	.#{$paddingKey}#{$separator}none#{$separator}widescreen {
-		padding: 0 !important;
-	}
-
-	@each $position-key, $direction in $directions {
-		.#{$paddingKey}#{$separator}#{$position-key}#{$separator}none#{$separator}widescreen {
-			padding-#{$direction}: 0 !important;
-		}
-	}
-
-	.#{$paddingKey}#{$separator}#{$inlineKey}#{$separator}none#{$separator}widescreen {
-		// Replace with padding-inline property when possible
-		padding-right: 0 !important;
-		padding-left: 0 !important;
-	}
-
-	.#{$paddingKey}#{$separator}#{$blockKey}#{$separator}none#{$separator}widescreen {
-		// Replace with padding-block property when possible
-		padding-top: 0 !important;
-		padding-bottom: 0 !important;
 	}
 }

--- a/css/src/atomics/spacing.scss
+++ b/css/src/atomics/spacing.scss
@@ -68,6 +68,7 @@ $layout-sizes: (
 		}
 	}
 }
+
 @include widescreen {
 	@each $property in $spacing-properties {
 		// iterates through margin, margin-inline, margin-block, etc


### PR DESCRIPTION
Task: task-[428733](https://dev.azure.com/ceapex/Engineering/_boards/board/t/Fox%20Team/Stories/?workitem=428733)

Link: preview-[199](https://design.docs.microsoft.com/pulls/199)

This PR changes the order to ensure the correct specificity. `padding-none` was overriding classes like `padding-xl-tablet` at all screen widths.

## Testing

1. Visit the preview link above. Inspect an element with DevTools and add the following classes: `padding-none padding-top-s padding-left-m-tablet padding-right-xl-desktop`. The same should work with `margin`.
2. Change the screen width and verify that there's `top` padding in mobile, `top and left` padding in tablet, `top, left, and right` padding in desktop.

![image](https://user-images.githubusercontent.com/64044661/119032584-33fb3700-b961-11eb-8742-ec46d307bffd.png)
