### PR TITLE
core folder to include a bare-elements.scss file 

### DIFF
--- a/.changeset/hip-chefs-play.md
+++ b/.changeset/hip-chefs-play.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+update core folder to include a bare-elements.scss file for styling bare elements. Include chromium bugfix for <details> box sizing lack of inheritance.

--- a/css/src/core/bare-elements.scss
+++ b/css/src/core/bare-elements.scss
@@ -1,0 +1,5 @@
+// https://bugs.chromium.org/p/chromium/issues/detail?id=589475&q=details%20box-sizing&can=2
+
+:is(details > *) {
+	box-sizing: border-box;
+}

--- a/css/src/core/index.scss
+++ b/css/src/core/index.scss
@@ -4,3 +4,4 @@
 @import './font-stack.scss';
 @import './animations.scss';
 @import './focus.scss';
+@import './bare-elements.scss';


### PR DESCRIPTION
…are elements. Include chromium bugfix for `<details>` box sizing lack of inheritance.

Task: Breadcrumbs content header work.

Link: preview-322
