### PR TITLE
add responsive-font-size mixin to replace rfs's font-size

### DIFF
--- a/.changeset/beige-pigs-sit.md
+++ b/.changeset/beige-pigs-sit.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Replace responsive font sizing (package:rfs) dependency with clamp based solution.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Looking for information about the Atlas CSS framework? Start at the [/css README
 ## Development
 
 - Ensure [git](https://git-scm.com/) is installed.
-- Ensure that have downloaded and installed a version of [NodeJS](https://nodejs.org/en/download/releases/) that supports monorepos. It's currently recommended you download version 15.7.0 with NPM at a greater version than 7.4.3.
+- Ensure that have downloaded and installed a version of [NodeJS](https://nodejs.org/en/download/releases/) that supports monorepos. It's currently recommended you download NodeJS version 16.6.\* and use with NPM at a greater version than 7.19.1.
 - Alternatively, you can install NPM with NVM: [mac](https://github.com/nvm-sh/nvm) | [windows](https://github.com/coreybutler/nvm-windows).
 - If contributing code, please read about using [changesets](https://github.com/atlassian/changesets) and [semantic versioning bump types](https://semver.org/).
 - Clone the repostory.

--- a/css/package.json
+++ b/css/package.json
@@ -38,8 +38,7 @@
 	"license": "MIT",
 	"dependencies": {
 		"minireset.css": "^0.0.7",
-		"normalize.css": "^8.0.1",
-		"rfs": "^9.0.3"
+		"normalize.css": "^8.0.1"
 	},
 	"devDependencies": {
 		"parcel": "2.0.0-beta.3.1",

--- a/css/src/components/markdown.scss
+++ b/css/src/components/markdown.scss
@@ -15,7 +15,9 @@ $list-top-spacing: 1rem !default;
 }
 
 .markdown {
+	// @include responsive-font-size($markdown-paragraph-size, 0.875rem); // experiment only
 	font-size: $markdown-paragraph-size;
+	line-height: 1.6;
 
 	// Inline code
 	:not(a):not(pre) > code {
@@ -118,7 +120,7 @@ $list-top-spacing: 1rem !default;
 	}
 
 	h5 {
-		@include responsive-font-size($font-size-5);
+		@include responsive-font-size($font-size-5, 1rem);
 
 		margin-top: 2.25rem;
 		margin-bottom: 0.375rem;
@@ -126,7 +128,7 @@ $list-top-spacing: 1rem !default;
 	}
 
 	h6 {
-		@include responsive-font-size($font-size-6);
+		@include responsive-font-size($font-size-6, 1rem);
 
 		margin-top: 2.25rem;
 		margin-bottom: 0.375rem;

--- a/css/src/components/markdown.scss
+++ b/css/src/components/markdown.scss
@@ -120,7 +120,7 @@ $list-top-spacing: 1rem !default;
 	}
 
 	h5 {
-		@include responsive-font-size($font-size-5, 1rem);
+		@include responsive-font-size($font-size-5, 1.1rem);
 
 		margin-top: 2.25rem;
 		margin-bottom: 0.375rem;
@@ -128,7 +128,7 @@ $list-top-spacing: 1rem !default;
 	}
 
 	h6 {
-		@include responsive-font-size($font-size-6, 1rem);
+		@include responsive-font-size($font-size-6, 1.05rem);
 
 		margin-top: 2.25rem;
 		margin-bottom: 0.375rem;

--- a/css/src/components/markdown.scss
+++ b/css/src/components/markdown.scss
@@ -84,7 +84,7 @@ $list-top-spacing: 1rem !default;
 	}
 
 	h1 {
-		@include font-size($font-size-1);
+		@include responsive-font-size($font-size-1);
 
 		margin-top: none;
 		margin-bottom: 0.75rem;
@@ -98,27 +98,27 @@ $list-top-spacing: 1rem !default;
 	}
 
 	h2 {
-		@include font-size($font-size-2);
+		@include responsive-font-size($font-size-2);
 
 		margin-top: 2rem;
 	}
 
 	h3 {
-		@include font-size($font-size-3);
+		@include responsive-font-size($font-size-3);
 
 		margin-top: 1.875rem;
 		margin-bottom: 1.125rem;
 	}
 
 	h4 {
-		@include font-size($font-size-4);
+		@include responsive-font-size($font-size-4);
 
 		margin-top: 2.25rem;
 		margin-bottom: 0.375rem;
 	}
 
 	h5 {
-		@include font-size($font-size-5);
+		@include responsive-font-size($font-size-5);
 
 		margin-top: 2.25rem;
 		margin-bottom: 0.375rem;
@@ -126,7 +126,7 @@ $list-top-spacing: 1rem !default;
 	}
 
 	h6 {
-		@include font-size($font-size-6);
+		@include responsive-font-size($font-size-6);
 
 		margin-top: 2.25rem;
 		margin-bottom: 0.375rem;

--- a/css/src/core/font-stack.scss
+++ b/css/src/core/font-stack.scss
@@ -1,3 +1,7 @@
+html {
+	font-size: $document-font-size;
+}
+
 html,
 body {
 	font-family: $normal-font-stack;

--- a/css/src/mixins/font-size.scss
+++ b/css/src/mixins/font-size.scss
@@ -16,65 +16,24 @@ $font-size-scaling-factor: 0.75 !default;
 @function strip-units($number) {
 	@return math.div($number, ($number * 0 + 1));
 }
-
-@function get-scaled-vw(
-	$size,
-	$breakpoint: $breakpoint-widescreen,
-	$smallest-allowed-px: $document-font-size
+@mixin responsive-font-size(
+	// font-size to stop scaling at
+	$end-rem,
+	// font-size to start scaling from
+	$start-rem: max($end-rem * $font-size-scaling-factor, 1rem),
+	// viewport width to stop scaling at
+	$end-width: $breakpoint-desktop,
+	// viewport width to start scaling from
+	$start-width: 480px
 ) {
-	// @debug 'Parameters: $size:#{$size}, $breakpoint:#{$breakpoint}, $smallest-allowed-px:#{$smallest-allowed-px} ';
+	$m: math.div(
+			strip-units($end-rem) - strip-units($start-rem),
+			strip-units($end-width) - strip-units($start-width)
+		) * strip-units($document-font-size);
 
-	// Math.div will soon not support division with units, strip units from values.
-	$unitless-original: strip-units($size); // 3.5rem h1
-	$unitless-breakpoint: strip-units($breakpoint); // 1478px widescreen
-	$unitless-document-font-size: strip-units($smallest-allowed-px); // 16px
-	$unitless-breakpoint-widescreen: math.div(
-		$unitless-breakpoint,
-		$unitless-document-font-size
-	); // 92rem
+	$y: strip-units($start-rem) * strip-units($document-font-size);
+	$x: strip-units($start-width);
+	$b: $y - $m * $x;
 
-	// @debug 'Unitless: $unitless-original:#{$unitless-original},  $unitless-$breakpoint:#{$unitless-breakpoint}, $unitless-document-font-size:#{$unitless-document-font-size}, $unitless-breakpoint-widescreen:#{$unitless-breakpoint-widescreen}';
-
-	$px: $unitless-original * $unitless-document-font-size; // 56px
-	$numerator: $px * ($unitless-document-font-size * $font-size-scaling-factor); // 56px * (16 * .6) 56* 9 // 504
-	$denom: $unitless-breakpoint-widescreen; // 92rem
-	// @debug 'Outputs: $px:#{$px}, $numerator:#{$numerator}, $denom:#{$denom}';
-
-	$target: math.div($numerator, $denom);
-	// @debug '$target:#{$target + vw}';
-
-	@return $target + vw;
-}
-
-@function get-min(
-	$rem-size: 1rem,
-	$scaling-factor: 0.6,
-	$smallest-allowed-px: $document-font-size
-) {
-	// Avoid non-compatible
-	$scaled-px: strip-units($rem-size) * $font-size-scaling-factor * strip-units($document-font-size);
-	$smallest-allowed: strip-units($smallest-allowed-px);
-	$adjusted: math.max($scaled-px, $smallest-allowed);
-	$adjusted-rem: math.div($adjusted, strip-units($document-font-size));
-	@return #{$adjusted-rem}rem;
-}
-
-/*
- * Outputs a font-size rule that uses clamp.
- * First parameter is the the font-size at the widescreen breakpoint.
- * Second (optional) parameter is minimum value to scale down to.
- * If the second param is omitted, a scaling value ($font-size-scaling-factor)
- * is applied to the first parameter to get the lowest boundary
- */
-@mixin responsive-font-size($max-rem, $min-rem: '') {
-	// scale the font size down by applying the scaling factor but not below the $document-font-size.
-	$smallest-allowed-px: $max-rem * $font-size-scaling-factor;
-	@if $min-rem != '' {
-		$smallest-allowed-px: strip-units($min-rem) * $document-font-size;
-	}
-
-	$min: if($min-rem != '', $min-rem, $smallest-allowed-px);
-	$target: #{get-scaled-vw($max-rem)};
-
-	font-size: clamp(#{$min}, #{$target}, #{$max-rem});
+	font-size: clamp(#{$start-rem}, #{$b}px + #{$m * 100}vw, #{$end-rem});
 }

--- a/css/src/mixins/font-size.scss
+++ b/css/src/mixins/font-size.scss
@@ -22,7 +22,7 @@ $font-size-scaling-factor: 0.75 !default;
 	$breakpoint: $breakpoint-widescreen,
 	$smallest-allowed-px: $document-font-size
 ) {
-	// @debug 'Parameters: original:#{$original},  $scaling-factor:#{ $scaling-factor}, $breakpoint:#{$breakpoint}';
+	// @debug 'Parameters: $size:#{$size}, $breakpoint:#{$breakpoint}, $smallest-allowed-px:#{$smallest-allowed-px} ';
 
 	// Math.div will soon not support division with units, strip units from values.
 	$unitless-original: strip-units($size); // 3.5rem h1

--- a/css/src/mixins/font-size.scss
+++ b/css/src/mixins/font-size.scss
@@ -1,0 +1,57 @@
+@use 'sass:math';
+
+// Remove the units from a value
+@function strip-units($number) {
+	@return math.div($number, ($number * 0 + 1));
+}
+
+@function get-scaled-vw($size, $scaling-factor: 0.6, $breakpoint: $breakpoint-widescreen) {
+	// @debug 'Parameters: original:#{$original},  $scaling-factor:#{ $scaling-factor}, $breakpoint:#{$breakpoint}';
+
+	// Math.div will soon not support division with units, strip units from values.
+	$unitless-original: strip-units($size); // 3.5rem h1
+	$unitless-breakpoint: strip-units($breakpoint); // 1478px widescreen
+	$unitless-document-font-size: strip-units($document-font-size); // 16px
+	$unitless-breakpoint-widescreen: math.div(
+		$unitless-breakpoint,
+		$unitless-document-font-size
+	); // 92rem
+	// @debug 'Unitless: $unitless-original:#{$unitless-original},  $unitless-$breakpoint:#{$unitless-breakpoint}, $unitless-document-font-size:#{$unitless-document-font-size}, $unitless-breakpoint-widescreen:#{$unitless-breakpoint-widescreen}';
+
+	$px: $unitless-original * $unitless-document-font-size; // 56px
+	$numerator: $px * ($unitless-document-font-size * $scaling-factor); // 56px * (16 * .6) 56* 9 // 504
+	$denom: $unitless-breakpoint-widescreen; // 92rem
+	// @debug 'Outputs: $px:#{$px}, $numerator:#{$numerator}, $denom:#{$denom}';
+
+	$target: math.div($numerator, $denom);
+	// @debug '$target:#{$target + vw}';
+
+	@return $target + vw;
+}
+
+@function get-min(
+	$rem-size: 1rem,
+	$scaling-factor: 0.6,
+	$smallest-allowed-px: $document-font-size
+) {
+	// Avoid non-compatible
+	$scaled-px: strip-units($rem-size) * $scaling-factor * strip-units($document-font-size);
+	$smallest-allowed: strip-units($smallest-allowed-px);
+	$adjusted: math.max($scaled-px, $smallest-allowed);
+	$adjusted-rem: math.div($adjusted, strip-units($document-font-size));
+	@return #{$adjusted-rem}rem;
+}
+
+// Output a font-size rule that uses clamp()
+@mixin responsive-font-size($size: 1rem, $scaling-factor: 0.6, $is-heading: true) {
+	// scale the font size down by applying the scaling factor
+	// but not below the $document-font-size.
+	$min: #{get-min($size, $scaling-factor)};
+	$target: #{get-scaled-vw($size)};
+
+	font-size: clamp(#{$min}, #{$target}, #{$size});
+}
+
+// 2.5rem * x = 1472
+// 2.5rem * 0.6 * x = 480;
+// difference = 992

--- a/css/src/mixins/font-size.scss
+++ b/css/src/mixins/font-size.scss
@@ -1,15 +1,5 @@
 @use 'sass:math';
 
-/*
- * A note on how to test changes made to this function.
- * 1. Uncomment the @debug lines to see your changes applied during build.
- * 2. Scaling should be relatively fluid from the maximum (the $size provided at the widescreen breakpoint),
- *	  to the minimum. There should be no very noticeable jumps.
- * 3. The math here is largely arbitrary.
- * 4. Should the difference between the max and min values increase drastically, you'll need to test with OS font size enlarged and zoomed.
- * 5. The markdown CSS component is a good place to test the headings.
-*/
-
 $font-size-scaling-factor: 0.75 !default;
 
 // Remove the units from a value

--- a/css/src/mixins/font-size.scss
+++ b/css/src/mixins/font-size.scss
@@ -1,25 +1,42 @@
 @use 'sass:math';
 
+/*
+ * A note on how to test changes made to this function.
+ * 1. Uncomment the @debug lines to see your changes applied during build.
+ * 2. Scaling should be relatively fluid from the maximum (the $size provided at the widescreen breakpoint),
+ *	  to the minimum. There should be no very noticeable jumps.
+ * 3. The math here is largely arbitrary.
+ * 4. Should the difference between the max and min values increase drastically, you'll need to test with OS font size enlarged and zoomed.
+ * 5. The markdown CSS component is a good place to test the headings.
+*/
+
+$font-size-scaling-factor: 0.75 !default;
+
 // Remove the units from a value
 @function strip-units($number) {
 	@return math.div($number, ($number * 0 + 1));
 }
 
-@function get-scaled-vw($size, $scaling-factor: 0.6, $breakpoint: $breakpoint-widescreen) {
+@function get-scaled-vw(
+	$size,
+	$breakpoint: $breakpoint-widescreen,
+	$smallest-allowed-px: $document-font-size
+) {
 	// @debug 'Parameters: original:#{$original},  $scaling-factor:#{ $scaling-factor}, $breakpoint:#{$breakpoint}';
 
 	// Math.div will soon not support division with units, strip units from values.
 	$unitless-original: strip-units($size); // 3.5rem h1
 	$unitless-breakpoint: strip-units($breakpoint); // 1478px widescreen
-	$unitless-document-font-size: strip-units($document-font-size); // 16px
+	$unitless-document-font-size: strip-units($smallest-allowed-px); // 16px
 	$unitless-breakpoint-widescreen: math.div(
 		$unitless-breakpoint,
 		$unitless-document-font-size
 	); // 92rem
+
 	// @debug 'Unitless: $unitless-original:#{$unitless-original},  $unitless-$breakpoint:#{$unitless-breakpoint}, $unitless-document-font-size:#{$unitless-document-font-size}, $unitless-breakpoint-widescreen:#{$unitless-breakpoint-widescreen}';
 
 	$px: $unitless-original * $unitless-document-font-size; // 56px
-	$numerator: $px * ($unitless-document-font-size * $scaling-factor); // 56px * (16 * .6) 56* 9 // 504
+	$numerator: $px * ($unitless-document-font-size * $font-size-scaling-factor); // 56px * (16 * .6) 56* 9 // 504
 	$denom: $unitless-breakpoint-widescreen; // 92rem
 	// @debug 'Outputs: $px:#{$px}, $numerator:#{$numerator}, $denom:#{$denom}';
 
@@ -35,23 +52,29 @@
 	$smallest-allowed-px: $document-font-size
 ) {
 	// Avoid non-compatible
-	$scaled-px: strip-units($rem-size) * $scaling-factor * strip-units($document-font-size);
+	$scaled-px: strip-units($rem-size) * $font-size-scaling-factor * strip-units($document-font-size);
 	$smallest-allowed: strip-units($smallest-allowed-px);
 	$adjusted: math.max($scaled-px, $smallest-allowed);
 	$adjusted-rem: math.div($adjusted, strip-units($document-font-size));
 	@return #{$adjusted-rem}rem;
 }
 
-// Output a font-size rule that uses clamp()
-@mixin responsive-font-size($size: 1rem, $scaling-factor: 0.6, $is-heading: true) {
-	// scale the font size down by applying the scaling factor
-	// but not below the $document-font-size.
-	$min: #{get-min($size, $scaling-factor)};
-	$target: #{get-scaled-vw($size)};
+/*
+ * Outputs a font-size rule that uses clamp.
+ * First parameter is the the font-size at the widescreen breakpoint.
+ * Second (optional) parameter is minimum value to scale down to.
+ * If the second param is omitted, a scaling value ($font-size-scaling-factor)
+ * is applied to the first parameter to get the lowest boundary
+ */
+@mixin responsive-font-size($max-rem, $min-rem: '') {
+	// scale the font size down by applying the scaling factor but not below the $document-font-size.
+	$smallest-allowed-px: $max-rem * $font-size-scaling-factor;
+	@if $min-rem != '' {
+		$smallest-allowed-px: strip-units($min-rem) * $document-font-size;
+	}
 
-	font-size: clamp(#{$min}, #{$target}, #{$size});
+	$min: if($min-rem != '', $min-rem, $smallest-allowed-px);
+	$target: #{get-scaled-vw($max-rem)};
+
+	font-size: clamp(#{$min}, #{$target}, #{$max-rem});
 }
-
-// 2.5rem * x = 1472
-// 2.5rem * 0.6 * x = 480;
-// difference = 992

--- a/css/src/mixins/index.scss
+++ b/css/src/mixins/index.scss
@@ -4,6 +4,6 @@
 @import 'focus.scss';
 @import 'loader.scss';
 @import 'media-queries.scss';
-@import 'rfs/scss';
+@import 'font-size.scss';
 @import 'transparency.scss';
 @import 'unselectable.scss';

--- a/css/src/tokens/typography.scss
+++ b/css/src/tokens/typography.scss
@@ -1,6 +1,9 @@
 /**
  * @sass-export-section="typography"
  */
+
+$document-font-size: 16px;
+
 // Typography
 $font-size-9: 0.75rem !default; // 12px
 $font-size-8: 0.875rem !default; // 14px

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"minireset.css": "^0.0.7",
-				"normalize.css": "^8.0.1",
-				"rfs": "^9.0.3"
+				"normalize.css": "^8.0.1"
 			},
 			"devDependencies": {
 				"@microsoft/stylelint-config-atlas": "3.0.0",
@@ -13725,17 +13724,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/rfs": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/rfs/-/rfs-9.0.4.tgz",
-			"integrity": "sha512-n8XGVpmqDv/fIIRx5NZ58/5HVFX+i29OmxzxVmQOwKuKbE9TOvfjUsDsLwQNcN226yumNgPMy1Pfdf31s25Ypw==",
-			"dependencies": {
-				"postcss-value-parser": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/rgb-regex": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
@@ -17775,7 +17763,6 @@
 				"parcel": "2.0.0-beta.3.1",
 				"prettier": "^2.2.1",
 				"quicktype-core": "^6.0.70",
-				"rfs": "^9.0.3",
 				"sass": "^1.32.8",
 				"sass-export": "^2.1.0",
 				"stylelint": "^13.11.0",
@@ -27646,14 +27633,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
-		},
-		"rfs": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/rfs/-/rfs-9.0.4.tgz",
-			"integrity": "sha512-n8XGVpmqDv/fIIRx5NZ58/5HVFX+i29OmxzxVmQOwKuKbE9TOvfjUsDsLwQNcN226yumNgPMy1Pfdf31s25Ypw==",
-			"requires": {
-				"postcss-value-parser": "^4.1.0"
-			}
 		},
 		"rgb-regex": {
 			"version": "1.0.1",

--- a/site/src/components/markdown.md
+++ b/site/src/components/markdown.md
@@ -27,7 +27,7 @@ The markdown element provides bare element styling to lists, paragraphs and inli
 
 ##### Headings (level 5)
 
-##### Headings (level 6)
+###### Headings (level 6)
 ```
 
 ## Unordered list

--- a/site/src/scaffold/styles/layout.scss
+++ b/site/src/scaffold/styles/layout.scss
@@ -1,5 +1,5 @@
 html {
-	font-size: 16px;
+	font-size: $document-font-size;
 }
 
 #body {


### PR DESCRIPTION
Task: task-437077

Removes `rfs` package in favor of an in house solution. Also, adds 1.6 line height within markdown to match Docs. Ideal for scaling is as follows:

- A fluid scaling between the max and min.
- Minimum values still allow for discernable differences between heading sizes, especially on h1-h4.
- Relatively straightfoward outer api. `@include responsive-font-size($max, $min)`.
- No major "jumps" between scaled values and min and max.
- OS font-size changes don't mess up anything.

Link: preview-228

https://design.docs.microsoft.com/pulls/228/components/markdown.html

## Testing

1. Visit link above.
2. Resize window from wide (circa 1500px to small)
3. View on your mobile device.

## Additional information

Testing a smaller paragraph font size on mobile worked fairly well too. Did not move forward with it, but it could be added with the following:

```scss
.markdown {
  	@include responsive-font-size($markdown-paragraph-size, 0.875rem); // experiment only
}
```