### PR TITLE
add .htmlnanorc and set minifySvg to false

### DIFF
--- a/.changeset/heavy-ears-tie.md
+++ b/.changeset/heavy-ears-tie.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': patch
+---
+
+Add .htmlnanorc file and prevent SVG minification.

--- a/site/src/.htmlnanorc
+++ b/site/src/.htmlnanorc
@@ -1,0 +1,3 @@
+{
+	"minifySvg": false
+}


### PR DESCRIPTION
Task: task-432750 (buttons follow up)

Fixes issue with SVGs getting mangled by html nano.