### PR TITLE
patch logical properties into popover

### DIFF
--- a/.changeset/pink-tools-glow.md
+++ b/.changeset/pink-tools-glow.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Bugfix: in popover component, use logical properties instead of `left` and `right`.

--- a/css/src/components/popover.scss
+++ b/css/src/components/popover.scss
@@ -30,13 +30,13 @@ $popover-width: 224px !default;
 
 	&.popover-right {
 		.popover-content {
-			right: 0;
+			inset-inline-end: 0;
 		}
 	}
 
 	&.popover-center {
 		.popover-content {
-			left: 50%;
+			inset-inline-start: 50%;
 			transform: translateX(-50%);
 		}
 	}

--- a/css/src/components/popover.scss
+++ b/css/src/components/popover.scss
@@ -36,8 +36,7 @@ $popover-width: 224px !default;
 
 	&.popover-center {
 		.popover-content {
-			inset-inline-start: 50%;
-			transform: translateX(-50%);
+			inset-inline-start: -25%;
 		}
 	}
 }


### PR DESCRIPTION
Link: preview-344

Popover has some unexpected results in right to left reading formats because we forgot to update this component when we rolled out logical properties.

https://design.docs.microsoft.com/pulls/344/components/popover.html

## Testing

1. View popover page for this PR.
2. Paste the following into the JS console: `document.documentElement.dir = 'rtl'`
3. Test popovers, ensure they're flipped.
