### PR TITLE
add htmlnanorc to root, address svg viewbox issue

### DIFF
--- a/.htmlnanorc
+++ b/.htmlnanorc
@@ -1,0 +1,3 @@
+{
+  "minifySvg": false
+}


### PR DESCRIPTION
Task: task-539422

Link: preview-335

`.htmlnanorc` has to be in the root directory apparent in order to shut off svg minification. Not very monorepo friendly, but what can you do?

## Testing

Look at the logo in the header.

1. Compare a previous PR: https://design.docs.microsoft.com/pulls/334
2. With this PR: https://design.docs.microsoft.com/pulls/335
