### PR TITLE
[bug] colors atomics order

### DIFF
--- a/.changeset/fresh-ladybugs-happen.md
+++ b/.changeset/fresh-ladybugs-happen.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Changing colors atomics output order.

--- a/.changeset/fresh-ladybugs-happen.md
+++ b/.changeset/fresh-ladybugs-happen.md
@@ -2,4 +2,4 @@
 '@microsoft/atlas-css': patch
 ---
 
-Changing colors atomics output order.
+Updating colors atomics output order.

--- a/css/src/atomics/colors.scss
+++ b/css/src/atomics/colors.scss
@@ -60,30 +60,6 @@
 	}
 }
 
-@include desktop {
-	@each $name, $color-set in $colors {
-		$base: nth($color-set, $color-index-base);
-		$invert: nth($color-set, $color-index-invert);
-
-		.background-color-#{$name}-desktop {
-			outline-color: $invert;
-			background-color: $base !important;
-		}
-	}
-}
-
-@include widescreen {
-	@each $name, $color-set in $colors {
-		$base: nth($color-set, $color-index-base);
-		$invert: nth($color-set, $color-index-invert);
-
-		.background-color-#{$name}-widescreen {
-			outline-color: $invert;
-			background-color: $base !important;
-		}
-	}
-}
-
 // Text color
 
 .color-text {

--- a/css/src/atomics/colors.scss
+++ b/css/src/atomics/colors.scss
@@ -51,10 +51,6 @@
 @include tablet {
 	@each $name, $color-set in $colors {
 		$base: nth($color-set, $color-index-base);
-		$background: nth($color-set, $color-index-background);
-		$dark: nth($color-set, $color-index-dark);
-		$hover: nth($color-set, $color-index-hover);
-		$active: nth($color-set, $color-index-active);
 		$invert: nth($color-set, $color-index-invert);
 
 		.background-color-#{$name}-tablet {
@@ -67,10 +63,6 @@
 @include desktop {
 	@each $name, $color-set in $colors {
 		$base: nth($color-set, $color-index-base);
-		$background: nth($color-set, $color-index-background);
-		$dark: nth($color-set, $color-index-dark);
-		$hover: nth($color-set, $color-index-hover);
-		$active: nth($color-set, $color-index-active);
 		$invert: nth($color-set, $color-index-invert);
 
 		.background-color-#{$name}-desktop {
@@ -83,10 +75,6 @@
 @include widescreen {
 	@each $name, $color-set in $colors {
 		$base: nth($color-set, $color-index-base);
-		$background: nth($color-set, $color-index-background);
-		$dark: nth($color-set, $color-index-dark);
-		$hover: nth($color-set, $color-index-hover);
-		$active: nth($color-set, $color-index-active);
 		$invert: nth($color-set, $color-index-invert);
 
 		.background-color-#{$name}-widescreen {

--- a/css/src/atomics/colors.scss
+++ b/css/src/atomics/colors.scss
@@ -32,27 +32,6 @@
 		background-color: $base !important;
 	}
 
-	.background-color-#{$name}-tablet {
-		@include tablet {
-			outline-color: $invert;
-			background-color: $base !important;
-		}
-	}
-
-	.background-color-#{$name}-desktop {
-		@include desktop {
-			outline-color: $invert;
-			background-color: $base !important;
-		}
-	}
-
-	.background-color-#{$name}-widescreen {
-		@include widescreen {
-			outline-color: $invert;
-			background-color: $base !important;
-		}
-	}
-
 	.background-color-#{$name}-invert {
 		outline-color: $base;
 		background-color: $invert !important;
@@ -66,6 +45,54 @@
 	.background-color-#{$name}-dark {
 		outline-color: $background;
 		background-color: $dark !important;
+	}
+}
+
+@include tablet {
+	@each $name, $color-set in $colors {
+		$base: nth($color-set, $color-index-base);
+		$background: nth($color-set, $color-index-background);
+		$dark: nth($color-set, $color-index-dark);
+		$hover: nth($color-set, $color-index-hover);
+		$active: nth($color-set, $color-index-active);
+		$invert: nth($color-set, $color-index-invert);
+
+		.background-color-#{$name}-tablet {
+			outline-color: $invert;
+			background-color: $base !important;
+		}
+	}
+}
+
+@include desktop {
+	@each $name, $color-set in $colors {
+		$base: nth($color-set, $color-index-base);
+		$background: nth($color-set, $color-index-background);
+		$dark: nth($color-set, $color-index-dark);
+		$hover: nth($color-set, $color-index-hover);
+		$active: nth($color-set, $color-index-active);
+		$invert: nth($color-set, $color-index-invert);
+
+		.background-color-#{$name}-desktop {
+			outline-color: $invert;
+			background-color: $base !important;
+		}
+	}
+}
+
+@include widescreen {
+	@each $name, $color-set in $colors {
+		$base: nth($color-set, $color-index-base);
+		$background: nth($color-set, $color-index-background);
+		$dark: nth($color-set, $color-index-dark);
+		$hover: nth($color-set, $color-index-hover);
+		$active: nth($color-set, $color-index-active);
+		$invert: nth($color-set, $color-index-invert);
+
+		.background-color-#{$name}-widescreen {
+			outline-color: $invert;
+			background-color: $base !important;
+		}
 	}
 }
 


### PR DESCRIPTION
Task: task-429358

Link: preview-202

Colors atomics output is in the incorrect order. `background-color-primary-tablet background-color-danger` did not work as expected.

## Testing

1. Visit https://design.docs.microsoft.com/pulls/202/atomics/position.html
2. In the example section, using dev tools, add `background-color-primary-tablet background-color-danger` classes to the example container. Nothing visually should change. You should see the `background-color-primary-tablet` takes higher priority over `background-color-danger`. Resize the browser screen, you should see how on mobile example section background color changes.

![image](https://user-images.githubusercontent.com/57374379/118894433-0f4b8480-b8b9-11eb-9a6b-12159485b0c7.png)
