### PR TITLE
Flex atomics extension

### DIFF
--- a/.changeset/honest-lies-divide.md
+++ b/.changeset/honest-lies-divide.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Add flex-wrap-nowrap and flex-wrap-nowrap-tablet Atomics.

--- a/.changeset/honest-suns-exist.md
+++ b/.changeset/honest-suns-exist.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Add flex-direction-row(-tablet) to Atomics to allow for screensize specific layout shifts with flex Atomics only.

--- a/css/src/atomics/flex.scss
+++ b/css/src/atomics/flex.scss
@@ -32,6 +32,7 @@ $flex-atomics: (
 		stretch
 	),
 	'flex-direction': (
+		row,
 		column,
 		column-reverse,
 		row-reverse

--- a/css/src/atomics/flex.scss
+++ b/css/src/atomics/flex.scss
@@ -38,6 +38,7 @@ $flex-atomics: (
 		row-reverse
 	),
 	'flex-wrap': (
+		nowrap,
 		wrap,
 		wrap-reverse
 	),


### PR DESCRIPTION
Task: task-[work-item-number]

Link: preview-306

Enabling a few more values in the flexbox atomics. These values were intentionally omitted at my advice due to some flawed logic. I'd thought that we should omit them because they were the default value for a given property (like `flex-wrap: nowrap`), however, now I believe they should be included to fit use cases where layouts switch from mobile to tablet. Here's a use case:

```html
// you would like a column-ish layout on mobile, and a row layout on tablet.
<article class="display-flex flex-direction-column flex-direction-row-tablet">
  [...]
</article>

// you would like elements to not wrap on mobile, but to wrap on tablet and greater
<article class="display-flex flex-wrap-nowrap flex-wrap-wrap-tablet">
  [...]
</article>
```

Haven't updated documentation to include these, since we still working on documenation for flex atomics as part of a separate item.