### PR TITLE
buttons have text decoration none

### DIFF
--- a/.changeset/sixty-crabs-talk.md
+++ b/.changeset/sixty-crabs-talk.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+.button has text-decoration none to ensure no underline on anchor elements.

--- a/css/src/components/button.scss
+++ b/css/src/components/button.scss
@@ -39,6 +39,7 @@ $button-font-weight: $weight-semibold !default;
 	background-color: $button-background-color;
 	color: $button-color;
 	font-weight: $button-font-weight;
+	text-decoration: none;
 	text-align: center;
 	white-space: nowrap;
 	cursor: pointer;


### PR DESCRIPTION
Link: preview-272

Anchors with button, especially those with icons, are not rendering as nicely as we'd like.

## Testing

1. Place anchor element in the dom with button class on it. Should have no text decoration, hovered or not.

Issue:
![image](https://user-images.githubusercontent.com/30843002/139484521-e163f506-20a1-4365-adb7-d08ac75a0d96.png)
