### PR TITLE
update border with md and update border tokens

### DIFF
--- a/.changeset/sixty-bulldogs-hope.md
+++ b/.changeset/sixty-bulldogs-hope.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-css': minor
+'@microsoft/atlas-site': minor
+---
+
+Include new md option for specifying border. Update border token values.

--- a/css/src/atomics/border.scss
+++ b/css/src/atomics/border.scss
@@ -2,6 +2,10 @@
 	border: $border-width solid $border !important;
 }
 
+.border-md {
+	border: $border-width-md solid $border !important;
+}
+
 .border-lg {
 	border: $border-width-lg solid $border !important;
 }
@@ -12,9 +16,13 @@
 
 // Rules for each side
 
-@each $border-key, $direction in $directions {
+@each $border-key, $direction in $logical-directions {
 	.border-#{$border-key} {
 		border-#{$direction}: $border-width solid $border !important;
+	}
+
+	.border-#{$border-key}-md {
+		border-#{$direction}: $border-width-md solid $border !important;
 	}
 
 	.border-#{$border-key}-lg {
@@ -31,6 +39,10 @@
 		border: $border-width solid $border !important;
 	}
 
+	.border-md-tablet {
+		border: $border-width-md solid $border !important;
+	}
+
 	.border-lg-tablet {
 		border: $border-width-lg solid $border !important;
 	}
@@ -41,9 +53,13 @@
 
 	// Rules for each side
 
-	@each $border-key, $direction in $directions {
+	@each $border-key, $direction in $logical-directions {
 		.border-#{$border-key}-tablet {
 			border-#{$direction}: $border-width solid $border !important;
+		}
+
+		.border-#{$border-key}-md-tablet {
+			border-#{$direction}: $border-width-md solid $border !important;
 		}
 
 		.border-#{$border-key}-lg-tablet {

--- a/css/src/tokens/border.scss
+++ b/css/src/tokens/border.scss
@@ -2,7 +2,8 @@
  * @sass-export-section="border"
  */
 $border-width: 1px !default;
-$border-width-lg: 0.5rem !default;
+$border-width-md: 0.125rem !default;
+$border-width-lg: 0.25rem !default;
 $border-radius: 0.25rem !default;
 $border-radius-lg: 0.5rem !default;
 //@end-sass-export-section

--- a/css/src/tokens/direction.scss
+++ b/css/src/tokens/direction.scss
@@ -16,3 +16,10 @@ $directions: (
 	'left': $user-left
 );
 //@end-sass-export-section
+
+$logical-directions: (
+	'top': 'block-start',
+	'right': 'inline-end',
+	'bottom': 'block-end',
+	'left': 'inline-start'
+);

--- a/site/src/atomics/border.md
+++ b/site/src/atomics/border.md
@@ -79,14 +79,20 @@ Currently two classes are available to set border radius:
 
 ### Size
 
-Additionally `-lg` may be added for a thicker border.
+Additionally `-md` and `-lg` may be added for a thicker border.
 
 ```html
-<div class="border-lg padding-sm">
+<div class="border-md padding-sm">
+	<p>Medium border</p>
+</div>
+<div class="border-md-tablet padding-sm margin-top-xs">
+	<p>Medium border on tablet+</p>
+</div>
+<div class="border-lg padding-sm margin-top-xs">
 	<p>Large border</p>
 </div>
 <div class="border-lg-tablet padding-sm margin-top-xs">
-	<p>Large border</p>
+	<p>Large border on tablet+</p>
 </div>
 ```
 


### PR DESCRIPTION
Task: task-533664

Link: preview-297

There's been a request for slightly more variant in the widths of border. Obliging here. Updating `.border-lg` to be slightly smaller, and adding `.border-md`.

Converts borders to use logical properties as well, instead of standard directions. Does this by adding a new `$logical-directions` map.

## Testing

1. Check out /border.md page to test.
https://design.docs.microsoft.com/pulls/297/atomics/border.html
