### PR TITLE
update release to use changeset/action@v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       # https://github.com/changesets/action
       - name: Publish on version increment
-        uses: changesets/action@master
+        uses: changesets/action@v1
         with:
           publish: npx changeset publish
         env:


### PR DESCRIPTION
Warning:

```
Warning: The workflow file using `changesets/action` is currently using `@master` as the version. This branch has been frozen and deprecated. Please update your workflow to either use `@v1` or a specific commit SHA that is tagged.
```

Followed instructions updated it. No changeset necessary here.