### PR TITLE
[bug] display atomics order

### DIFF
--- a/css/src/atomics/display.scss
+++ b/css/src/atomics/display.scss
@@ -2,21 +2,27 @@
 	.display-#{$item} {
 		display: #{$item} !important;
 	}
+}
 
-	.display-#{$item}-tablet {
-		@include tablet {
+@include tablet {
+	@each $item in $displays {
+		.display-#{$item}-tablet {
 			display: #{$item} !important;
 		}
 	}
+}
 
-	.display-#{$item}-desktop {
-		@include desktop {
+@include desktop {
+	@each $item in $displays {
+		.display-#{$item}-desktop {
 			display: #{$item} !important;
 		}
 	}
+}
 
-	.display-#{$item}-widescreen {
-		@include widescreen {
+@include widescreen {
+	@each $item in $displays {
+		.display-#{$item}-widescreen {
 			display: #{$item} !important;
 		}
 	}


### PR DESCRIPTION
Task: task-429228

Link: preview-201

Display atomics output is in the incorrect order. `display-none display-block-tablet` combo did not work as expected.

## Testing

1. Visit https://design.docs.microsoft.com/pulls/201/atomics/position.html
2. In the example section, using dev tools, add `display-none display-block-tablet` classes to the example container. Nothing visually should change. You should see the `display-block-tablet` takes higher priority over `display-none`. Resize the browser screen, you should see how on mobile example section disappears.
![image](https://user-images.githubusercontent.com/57374379/118882313-ea4f1580-b8a8-11eb-8507-73a5686dbb36.png)