### PR TITLE
Created togglable sidebar for tablet view and modified layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 		},
 		"css": {
 			"name": "@microsoft/atlas-css",
-			"version": "3.6.0",
+			"version": "3.8.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@microsoft/stylelint-config-atlas": "4.0.0",
@@ -14681,10 +14681,10 @@
 		},
 		"site": {
 			"name": "@microsoft/atlas-site",
-			"version": "0.13.0",
+			"version": "0.15.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@microsoft/atlas-css": "^3.6.0",
+				"@microsoft/atlas-css": "^3.8.0",
 				"@microsoft/parcel-transformer-markdown-html": "^2.5.1",
 				"@parcel/transformer-sass": "^2.0.1",
 				"@typescript-eslint/eslint-plugin": "^5.9.0",
@@ -16081,7 +16081,7 @@
 		"@microsoft/atlas-site": {
 			"version": "file:site",
 			"requires": {
-				"@microsoft/atlas-css": "^3.6.0",
+				"@microsoft/atlas-css": "^3.8.0",
 				"@microsoft/parcel-transformer-markdown-html": "^2.5.1",
 				"@parcel/transformer-sass": "^2.0.1",
 				"@typescript-eslint/eslint-plugin": "^5.9.0",

--- a/site/src/scaffold/index.scss
+++ b/site/src/scaffold/index.scss
@@ -3,3 +3,56 @@
 @import './styles/height.scss';
 @import './styles/overflow.scss';
 @import './code-block.scss';
+
+@include tablet {
+	#nav-mobile {
+		position: fixed;
+		margin-top: 1em;
+		left: 0;
+		height: 100%;
+		width: 250px;
+	}
+	.sidebar.open {
+		animation-name: showSidebar;
+		transform: translate(0, 0);
+		animation-duration: 1s;
+	}
+	.sidebar {
+		transform: translate(-280px, 0);
+	}
+}
+
+@include desktop {
+	#nav-mobile {
+		display: none;
+	}
+	.sidebar.open {
+		transform: translate(0, 0);
+	}
+	.sidebar {
+		transform: translate(0, 0);
+	}
+}
+
+@include widescreen {
+	#nav-mobile {
+		display: none;
+	}
+	.sidebar.open {
+		transform: translate(0, 0);
+	}
+	.sidebar {
+		transform: translate(0, 0);
+	}
+}
+
+@keyframes showSidebar {
+	0% {
+		opacity: 0;
+		transform: translate(-280px, 0);
+	}
+	100% {
+		opacity: 1;
+		transform: translate(0, 0);
+	}
+}

--- a/site/src/scaffold/index.ts
+++ b/site/src/scaffold/index.ts
@@ -7,3 +7,12 @@ initTheme();
 initPopovers(document.body);
 handleCodeFilters();
 handleFigmaFullScreenRequest();
+
+const navbarMobile = document.querySelector('#nav-mobile');
+const navbarToggle = document.querySelector('#navbar-toggle');
+
+const toggleSidebar = () => {
+	navbarMobile?.classList.toggle('open');
+};
+
+navbarToggle?.addEventListener('click', toggleSidebar);

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -13,8 +13,31 @@
 		<script type="module" src="~/src/scaffold/index.ts"></script>
 	</head>
 	<body id="body">
-		<header id="header" class="border-bottom display-flex justify-content-space-between align-items-center">
-			<a href="~/src/index.md" class="color-text text-decoration-none font-weight-bold">
+		<header id="header" class="border-bottom align-items-center">
+			<button type="button" area-haspopup="true" area-expanded="true" id="navbar-toggle" class="display-none-desktop">☰</button>
+
+			<nav id="nav-mobile" class="sidebar background-color-body">
+			<div class="padding-left-sm">
+			{{#toc}}
+				{{#entries}}
+					{{#isDirectory}}
+						<div class="margin-top-xs">
+							<p class="font-weight-semibold">{{name}}</p>
+							<div class="margin-left-xs">
+								{{#children}}
+									<a class="display-block margin-top-xxs" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+								{{/children}}
+							</div>
+						</div>
+					{{/isDirectory}}
+					{{^children.0}}
+						<a class="display-block margin-top-xs" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+					{{/children.0}}
+				{{/entries}}
+			{{/toc}}
+			</div>
+		</nav>
+			<a href="~/src/index.md" class="color-text text-decoration-none font-weight-bold margin-left-xs">
 				<span class="margin-right-xxs icon">
 					<svg width="21" height="21" viewBox="0 0 21 21" fill="none" xmlns="http://www.w3.org/2000/svg">
 						<rect width="10" height="10" class="fill-current-color" />
@@ -26,6 +49,26 @@
 				<span class="font-size-xl">Atlas Design</span>
 			</a>
 		</header>
+
+		<nav id="nav">
+			{{#toc}}
+				{{#entries}}
+					{{#isDirectory}}
+						<div class="margin-top-xs">
+							<p class="font-weight-semibold">{{name}}</p>
+							<div class="margin-left-xs">
+								{{#children}}
+									<a class="display-block margin-top-xxs" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+								{{/children}}
+							</div>
+						</div>
+					{{/isDirectory}}
+					{{^children.0}}
+						<a class="display-block margin-top-xs" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+					{{/children.0}}
+				{{/entries}}
+			{{/toc}}
+		</nav>		
 
 		<main id="main">
 			{{{breadcrumbs}}}
@@ -76,26 +119,6 @@
 				{{/figmaEmbed}}
 			</div>
 		</main>
-
-		<nav id="nav">
-			{{#toc}}
-				{{#entries}}
-					{{#isDirectory}}
-						<div class="margin-top-xs">
-							<p class="font-weight-semibold">{{name}}</p>
-							<div class="margin-left-xs">
-								{{#children}}
-									<a class="display-block margin-top-xxs" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
-								{{/children}}
-							</div>
-						</div>
-					{{/isDirectory}}
-					{{^children.0}}
-						<a class="display-block margin-top-xs" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
-					{{/children.0}}
-				{{/entries}}
-			{{/toc}}
-		</nav>
 
 		<aside id="aside">
 			<!-- empty for now -->

--- a/site/src/scaffold/styles/layout.scss
+++ b/site/src/scaffold/styles/layout.scss
@@ -17,8 +17,8 @@ $size-bar-width: 300px - strip-units($gap-size) * $document-font-size;
 		grid-template: auto 1fr auto auto / $size-bar-width 1fr; // [ rows / columns ]
 		grid-template-areas:
 			'header header'
-			'nav main'
-			'nav aside'
+			'main main'
+			'aside aside'
 			'footer footer';
 	}
 
@@ -37,7 +37,7 @@ $size-bar-width: 300px - strip-units($gap-size) * $document-font-size;
 
 		grid-template-areas:
 			'header header header header header'
-			'. nav main aside .'
+			'nav main main aside .'
 			'footer footer footer footer footer';
 	}
 }
@@ -52,6 +52,9 @@ $size-bar-width: 300px - strip-units($gap-size) * $document-font-size;
 
 #header {
 	grid-area: header;
+	position: sticky;
+	top: 0;
+	z-index: 2;
 }
 
 #nav {


### PR DESCRIPTION
Overview:
- Created a sidebar for the tablet and mobile layout.
- Altered the CSS Grid layout to show more of the documentation since aside isn't being used(yet).
- Header bar is now sticky.
- Header bar has `$primary-background`

## Testing

1. Resize window to Tablet and mobile view
2. Click menu button on top-left of header bar.
   Expected result: You should see the sidebar expand and collapse when clicking the sidebar button in tablet/mobile view

## Additional information