### PR TITLE
Removing border class from the table-wrapper

### DIFF
--- a/.changeset/eight-clocks-press.md
+++ b/.changeset/eight-clocks-press.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/parcel-transformer-markdown-html': patch
+---
+
+Removing border from the table-wrapper.

--- a/plugins/parcel-transformer-markdown-html/lib/index.js
+++ b/plugins/parcel-transformer-markdown-html/lib/index.js
@@ -100,7 +100,7 @@ const markedOptions = {
 	},
 	table(header, body) {
 		return `
-			<div class="markdown border table-wrapper margin-top-sm">
+			<div class="markdown table-wrapper margin-top-sm">
 				<table class="table">
 					<thead>${header}</thead>
 					<tbody>${body}</tbody>


### PR DESCRIPTION
## Testing

1. Visit [button](https://design.docs.microsoft.com/pulls/348/components/button.html) (or any other page that has a table) 
2. You should not see the extra border around the table (applied on `.table-wrapper` container)
