### PR TITLE
Add xxs to spacing layout ramp

### DIFF
--- a/.changeset/angry-pumpkins-tease.md
+++ b/.changeset/angry-pumpkins-tease.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Add xxs size to spacing tokens and atomics.

--- a/css/src/atomics/spacing.scss
+++ b/css/src/atomics/spacing.scss
@@ -4,13 +4,14 @@ $spacing-properties: 'margin', 'margin-inline', 'margin-block', 'margin-top', 'm
 	'padding-bottom', 'padding-left', 'padding-right' !default;
 
 $layout-sizes: (
-	('xs', $layout-1),
-	('s', $layout-2),
-	('m', $layout-3),
-	('l', $layout-4),
-	('xl', $layout-5),
-	('xxl', $layout-6),
-	('xxxl', $layout-7),
+	('xxs', $layout-1),
+	('xs', $layout-2),
+	('s', $layout-3),
+	('m', $layout-4),
+	('l', $layout-5),
+	('xl', $layout-6),
+	('xxl', $layout-7),
+	('xxxl', $layout-8),
 	('none', $layout-0)
 );
 

--- a/css/src/tokens/spacing.scss
+++ b/css/src/tokens/spacing.scss
@@ -1,11 +1,12 @@
 $layout-0: 0 !default; // 0
-$layout-1: 1rem !default; // 16px
-$layout-2: 1.5rem !default; // 24px
-$layout-3: 2rem !default; // 32px
-$layout-4: 3rem !default; // 48px
-$layout-5: 4rem !default; // 64px
-$layout-6: 6rem !default; // 96px;
-$layout-7: 8rem !default; // 128px;
+$layout-1: 0.5rem !default; // 8px
+$layout-2: 1rem !default; // 16px
+$layout-3: 1.5rem !default; // 24px
+$layout-4: 2rem !default; // 32px
+$layout-5: 3rem !default; // 48px
+$layout-6: 4rem !default; // 64px
+$layout-7: 6rem !default; // 96px;
+$layout-8: 8rem !default; // 128px;
 
 $spacer-0: 0 !default; // 0
 $spacer-1: 0.125rem !default; // 2px

--- a/site/src/scaffold/styles/layout.scss
+++ b/site/src/scaffold/styles/layout.scss
@@ -29,7 +29,7 @@
 #aside,
 #footer {
 	overflow: hidden;
-	padding: $layout-1 $layout-2;
+	padding: $layout-2 $layout-3;
 }
 
 #header {
@@ -58,12 +58,14 @@
 	max-width: 70ch;
 	margin: auto;
 	@include tablet {
-		padding-inline: $layout-3;
+		//Replace with padding-inline when IE supported is dropped
+		padding-left: $layout-4;
+		padding-right: $layout-4;
 	}
 }
 
 .example {
-	padding: 1rem;
+	padding: $layout-2;
 }
 
 // For debugging layout purposes only


### PR DESCRIPTION
Task: task-[430478](https://dev.azure.com/ceapex/Engineering/_boards/board/t/Fox%20Team/Stories/?workitem=430478)

Link: preview-[204](https://design.docs.microsoft.com/pulls/204)

This PR adds another size (0.5rem) between the current `layout-0` (0px) and `layout-1` (1rem). This new size `xxs` will be used to replace Doc's `extra-small` and `margin-small` sizes.

## Testing

1. Review code. Use the preview link to test.