### PR TITLE
[bug] position atomics output order

### DIFF
--- a/css/src/atomics/position.scss
+++ b/css/src/atomics/position.scss
@@ -2,9 +2,11 @@
 	.position-#{$item} {
 		position: #{$item} !important;
 	}
+}
 
-	.position-#{$item}-tablet {
-		@include tablet {
+@include tablet {
+	@each $item in $positions {
+		.position-#{$item}-tablet {
 			position: #{$item} !important;
 		}
 	}


### PR DESCRIPTION
Task: task-429267

Link: preview-200

Position atomics output is in the incorrect order. `position-absolute position-relative-tablet` combo did not work as expected.

## Testing

1. Visit https://design.docs.microsoft.com/pulls/200/atomics/position.html
2. In the example section, using dev tools, update the classes from `position-relative background-color-primary padding-xl` to `position-absolute position-relative-tablet background-color-primary padding-xl`. Nothing visually should change. You should see the `position-relative-tablet` takes higher priority over `position-absolute`. Resize the browser screen, you should see how on mobile example section changes.
3. 
![image](https://user-images.githubusercontent.com/57374379/118878560-8aef0680-b8a4-11eb-8ea1-bdb59a7dcf02.png)
