### PR TITLE
add link button documentation and a reference to it in .button docs

### DIFF
--- a/.changeset/hot-cars-compare.md
+++ b/.changeset/hot-cars-compare.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': minor
+---
+
+add link button documentation and a reference to it in .button docs

--- a/site/src/components/button.md
+++ b/site/src/components/button.md
@@ -35,7 +35,7 @@ All buttons, by default, are secondary buttons. There are three gradutating seco
 
 ## Primary
 
-A visual style used to highlight only the most important actions. To avoid confusing users, don't use more than more primary button within a section or view.
+A visual style used to highlight only the most important actions. To avoid confusing users, don't use more than more primary button within a section or view. Note that the clear variant of primary buttons must be used on a very light background or it will not pass constrast requirements. If you run into this issue, try using [`link-button`](~/src/components/link-button.md), which defaults to a slightly darker blue for this very reason.
 
 | Type     | Class                                          | Default State                                                        | Hover                                                                           |
 | -------- | ---------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- |

--- a/site/src/components/button.md
+++ b/site/src/components/button.md
@@ -35,7 +35,7 @@ All buttons, by default, are secondary buttons. There are three gradutating seco
 
 ## Primary
 
-A visual style used to highlight only the most important actions. To avoid confusing users, don't use more than more primary button within a section or view. Note that the clear variant of primary buttons must be used on a very light background or it will not pass constrast requirements. If you run into this issue, try using [`link-button`](~/src/components/link-button.md), which defaults to a slightly darker blue for this very reason.
+A visual style used to highlight only the most important actions. To avoid confusing users, don't use more than one primary button within a section or view. Note that the clear variant of primary buttons must be used on a very light background or it will not pass constrast requirements. If you run into this issue, try using [`link-button`](~/src/components/link-button.md), which defaults to a slightly darker blue for this very reason.
 
 | Type     | Class                                          | Default State                                                        | Hover                                                                           |
 | -------- | ---------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- |

--- a/site/src/components/link-button.md
+++ b/site/src/components/link-button.md
@@ -1,0 +1,15 @@
+---
+title: Link button
+description: .link-button the Atlas Design System
+template: standard
+---
+
+# Link Button
+
+Link button is a simple component that makes a `<button>` element adopt the styles of a bare anchor.
+
+## Usage
+
+```html
+<button class="link-button">I look like an anchor, but I'm really a button!</button>
+```


### PR DESCRIPTION
Updating documentation after a recent conversation. Noticed we hadn't written anything for `link-button` yet.

Link: preview-321
https://design.docs.microsoft.com/pulls/321/components/link-button.html
https://design.docs.microsoft.com/pulls/321/components/button.html