### PR TITLE
Updating controls with fixed border radius for all sizes.

### DIFF
--- a/.changeset/brown-paws-battle.md
+++ b/.changeset/brown-paws-battle.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Updating controls with fixed border radius for all sizes.

--- a/css/src/components/button.scss
+++ b/css/src/components/button.scss
@@ -8,7 +8,7 @@ $button-sm-font-size: $font-size-8 !default;
 
 $button-border-color: $text-subtle !default;
 $button-border-width: $control-border-width !default;
-$button-border-radius: $radius-sm;
+$button-border-radius: $control-radius !default;
 
 $button-padding-vertical: calc(0.375em - #{$button-border-width}) !default;
 $button-padding-horizontal: 0.75em !default;

--- a/css/src/components/form/select.scss
+++ b/css/src/components/form/select.scss
@@ -92,10 +92,6 @@ $select-arrow-actual-width: 0.75em !default;
 
 	&.select-sm {
 		font-size: $control-sm-font-size;
-
-		select {
-			border-radius: $control-radius-sm;
-		}
 	}
 
 	&.select-lg {

--- a/css/src/mixins/control.scss
+++ b/css/src/mixins/control.scss
@@ -1,5 +1,4 @@
-$control-radius: $radius !default;
-$control-radius-sm: $radius-sm !default;
+$control-radius: $radius-sm !default;
 
 $control-font-size: $font-size-7 !default;
 $control-sm-font-size: $font-size-8 !default;
@@ -36,7 +35,6 @@ $control-padding-horizontal: calc(0.625em - #{$control-border-width}) !default;
 }
 
 @mixin control-sm {
-	border-radius: $control-radius-sm;
 	font-size: $control-sm-font-size;
 }
 


### PR DESCRIPTION
Link: preview-[pull-request-number]

All controls should have a 2px border radius no matter their size.

## Links

[Input](https://design.docs.microsoft.com/pulls/365/components/input.html)
[Select](https://design.docs.microsoft.com/pulls/365/components/select.html)
[Textarea](https://design.docs.microsoft.com/pulls/365/components/textarea.html)
[Checkbox](https://design.docs.microsoft.com/pulls/365/components/checkbox.html)
[Button](https://design.docs.microsoft.com/pulls/365/components/button.html)

## Testing

1. Visit the pages linked above. All controls should have a consistent border-radius value.
