### PR TITLE
update buttons modfiers to follow conventions

### DIFF
--- a/.changeset/neat-apples-perform.md
+++ b/.changeset/neat-apples-perform.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Update .buttons subclasses to follow component naming conventions.

--- a/css/src/components/buttons.scss
+++ b/css/src/components/buttons.scss
@@ -6,10 +6,12 @@
 	align-items: center;
 	justify-content: flex-start;
 
+	&.buttons-centered,
 	&.is-centered {
 		justify-content: center;
 	}
 
+	&.buttons-right,
 	&.is-right {
 		justify-content: flex-end;
 	}
@@ -42,6 +44,7 @@
 		margin-bottom: 1rem;
 	}
 
+	&.buttons-addons,
 	&.has-addons,
 	&.addons {
 		.button {

--- a/css/src/components/buttons.scss
+++ b/css/src/components/buttons.scss
@@ -6,13 +6,11 @@
 	align-items: center;
 	justify-content: flex-start;
 
-	&.buttons-centered,
-	&.is-centered {
+	&.buttons-centered {
 		justify-content: center;
 	}
 
-	&.buttons-right,
-	&.is-right {
+	&.buttons-right {
 		justify-content: flex-end;
 	}
 
@@ -44,9 +42,7 @@
 		margin-bottom: 1rem;
 	}
 
-	&.buttons-addons,
-	&.has-addons,
-	&.addons {
+	&.buttons-addons {
 		.button {
 			&:not(:first-child) {
 				border-bottom-#{$user-left}-radius: 0;


### PR DESCRIPTION
Fixes bug where `.buttons` moved from old code base without having class names moved to the new convention.
