### PR TITLE
Adding an additional popover closing method

### DIFF
--- a/.changeset/wicked-points-rhyme.md
+++ b/.changeset/wicked-points-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': patch
+---
+
+Add data-popover-close attribute to allow an additional closing method to the popover.

--- a/site/src/components/popover.md
+++ b/site/src/components/popover.md
@@ -71,3 +71,26 @@ Popover is left aligned by default, but also can be centered or right aligned re
 	<div class="popover-content border">Popover content.</div>
 </details>
 ```
+
+## Closing popover
+
+An additional way to collapse the popover is to add the `data-close` attribute to the link/button in the content.
+
+```html
+<details class="popover margin-xxs">
+	<summary class="button">Popover</summary>
+	<div class="popover-content border">
+		<ul>
+			<li class="margin-bottom-xxs">
+				<a href="#">Link</a>
+			</li>
+			<li class="margin-bottom-xxs">
+				<a href="#">Link</a>
+			</li>
+			<li>
+				<a href="#" data-close>Closing link</a>
+			</li>
+		</ul>
+	</div>
+</details>
+```

--- a/site/src/components/popover.md
+++ b/site/src/components/popover.md
@@ -71,26 +71,3 @@ Popover is left aligned by default, but also can be centered or right aligned re
 	<div class="popover-content border">Popover content.</div>
 </details>
 ```
-
-## Closing popover
-
-An additional way to collapse the popover is to add the `data-close` attribute to the link/button in the content.
-
-```html
-<details class="popover margin-xxs">
-	<summary class="button">Popover</summary>
-	<div class="popover-content border">
-		<ul>
-			<li class="margin-bottom-xxs">
-				<a href="#">Link</a>
-			</li>
-			<li class="margin-bottom-xxs">
-				<a href="#">Link</a>
-			</li>
-			<li>
-				<a href="#" data-close>Closing link</a>
-			</li>
-		</ul>
-	</div>
-</details>
-```

--- a/site/src/scaffold/scripts/popover.ts
+++ b/site/src/scaffold/scripts/popover.ts
@@ -29,7 +29,7 @@ export function initPopovers(container: HTMLElement) {
 					closePopovers();
 				}
 
-				if (event.type === 'click' && event.target.hasAttribute('data-close')) {
+				if (event.type === 'click' && event.target.hasAttribute('data-popover-close')) {
 					closePopovers();
 				}
 			};

--- a/site/src/scaffold/scripts/popover.ts
+++ b/site/src/scaffold/scripts/popover.ts
@@ -28,6 +28,10 @@ export function initPopovers(container: HTMLElement) {
 				if (!targetPopover?.contains(event.target)) {
 					closePopovers();
 				}
+
+				if (event.type === 'click' && event.target.hasAttribute('data-close')) {
+					closePopovers();
+				}
 			};
 
 			const blurHandler = () => {


### PR DESCRIPTION
Task: task-[work-item-number]

Link: preview-326

Adding the `data-close` attribute to the popover's main content link/button would collapse it after a click.

## Testing

1. Step one
2. Step two
   Expected result:

## Additional information

[Optional]
