### PR TITLE
add position sticky to positions

### DIFF
--- a/.changeset/clean-ways-sparkle.md
+++ b/.changeset/clean-ways-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Add sticky to positions. Makes class .position-sticky available.

--- a/css/src/tokens/position.scss
+++ b/css/src/tokens/position.scss
@@ -1,5 +1,5 @@
 /**
  * @sass-export-section="position"
  */
-$positions: 'fixed', 'absolute', 'relative' !default;
+$positions: 'fixed', 'absolute', 'relative', 'sticky' !default;
 //@end-sass-export-section

--- a/site/src/atomics/position.md
+++ b/site/src/atomics/position.md
@@ -14,6 +14,7 @@ These classes can be used to help us place elements outside of the typical docum
 .position-fixed
 .position-relative
 .position-absolute
+.position-sticky
 
 .position-fixed-tablet
 .position-relative-tablet


### PR DESCRIPTION
Task: task-488227

Link: preview-247

Position sticky was previously omitted from our helper classes, but now we've got use cases for this. Adding!

## Testing

1. Omitted stylesheet should contain `position-sticky` class.