### PR TITLE
Fix button-filled disabled + loading colors

### DIFF
--- a/.changeset/nervous-dragons-protect.md
+++ b/.changeset/nervous-dragons-protect.md
@@ -2,4 +2,4 @@
 '@microsoft/atlas-css': patch
 ---
 
-Fix button colors for button-filled disabled + loading state."
+Fix button colors for button-filled disabled + loading state.

--- a/.changeset/nervous-dragons-protect.md
+++ b/.changeset/nervous-dragons-protect.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Fix button colors for button-filled disabled + loading state."

--- a/css/src/components/button.scss
+++ b/css/src/components/button.scss
@@ -239,6 +239,15 @@ $button-filled-text-color: $text-invert !default;
 				background-color: transparent;
 				color: $base;
 				box-shadow: none;
+
+				/* stylelint-disable max-nesting-depth */
+
+				&.is-loading {
+					background-color: $base !important;
+					opacity: 0.5 !important;
+				}
+
+				/* stylelint-enable */
 			}
 		}
 	}


### PR DESCRIPTION
Task: task-[564823](https://dev.azure.com/ceapex/Engineering/_workitems/edit/564823/)

Link: preview-[361](https://design.docs.microsoft.com/pulls/361)

Currently, when a filled button is both disabled and loading, it becomes a transparent button. 
![image](https://user-images.githubusercontent.com/94572161/157115267-32fd78b2-8962-4afe-9732-72a4e40786cb.png)

This PR adds disabled styles so that the button is visible, which should resolve issue 2 in the related task above. 

## Testing

1. Visit the [buttons page](https://design.docs.microsoft.com/pulls/361/components/button.html). Scroll to the bottom to the section with buttons in loading state.
2. Inspect one of the filled buttons and add `disabled` attribute. You should still be able to see the button, but with less opacity like a disabled button. 
![image](https://user-images.githubusercontent.com/94572161/157116034-35449595-8038-4e8d-a4c3-e345c7e95bb7.png)

