### PR TITLE
Create Atomics overview page

### DIFF
--- a/.changeset/little-jobs-carry.md
+++ b/.changeset/little-jobs-carry.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/parcel-transformer-markdown-html': minor
+'@microsoft/atlas-site': minor
+---
+
+Add ability to import the content of another md file into a md file.

--- a/.changeset/little-jobs-carry.md
+++ b/.changeset/little-jobs-carry.md
@@ -3,4 +3,4 @@
 '@microsoft/atlas-site': minor
 ---
 
-Add ability to import the content of another md file into a md file.
+Create Atomics overview page.

--- a/plugins/parcel-transformer-markdown-html/lib/index.js
+++ b/plugins/parcel-transformer-markdown-html/lib/index.js
@@ -162,7 +162,7 @@ module.exports = new Transformer({
 				skipFormatting: true
 			});
 
-			let [template, tocEntries] = await Promise.all([
+			const [template, tocEntries] = await Promise.all([
 				options.inputFS.readFile(templateFilename, 'utf-8'),
 				tocFilename
 					? options.inputFS.readFile(tocFilename, 'utf-8').then(r => JSON.parse(r))

--- a/site/src/atomics/overview.md
+++ b/site/src/atomics/overview.md
@@ -1,0 +1,6 @@
+---
+title: Atomics Overview
+description: Overview page for Atomic classes
+template: standard
+import: ../css/src/atomics/README.md
+---

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -39,7 +39,7 @@
 					{{#isDirectory}}
 						<div class="margin-top-s">
 							<p>{{name}}</p>
-							<div class="padding-left-xs">
+							<div class="margin-left-xs">
 								{{#children}}
 									<a class="display-block color-primary" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
 								{{/children}}

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -18,12 +18,7 @@
 		<main id="main">
 			<div class="layout-container padding-top-s">
 				<div class="body">
-					{{#importFile}}
-						{{{ importFile }}}
-					{{/importFile}}
-					{{^importFile}}
-						{{{ body }}}
-					{{/importFile}}
+					{{{ body }}}
 				</div>
 				{{#figmaEmbed}}
 				<div class="figma-embed-container padding-top-m">

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -18,7 +18,12 @@
 		<main id="main">
 			<div class="layout-container padding-top-s">
 				<div class="body">
-					{{{ body }}}
+					{{#importFile}}
+						{{{ importFile }}}
+					{{/importFile}}
+					{{^importFile}}
+						{{{ body }}}
+					{{/importFile}}
 				</div>
 				{{#figmaEmbed}}
 				<div class="figma-embed-container padding-top-m">
@@ -35,13 +40,15 @@
 		</main>
 		<nav id="nav" class="background-color-body-medium" style="border-right: 1px solid var(--theme-border)">
 			{{#toc}}
-			{{#entries}}
+				{{#entries}}
 					{{#isDirectory}}
 						<div class="margin-top-s">
 							<p>{{name}}</p>
-							{{#children}}
-								<a class="display-block color-primary" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
-							{{/children}}
+							<div class="padding-left-xs">
+								{{#children}}
+									<a class="display-block color-primary" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+								{{/children}}
+							</div>
 						</div>
 					{{/isDirectory}}
 					{{^children.0}}

--- a/site/src/scaffold/token.html
+++ b/site/src/scaffold/token.html
@@ -46,7 +46,7 @@
 					{{#isDirectory}}
 						<div class="margin-top-s">
 							<p>{{name}}</p>
-							<div class="margin-left-s">
+							<div class="margin-left-xs">
 								{{#children}}
 									<a class="display-block color-primary" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
 								{{/children}}

--- a/site/src/scaffold/token.html
+++ b/site/src/scaffold/token.html
@@ -46,9 +46,11 @@
 					{{#isDirectory}}
 						<div class="margin-top-s">
 							<p>{{name}}</p>
-							{{#children}}
-								<a class="display-block color-primary" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
-							{{/children}}
+							<div class="margin-left-s">
+								{{#children}}
+									<a class="display-block color-primary" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+								{{/children}}
+							</div>
 						</div>
 					{{/isDirectory}}
 					{{^children.0}}

--- a/site/toc.js
+++ b/site/toc.js
@@ -115,7 +115,7 @@ async function createToc(subDir) {
 			isHidden: name === '[hide]'
 		};
 
-		if (isDirectory) {
+		if (entry.isDirectory) {
 			entry.children = await createToc(srcPath);
 			entry.children.sort(
 				(a, b) => b.href.includes('overview.md') - a.href.includes('overview.md')

--- a/site/toc.js
+++ b/site/toc.js
@@ -25,6 +25,7 @@ const settings = normalizePaths({
 		'/tokens': 'Tokens',
 		'/components': 'Components',
 		'/atomics': 'Atomics',
+		'/atomics/overview.md': 'Overview',
 		'/atomics/border.md': 'Border',
 		'/atomics/spacing.md': 'Spacing',
 		'/atomics/typography.md': 'Typography',
@@ -114,8 +115,11 @@ async function createToc(subDir) {
 			isHidden: name === '[hide]'
 		};
 
-		if (entry.isDirectory) {
+		if (isDirectory) {
 			entry.children = await createToc(srcPath);
+			entry.children.sort(
+				(a, b) => b.href.includes('overview.md') - a.href.includes('overview.md')
+			);
 		}
 
 		scaffold.push(entry);


### PR DESCRIPTION
Task: task-[431989](https://dev.azure.com/ceapex/Engineering/_boards/board/t/Fox%20Team/Stories/?workitem=431989)

Link: preview-[214](https://design.docs.microsoft.com/pulls/214/atomics/overview.html)

This PR adds an overview page for Atomics. The content of the page is imported from the Atomics readme so the two files are synced. 

Todo: do more research on a different approach `<include>` + posthtml transform md -> html 

## Testing

1. Visit preview-[214](https://design.docs.microsoft.com/pulls/214/atomics/overview.html). Compare the content with the [CSS Atomics readme file](https://github.com/microsoft/atlas-design/blob/main/css/src/atomics/README.md) 


