### PR TITLE
articles can add figmaEmbed url to metadata and Figma will be iframed on page

### DIFF
--- a/.changeset/tough-months-accept.md
+++ b/.changeset/tough-months-accept.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/parcel-transformer-markdown-html': minor
+'@microsoft/atlas-site': patch
+---
+
+Add ability to add figmaEmbed to yaml front matter.

--- a/plugins/parcel-transformer-markdown-html/lib/index.js
+++ b/plugins/parcel-transformer-markdown-html/lib/index.js
@@ -141,6 +141,7 @@ module.exports = new Transformer({
 			const workingDir = process.cwd();
 			const templateDir = path.join(workingDir, config.contents.templatePath);
 			const templateFilename = path.join(templateDir, `${attributes.template}.html`);
+			const figmaEmbed = attributes.figmaEmbed;
 			const tocFilename = config.contents.tocPath
 				? path.join(workingDir, config.contents.tocPath)
 				: null;
@@ -190,7 +191,8 @@ module.exports = new Transformer({
 					toc: { name: 'TOC', entries: tocEntries },
 					...attributes,
 					tokens,
-					cssTokenSource
+					cssTokenSource,
+					figmaEmbed
 				})
 			);
 		} else {

--- a/site/src/components/markdown.md
+++ b/site/src/components/markdown.md
@@ -2,6 +2,7 @@
 title: Markdown
 description: An element to render html generated from markdown.
 template: standard
+figmaEmbed: https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Fproto%2FfiMDOM9S3wiWTy9YiA3988%2FDesign-System-IA-Artifacts%3Fnode-id%3D23%253A435%26scaling%3Dmin-zoom
 ---
 
 # Markdown

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -17,7 +17,20 @@
 
 		<main id="main">
 			<div class="layout-container padding-top-s">
-				{{{ body }}}
+				<div class="body">
+					{{{ body }}}
+				</div>
+				{{#figmaEmbed}}
+				<div class="figma-embed-container padding-top-m">
+						<h2 class="font-size-h2 margin-bottom-m">Figma</h2>
+						<iframe
+							width="100%";
+							class="border"
+							height="450"
+							src="{{figmaEmbed}}"
+							allowfullscreen></iframe>
+					</div>
+				{{/figmaEmbed}}
 			</div>
 		</main>
 		<nav id="nav" class="background-color-body-medium" style="border-right: 1px solid var(--theme-border)">

--- a/site/src/scaffold/token.html
+++ b/site/src/scaffold/token.html
@@ -26,7 +26,17 @@
 					<pre><code>{{#tokens}}{{name}}: {{value}}
 {{/tokens}}</code></pre>
 					</div>
-
+					{{#figmaEmbed}}
+					<div class="figma-embed-container padding-top-m">
+						<h2 class="font-size-h2 margin-bottom-m">Figma</h2>
+						<iframe
+							width="100%";
+							class="border"
+							height="450"
+							src="{{figmaEmbed}}"
+							allowfullscreen></iframe>
+						</div>
+					{{/figmaEmbed}}
 				</div>
 			</div>
 		</main>


### PR DESCRIPTION
Task: hack

Link: preview-212

Stumbled across Figma embeds. Seemed like an interesting thing to try out. It works well!

![image](https://user-images.githubusercontent.com/30843002/120861700-8ed58680-c53c-11eb-99d3-dc42917e07e5.png)

## Testing

1. Visit markdown page
2. Scroll to the bottom
   Expected result: See a figma embed.

## Additional information

[Optional]
