### PR TITLE
Add small border to .popover-content, equivalent to .border class.

### DIFF
--- a/.changeset/thick-oranges-worry.md
+++ b/.changeset/thick-oranges-worry.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-css': patch
+'@microsoft/atlas-site': patch
+---
+
+Add small border to .popover-content, equivalent to .border class.

--- a/css/src/components/popover.scss
+++ b/css/src/components/popover.scss
@@ -1,5 +1,5 @@
 $popover-background-color: $body-background !default;
-$popover-border: $border-width solid $border-white-high-contrast !default;
+$popover-border: $border-width solid $border !default;
 $popover-border-radius: $border-radius !default;
 $popover-shadow: $box-shadow-heavy !default;
 $popover-width: 224px !default;

--- a/site/src/components/popover.md
+++ b/site/src/components/popover.md
@@ -58,16 +58,16 @@ Popover is left aligned by default, but also can be centered or right aligned re
 ```html
 <details class="popover margin-xxs">
 	<summary class="button">Popover aligned to the left</summary>
-	<div class="popover-content border">Popover content.</div>
+	<div class="popover-content">Popover content.</div>
 </details>
 
 <details class="popover popover-center margin-xxs">
 	<summary class="button">Popover centered</summary>
-	<div class="popover-content border">Popover content.</div>
+	<div class="popover-content">Popover content.</div>
 </details>
 
 <details class="popover popover-right margin-xxs">
 	<summary class="button">Popover aligned to the right</summary>
-	<div class="popover-content border">Popover content.</div>
+	<div class="popover-content">Popover content.</div>
 </details>
 ```


### PR DESCRIPTION
Task: task-516183

Link: preview-327

It's hard to see the .popover menu on dark themes. Adding a border.

## Testing

1. Visit link. Click a popover trigger.
