### PR TITLE
horizontal auto margin spacing atomics

### DIFF
--- a/.changeset/brown-ducks-wonder.md
+++ b/.changeset/brown-ducks-wonder.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-css': minor
+'@microsoft/atlas-site': minor
+---
+
+Add horizontal spacing atomics that target margin: auto. Ex. .margin-inline-auto, .margin-left-auto-tablet.

--- a/css/src/atomics/index.scss
+++ b/css/src/atomics/index.scss
@@ -4,6 +4,7 @@
 @import './display.scss';
 @import './overflow.scss';
 @import './shadow.scss';
+@import './spacing-auto.scss';
 @import './spacing.scss';
 @import './flex.scss';
 @import './position.scss';

--- a/css/src/atomics/spacing-auto.scss
+++ b/css/src/atomics/spacing-auto.scss
@@ -1,0 +1,34 @@
+$auto-spacing-properties: 'margin-inline', 'margin-left', 'margin-right' !default;
+$separator: '-';
+
+@each $property in $auto-spacing-properties {
+	// .<property>-auto
+	.#{$property}#{$separator}auto {
+		#{$property}: auto !important;
+	}
+}
+
+// .<property>-auto-<screensize>
+@each $property in $auto-spacing-properties {
+	@include tablet {
+		.#{$property}#{$separator}auto#{$separator}tablet {
+			#{$property}: auto !important;
+		}
+	}
+}
+
+@each $property in $auto-spacing-properties {
+	@include desktop {
+		.#{$property}#{$separator}auto#{$separator}desktop {
+			#{$property}: auto !important;
+		}
+	}
+}
+
+@each $property in $auto-spacing-properties {
+	@include widescreen {
+		.#{$property}#{$separator}auto#{$separator}widescreen {
+			#{$property}: auto !important;
+		}
+	}
+}

--- a/css/src/atomics/spacing.scss
+++ b/css/src/atomics/spacing.scss
@@ -1,4 +1,4 @@
-$separator: '-';
+$separator: '-' !default;
 $spacing-properties: 'margin', 'margin-inline', 'margin-block', 'margin-top', 'margin-bottom',
 	'margin-left', 'margin-right', 'padding', 'padding-inline', 'padding-block', 'padding-top',
 	'padding-bottom', 'padding-left', 'padding-right' !default;

--- a/site/src/atomics/spacing.md
+++ b/site/src/atomics/spacing.md
@@ -11,6 +11,7 @@ Spacing atomics can be used to add margin or padding on elements. They are espec
 | cssproperty                                                                                                                                                                                                            | value                                                      | screensize                        |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | --------------------------------- |
 | `margin`, `padding`, `margin-block`, `padding-block`,`margin-inline`, `padding-inline`, `margin-top`, `padding-top`, `margin-right`, `padding-right`, `margin-bottom`, `padding-bottom`, `margin-left`, `padding-left` | `xxs`, `xs`, `sm`, `md`, `lg`, `xl`, `xxl`, `xxxl`, `none` | `tablet`, `desktop`, `widescreen` |
+| `margin-inline` `margin-right`, `margin-left`                                                                                                                                                                          | `auto`                                                     | `tablet`, `desktop`, `widescreen` |
 
 ## Usage
 
@@ -60,9 +61,24 @@ Appending a screen size to an atomic class can be used to apply responsive sizin
 </div>
 ```
 
+### The auto value
+
+Because the `auto` value is inapplicable to padding, and less useful when used with top, bottom, and block margin properties, it has a much smaller subset of properties: `margin-left`, `margin-right`, and `margin-inline`. You can still use responsive rules just like any other spacing atomic.
+
+```html
+<div class="display-flex flex-direction-column">
+	<div class="margin-left-auto margin-bottom-md padding-sm border">Auto left margin</div>
+	<div class="margin-right-auto margin-bottom-md padding-sm border">Auto right margin</div>
+	<div class="margin-inline-auto margin-bottom-md padding-sm border">Auto side margin</div>
+</div>
+```
+
 ## Available classes
 
 ```atomics-filter
+.margin-left-auto
+.margin-right-auto
+.margin-inline-auto
 .margin-xxs
 .margin-xs
 .margin-sm
@@ -567,4 +583,13 @@ Appending a screen size to an atomic class can be used to apply responsive sizin
 .padding-right-xxl-widescreen
 .padding-right-xxxl-widescreen
 .padding-right-none-widescreen
+.margin-left-auto-tablet
+.margin-right-auto-tablet
+.margin-inline-auto-tablet
+.margin-left-auto-desktop
+.margin-right-auto-desktop
+.margin-inline-auto-desktop
+.margin-left-auto-widescreen
+.margin-right-auto-widescreen
+.margin-inline-auto-widescreen
 ```


### PR DESCRIPTION
Link: preview-312

https://design.docs.microsoft.com/pulls/312/atomics/spacing.html

Because the `auto` value is inapplicable to padding, and less useful when used with top, bottom, and block margin properties, it has a much smaller subset of properties: `margin-left`, `margin-right`, and `margin-inline`. You can still use responsive rules just like any other spacing atomic.

In order to keep the more systematic `spacing.scss` clean and free of exceptions, I included a new file called `auto-spacing.scss`. This is imported _before_ `spacing.scss` to ensure that all `none` and `specific` values take precedence over auto values.

## Testing

1. Visit page.
2. See additional information for responsive / specificity testing done.

## Additional information

Tested specificity with the following code, but chose not to commit it.

```html
<div class="display-flex flex-direction-column">
	<div class="margin-left-sm margin-left-auto-tablet margin-bottom-md padding-sm border">Auto left margin</div>
	<div class="margin-right-sm margin-right-auto-tablet margin-bottom-md padding-sm border">Auto right margin</div>
	<div class="margin-inline-sm margin-inline-auto-tablet margin-bottom-md padding-sm border">Auto side margin</div>
</div>

<div class="display-flex flex-direction-column">
	<div class="margin-left-auto margin-left-sm-tablet margin-bottom-md padding-sm border">
		Auto left margin
	</div>
	<div class="margin-right-auto margin-right-sm-tablet margin-bottom-md padding-sm border">
		Auto right margin
	</div>
	<div class="margin-inline-auto margin-inline-sm-tablet margin-bottom-md padding-sm border">
		Auto side margin
	</div>
</div>
```

