### PR TITLE
Adding event listeners to popover

### DIFF
--- a/.changeset/grumpy-experts-smell.md
+++ b/.changeset/grumpy-experts-smell.md
@@ -2,4 +2,4 @@
 '@microsoft/atlas-site': minor
 ---
 
-Adding event listeners to popover
+Adding event listeners to popover.

--- a/.changeset/grumpy-experts-smell.md
+++ b/.changeset/grumpy-experts-smell.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': minor
+---
+
+Adding event listeners to popover

--- a/css/src/components/popover.scss
+++ b/css/src/components/popover.scss
@@ -11,7 +11,7 @@ $popover-width: 224px !default;
 	summary {
 		list-style: none;
 
-		&::marker {
+		&::-webkit-details-marker {
 			display: none;
 		}
 	}

--- a/css/src/components/popover.scss
+++ b/css/src/components/popover.scss
@@ -25,7 +25,6 @@ $popover-width: 224px !default;
 		border-radius: $popover-border-radius;
 		background-color: $popover-background-color;
 		box-shadow: $popover-shadow;
-		overflow: hidden;
 		z-index: $zindex-popover;
 	}
 

--- a/css/src/components/popover.scss
+++ b/css/src/components/popover.scss
@@ -10,6 +10,10 @@ $popover-width: 224px !default;
 
 	summary {
 		list-style: none;
+
+		&::marker {
+			display: none;
+		}
 	}
 
 	.popover-content {

--- a/site/src/components/popover.md
+++ b/site/src/components/popover.md
@@ -53,21 +53,21 @@ You can apply almost any classes on the `summary` element to achieve the look yo
 
 ## Alignments
 
-Popover is left aligned by default, but also can be centered or right aligned relatively to the summary's width. Apply any of the corresponding classes to the `popover` element: `popover-right`, `popover-center`.
+Popover is left aligned by default, but also can be centered or right aligned relatively to the `summary`'s width. Apply any of the corresponding classes to the `popover` element: `popover-right`, `popover-center`.
 
 ```html
 <details class="popover margin-xxs">
 	<summary class="button">Popover aligned to the left</summary>
-	<div class="popover-content">Popover content.</div>
+	<div class="popover-content border">Popover content.</div>
 </details>
 
 <details class="popover popover-center margin-xxs">
 	<summary class="button">Popover centered</summary>
-	<div class="popover-content">Popover content.</div>
+	<div class="popover-content border">Popover content.</div>
 </details>
 
 <details class="popover popover-right margin-xxs">
 	<summary class="button">Popover aligned to the right</summary>
-	<div class="popover-content">Popover content.</div>
+	<div class="popover-content border">Popover content.</div>
 </details>
 ```

--- a/site/src/components/popover.md
+++ b/site/src/components/popover.md
@@ -53,7 +53,7 @@ You can apply almost any classes on the `summary` element to achieve the look yo
 
 ## Alignments
 
-Popover is left aligned by default, but also can be centered or right aligned. Apply any of the corresponding classes to the `popover` element: `popover-right`, `popover-center`.
+Popover is left aligned by default, but also can be centered or right aligned relatively to the summary's width. Apply any of the corresponding classes to the `popover` element: `popover-right`, `popover-center`.
 
 ```html
 <details class="popover margin-xxs">

--- a/site/src/scaffold/index.ts
+++ b/site/src/scaffold/index.ts
@@ -1,10 +1,10 @@
 import { handleCodeFilters } from './scripts/code-filter';
-import { initPopover } from './scripts/popover';
+import { initPopovers } from './scripts/popover';
 import { initTheme } from './scripts/theming';
 
 initTheme();
 handleCodeFilters();
 
-initPopover(document.body);
+initPopovers(document.body);
 
 // document.documentElement.classList.add('debug');

--- a/site/src/scaffold/index.ts
+++ b/site/src/scaffold/index.ts
@@ -1,7 +1,10 @@
 import { handleCodeFilters } from './scripts/code-filter';
+import { initPopover } from './scripts/popover';
 import { initTheme } from './scripts/theming';
 
 initTheme();
 handleCodeFilters();
+
+initPopover(document.body);
 
 // document.documentElement.classList.add('debug');

--- a/site/src/scaffold/scripts/popover.ts
+++ b/site/src/scaffold/scripts/popover.ts
@@ -1,52 +1,58 @@
 export function initPopovers(container: HTMLElement) {
-	container.addEventListener('click', (event: Event) => {
-		const targetPopover =
-			(event.target instanceof Element &&
-				(event.target.closest('details.popover') as HTMLDetailsElement)) ||
-			(event.target instanceof Element &&
-				(event.target.shadowRoot?.activeElement?.closest('details.popover') as HTMLDetailsElement));
+	container.addEventListener(
+		'toggle',
+		(event: Event) => {
+			const targetPopover =
+				(event.target instanceof Element &&
+					(event.target.closest('details.popover') as HTMLDetailsElement)) ||
+				(event.target instanceof Element &&
+					(event.target.shadowRoot?.activeElement?.closest(
+						'details.popover'
+					) as HTMLDetailsElement));
 
-		if (!targetPopover || targetPopover.open) {
-			return;
-		}
-
-		const keyHandler = (event: KeyboardEvent) => {
-			if (event.key === 'Escape') {
-				closePopovers();
-			}
-		};
-
-		const checkTarget = (event: Event) => {
-			if (!(event.target instanceof Element)) {
+			if (!targetPopover || !targetPopover.open) {
 				return;
 			}
 
-			if (!targetPopover?.contains(event.target)) {
-				closePopovers();
-			}
-		};
+			const keyHandler = (event: KeyboardEvent) => {
+				if (event.key === 'Escape') {
+					closePopovers();
+				}
+			};
 
-		const blurHandler = () => {
-			if (document.activeElement?.nodeName?.toLowerCase() === 'iframe') {
-				closePopovers();
-			}
-		};
+			const checkTarget = (event: Event) => {
+				if (!(event.target instanceof Element)) {
+					return;
+				}
 
-		const closePopovers = () => {
-			container.removeEventListener('focus', checkTarget, true);
-			container.removeEventListener('click', checkTarget);
-			container.removeEventListener('touchstart', checkTarget);
-			container.removeEventListener('keydown', keyHandler);
-			window.removeEventListener('blur', blurHandler);
-			if (targetPopover?.open) {
-				targetPopover.removeAttribute('open');
-			}
-		};
+				if (!targetPopover?.contains(event.target)) {
+					closePopovers();
+				}
+			};
 
-		container.addEventListener('focus', checkTarget, true);
-		container.addEventListener('click', checkTarget);
-		container.addEventListener('touchstart', checkTarget);
-		container.addEventListener('keydown', keyHandler);
-		window.addEventListener('blur', blurHandler);
-	});
+			const blurHandler = () => {
+				if (document.activeElement?.nodeName?.toLowerCase() === 'iframe') {
+					closePopovers();
+				}
+			};
+
+			const closePopovers = () => {
+				container.removeEventListener('focus', checkTarget, true);
+				container.removeEventListener('click', checkTarget);
+				container.removeEventListener('touchstart', checkTarget);
+				container.removeEventListener('keydown', keyHandler);
+				window.removeEventListener('blur', blurHandler);
+				if (targetPopover?.open) {
+					targetPopover.removeAttribute('open');
+				}
+			};
+
+			container.addEventListener('focus', checkTarget, true);
+			container.addEventListener('click', checkTarget);
+			container.addEventListener('touchstart', checkTarget);
+			container.addEventListener('keydown', keyHandler);
+			window.addEventListener('blur', blurHandler);
+		},
+		true
+	);
 }

--- a/site/src/scaffold/scripts/popover.ts
+++ b/site/src/scaffold/scripts/popover.ts
@@ -1,13 +1,5 @@
 export function initPopovers(container: HTMLElement) {
 	container.addEventListener('click', (event: Event) => {
-		const allPopovers: HTMLDetailsElement[] = Array.from(
-			container.querySelectorAll('details.popover')
-		);
-
-		if (allPopovers.length === 0) {
-			return;
-		}
-
 		let targetPopover: HTMLDetailsElement | null;
 		targetPopover =
 			event.target instanceof Element &&
@@ -29,10 +21,14 @@ export function initPopovers(container: HTMLElement) {
 			return;
 		}
 
-		if (!targetPopover.hasAttribute('open')) {
+		const allPopovers: HTMLDetailsElement[] = Array.from(
+			container.querySelectorAll('details.popover')
+		);
+
+		if (!targetPopover.open) {
 			const keyHandler = (event: KeyboardEvent) => {
 				if (event.key === 'Escape') {
-					closePopovers(allPopovers);
+					closePopovers();
 				}
 			};
 
@@ -42,32 +38,31 @@ export function initPopovers(container: HTMLElement) {
 				}
 
 				if (!targetPopover?.contains(event.target)) {
-					closePopovers(allPopovers);
+					targetPopover ? closePopovers([targetPopover]) : closePopovers();
 				}
 			};
 
 			const blurHandler = () => {
 				if ((document.activeElement?.nodeName || '').toLowerCase() === 'iframe') {
-					closePopovers(allPopovers);
+					closePopovers();
 				}
 			};
 
-			const closePopovers = (popovers: HTMLDetailsElement[]) => {
-				for (const popover of popovers) {
-					if (popover.hasAttribute('open')) {
-						popover.removeAttribute('open');
-					}
-				}
-
+			const closePopovers = (popovers: HTMLDetailsElement[] = allPopovers) => {
+				container.removeEventListener('focus', clickHandler, true);
 				container.removeEventListener('click', clickHandler);
 				container.removeEventListener('touchstart', clickHandler);
 				container.removeEventListener('keydown', keyHandler);
 				window.removeEventListener('blur', blurHandler);
+
+				for (const popover of popovers) {
+					if (popover.open) {
+						popover.removeAttribute('open');
+					}
+				}
 			};
 
-			const otherPopovers = allPopovers.filter(el => el !== targetPopover);
-			closePopovers(otherPopovers);
-
+			container.addEventListener('focus', clickHandler, true);
 			container.addEventListener('click', clickHandler);
 			container.addEventListener('touchstart', clickHandler);
 			container.addEventListener('keydown', keyHandler);

--- a/site/src/scaffold/scripts/popover.ts
+++ b/site/src/scaffold/scripts/popover.ts
@@ -1,0 +1,33 @@
+export function initPopover(container: Element) {
+	const popovers = container.querySelectorAll('details');
+
+	if (popovers.length === 0) {
+		return;
+	}
+
+	popovers.forEach(p =>
+		p.addEventListener('keydown', event => {
+			if (event.key === 'Escape') {
+				if (p.hasAttribute('open')) {
+					p.removeAttribute('open');
+				}
+				p.focus();
+			}
+		})
+	);
+
+	container.addEventListener('click', event => {
+		const targetPopover =
+			event.target instanceof Element && (event.target.closest('details') as HTMLDetailsElement)
+				? (event.target.closest('details') as HTMLDetailsElement)
+				: null;
+
+		const otherPopovers = Array.from(popovers).filter(el => el !== targetPopover);
+
+		otherPopovers.forEach(p => {
+			if (p.hasAttribute('open')) {
+				p.removeAttribute('open');
+			}
+		});
+	});
+}

--- a/site/src/scaffold/scripts/popover.ts
+++ b/site/src/scaffold/scripts/popover.ts
@@ -1,37 +1,42 @@
-export function initPopover(container: HTMLElement) {
+export function initPopovers(container: HTMLElement) {
 	container.addEventListener('click', event => {
-		const popovers: HTMLDetailsElement[] = Array.from(
+		const allPopovers: HTMLDetailsElement[] = Array.from(
 			container.querySelectorAll('details.popover')
 		);
 
-		if (popovers.length === 0) {
+		if (allPopovers.length === 0) {
 			return;
 		}
 
-		popovers.forEach(p =>
-			p.addEventListener('keydown', event => {
-				if (event.key === 'Escape') {
-					closePopover(p);
+		const keyHandler = (event: KeyboardEvent) => {
+			if (event.key === 'Escape') {
+				closePopovers(allPopovers);
+			}
+
+			if (targetPopover) {
+				targetPopover.removeEventListener('keydown', keyHandler);
+			}
+		};
+
+		const closePopovers = (popovers: HTMLDetailsElement[]) => {
+			for (const popover of popovers) {
+				if (popover.hasAttribute('open')) {
+					popover.removeAttribute('open');
 				}
-			})
-		);
+			}
+		};
 
 		const targetPopover =
-			event.target instanceof HTMLElement &&
+			(event.target instanceof HTMLElement || event.target instanceof SVGElement) &&
 			(event.target.closest('details.popover') as HTMLDetailsElement)
 				? (event.target.closest('details.popover') as HTMLDetailsElement)
 				: null;
 
-		const otherPopovers = popovers.filter(el => el !== targetPopover);
+		if (targetPopover) {
+			targetPopover.addEventListener('keydown', keyHandler);
+		}
 
-		otherPopovers.forEach(p => {
-			closePopover(p);
-		});
+		const otherPopovers = allPopovers.filter(el => el !== targetPopover);
+		closePopovers(otherPopovers);
 	});
-}
-
-function closePopover(popover: HTMLDetailsElement) {
-	if (popover.hasAttribute('open')) {
-		popover.removeAttribute('open');
-	}
 }

--- a/site/src/scaffold/scripts/popover.ts
+++ b/site/src/scaffold/scripts/popover.ts
@@ -1,33 +1,37 @@
-export function initPopover(container: Element) {
-	const popovers = container.querySelectorAll('details');
-
-	if (popovers.length === 0) {
-		return;
-	}
-
-	popovers.forEach(p =>
-		p.addEventListener('keydown', event => {
-			if (event.key === 'Escape') {
-				if (p.hasAttribute('open')) {
-					p.removeAttribute('open');
-				}
-				p.focus();
-			}
-		})
-	);
-
+export function initPopover(container: HTMLElement) {
 	container.addEventListener('click', event => {
+		const popovers: HTMLDetailsElement[] = Array.from(
+			container.querySelectorAll('details.popover')
+		);
+
+		if (popovers.length === 0) {
+			return;
+		}
+
+		popovers.forEach(p =>
+			p.addEventListener('keydown', event => {
+				if (event.key === 'Escape') {
+					closePopover(p);
+				}
+			})
+		);
+
 		const targetPopover =
-			event.target instanceof Element && (event.target.closest('details') as HTMLDetailsElement)
-				? (event.target.closest('details') as HTMLDetailsElement)
+			event.target instanceof HTMLElement &&
+			(event.target.closest('details.popover') as HTMLDetailsElement)
+				? (event.target.closest('details.popover') as HTMLDetailsElement)
 				: null;
 
-		const otherPopovers = Array.from(popovers).filter(el => el !== targetPopover);
+		const otherPopovers = popovers.filter(el => el !== targetPopover);
 
 		otherPopovers.forEach(p => {
-			if (p.hasAttribute('open')) {
-				p.removeAttribute('open');
-			}
+			closePopover(p);
 		});
 	});
+}
+
+function closePopover(popover: HTMLDetailsElement) {
+	if (popover.hasAttribute('open')) {
+		popover.removeAttribute('open');
+	}
 }

--- a/site/src/scaffold/scripts/popover.ts
+++ b/site/src/scaffold/scripts/popover.ts
@@ -41,16 +41,13 @@ export function initPopovers(container: HTMLElement) {
 					return;
 				}
 
-				if (!(targetPopover && targetPopover.contains(event.target))) {
+				if (!targetPopover?.contains(event.target)) {
 					closePopovers(allPopovers);
 				}
 			};
 
 			const blurHandler = () => {
-				if (
-					((document.activeElement && document.activeElement.nodeName) || '').toLowerCase() ===
-					'iframe'
-				) {
+				if ((document.activeElement?.nodeName || '').toLowerCase() === 'iframe') {
 					closePopovers(allPopovers);
 				}
 			};

--- a/site/src/scaffold/scripts/popover.ts
+++ b/site/src/scaffold/scripts/popover.ts
@@ -1,5 +1,5 @@
 export function initPopovers(container: HTMLElement) {
-	container.addEventListener('click', event => {
+	container.addEventListener('click', (event: Event) => {
 		const allPopovers: HTMLDetailsElement[] = Array.from(
 			container.querySelectorAll('details.popover')
 		);
@@ -8,35 +8,73 @@ export function initPopovers(container: HTMLElement) {
 			return;
 		}
 
-		const keyHandler = (event: KeyboardEvent) => {
-			if (event.key === 'Escape') {
-				closePopovers(allPopovers);
-			}
-
-			if (targetPopover) {
-				targetPopover.removeEventListener('keydown', keyHandler);
-			}
-		};
-
-		const closePopovers = (popovers: HTMLDetailsElement[]) => {
-			for (const popover of popovers) {
-				if (popover.hasAttribute('open')) {
-					popover.removeAttribute('open');
-				}
-			}
-		};
-
-		const targetPopover =
-			(event.target instanceof HTMLElement || event.target instanceof SVGElement) &&
+		let targetPopover: HTMLDetailsElement | null;
+		targetPopover =
+			event.target instanceof Element &&
 			(event.target.closest('details.popover') as HTMLDetailsElement)
 				? (event.target.closest('details.popover') as HTMLDetailsElement)
 				: null;
 
-		if (targetPopover) {
-			targetPopover.addEventListener('keydown', keyHandler);
+		if (!targetPopover) {
+			targetPopover =
+				event.target instanceof Element &&
+				event.target.shadowRoot &&
+				event.target.shadowRoot.activeElement &&
+				(event.target.shadowRoot.activeElement.closest('details.popover') as HTMLDetailsElement)
+					? (event.target.shadowRoot.activeElement.closest('details.popover') as HTMLDetailsElement)
+					: null;
 		}
 
-		const otherPopovers = allPopovers.filter(el => el !== targetPopover);
-		closePopovers(otherPopovers);
+		if (!targetPopover) {
+			return;
+		}
+
+		if (!targetPopover.hasAttribute('open')) {
+			const keyHandler = (event: KeyboardEvent) => {
+				if (event.key === 'Escape') {
+					closePopovers(allPopovers);
+				}
+			};
+
+			const clickHandler = (event: Event) => {
+				if (!(event.target instanceof Element)) {
+					return;
+				}
+
+				if (!(targetPopover && targetPopover.contains(event.target))) {
+					closePopovers(allPopovers);
+				}
+			};
+
+			const blurHandler = () => {
+				if (
+					((document.activeElement && document.activeElement.nodeName) || '').toLowerCase() ===
+					'iframe'
+				) {
+					closePopovers(allPopovers);
+				}
+			};
+
+			const closePopovers = (popovers: HTMLDetailsElement[]) => {
+				for (const popover of popovers) {
+					if (popover.hasAttribute('open')) {
+						popover.removeAttribute('open');
+					}
+				}
+
+				container.removeEventListener('click', clickHandler);
+				container.removeEventListener('touchstart', clickHandler);
+				container.removeEventListener('keydown', keyHandler);
+				window.removeEventListener('blur', blurHandler);
+			};
+
+			const otherPopovers = allPopovers.filter(el => el !== targetPopover);
+			closePopovers(otherPopovers);
+
+			container.addEventListener('click', clickHandler);
+			container.addEventListener('touchstart', clickHandler);
+			container.addEventListener('keydown', keyHandler);
+			window.addEventListener('blur', blurHandler);
+		}
 	});
 }


### PR DESCRIPTION
Task: task-533553

Link: preview-299

Adding event listeners to the Atlas' site.

## Testing

1. Go to [popover](https://design.docs.microsoft.com/pulls/299/components/popover.html) page
2. Try to open different popovers. Just one popover can be opened at a time
3. Trigger the popover. After clicking the Escape button popover should disappear, focus is on the details' summary
4. Trigger the popover. Click somewhere on a page. An opened popover should disappear
5. Trigger the popover. Using keyboard move focus away from the popover. Popover should close
6. Testing nesting popovers. Using the dev tools directly in the browser, paste one popover inside another. Opening the inner popover won't close the parent. Clicking inside the child popover content - won't close any of the popovers. Clicking the parent's popover content, while the inner one is open, would close the child popover