### PR TITLE
Popover - fixing closing event listener

### DIFF
--- a/.changeset/rude-bees-dress.md
+++ b/.changeset/rude-bees-dress.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': patch
+---
+
+Fixing popover's closing even listener.

--- a/site/src/scaffold/scripts/popover.ts
+++ b/site/src/scaffold/scripts/popover.ts
@@ -29,7 +29,7 @@ export function initPopovers(container: HTMLElement) {
 					closePopovers();
 				}
 
-				if (event.type === 'click' && event.target.hasAttribute('data-popover-close')) {
+				if (event.type === 'click' && event.target.closest('[data-popover-close]')) {
 					closePopovers();
 				}
 			};


### PR DESCRIPTION
Task: task-[work-item-number]

Link: preview-341

Fixing additional closing event listener: covering case when there is an icon inside the button.

## Testing

1. Go to the popover page
2. Manually add this - `<button class="button margin-top-xs" data-popover-close><span>Close the popover</span></button>` ` into any popover's content.
3. Clicking this button should collapse the popover