### PR TITLE
update sm/lg control font size vars

### DIFF
--- a/.changeset/four-mice-decide.md
+++ b/.changeset/four-mice-decide.md
@@ -2,4 +2,4 @@
 '@microsoft/atlas-css': patch
 ---
 
-Update control-sm & control-lg font size variables
+Update control-sm & control-lg font size variables.

--- a/.changeset/four-mice-decide.md
+++ b/.changeset/four-mice-decide.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Update control-sm & control-lg font size variables

--- a/css/src/mixins/control.scss
+++ b/css/src/mixins/control.scss
@@ -2,6 +2,9 @@ $control-radius: $radius !default;
 $control-radius-sm: $radius-sm !default;
 
 $control-font-size: $font-size-7 !default;
+$control-sm-font-size: $font-size-8 !default;
+$control-lg-font-size: $font-size-6 !default;
+
 $control-border-width: 1px !default;
 
 $control-padding-vertical: calc(0.375em - #{$control-border-width}) !default;
@@ -34,9 +37,9 @@ $control-padding-horizontal: calc(0.625em - #{$control-border-width}) !default;
 
 @mixin control-sm {
 	border-radius: $control-radius-sm;
-	font-size: $font-size-sm;
+	font-size: $control-sm-font-size;
 }
 
 @mixin control-lg {
-	font-size: $font-size-lg;
+	font-size: $control-lg-font-size;
 }


### PR DESCRIPTION
Task: task-515429

Link: preview-342

Replaces control-sm & control-lg font size vars in control.scss

## Testing

1.  Tested locally by installing a local .tgz to docs-ui
