### PR TITLE
Add position to checkbox-check

### DIFF
--- a/.changeset/chilly-badgers-pretend.md
+++ b/.changeset/chilly-badgers-pretend.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Update checkbox positioning.

--- a/css/src/components/form/checkbox.scss
+++ b/css/src/components/form/checkbox.scss
@@ -36,6 +36,7 @@ $checkbox-spacing: $spacer-3 !default;
 
 	.checkbox-check {
 		display: flex;
+		position: relative;
 		flex-shrink: 0;
 		align-items: center;
 		justify-content: center;


### PR DESCRIPTION
Task: task-[559170](https://dev.azure.com/ceapex/Engineering/_workitems/edit/559170)

Link: preview-[353](https://design.docs.microsoft.com/pulls/353/components/checkbox.html)

This PR fixes a bug with the top positioning of the checkmark with the `checkbox-sm` variant. `checkbox-check` should have a position property to ensure that the `inset-block-start` property of the checkmark is based on its immediate parent.

## Testing

1. Visit https://design.docs.microsoft.com/pulls/353/components/checkbox.html and click on both the normal checkbox  `checkbox-sm` variant. The vertical position of the checkmark should still look ok.