### PR TITLE
Fix `[disabled].button.button-filled` buttons in all semantic colors.

### DIFF
--- a/.changeset/swift-ways-explain.md
+++ b/.changeset/swift-ways-explain.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-css': patch
+'@microsoft/atlas-site': patch
+---
+
+Fix `[disabled].button.button-filled` buttons in all semantic colors.

--- a/css/src/components/README.md
+++ b/css/src/components/README.md
@@ -24,7 +24,13 @@ When horizontal (inline) direction is important to a component, the user's text 
 
 ## Class nomenclature within components
 
-The component name itself should be a noun or noun-phrase. Endeavor to choose the shorted applicable word or series of words that best describes the component. Modifiers on a particular component should contain the top level component within the class name. State based class modifiers will follow a different convention, and be prefixed with `is-`.
+The component name itself should be a noun or noun-phrase. Endeavor to choose the shortest applicable word or series of words that best describes the component. Modifiers on a particular component should contain the top level component within the class name. State based class modifiers will follow a different convention, and be prefixed with `is-`.
+
+Examples of state-targeting classes are:
+
+- `is-disabled`
+- `is-hovered`
+- `is-focused`
 
 ## Sizes within class names
 

--- a/css/src/components/button.scss
+++ b/css/src/components/button.scss
@@ -178,7 +178,7 @@ $button-clear-hover-background-color: transparentize(#8e8e8e, 0.95) !default;
 				color: $dark;
 			}
 
-			&.button-disabled,
+			&.is-disabled,
 			&[disabled] {
 				background-color: transparent;
 				color: $base;
@@ -231,23 +231,6 @@ $button-filled-text-color: $text-invert !default;
 				@include loader;
 
 				border-color: transparent transparent $invert $invert !important;
-			}
-
-			&.button-disabled,
-			&[disabled] {
-				border-color: $base;
-				background-color: transparent;
-				color: $base;
-				box-shadow: none;
-
-				/* stylelint-disable max-nesting-depth */
-
-				&.is-loading {
-					background-color: $base !important;
-					opacity: 0.5 !important;
-				}
-
-				/* stylelint-enable */
 			}
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 		},
 		"css": {
 			"name": "@microsoft/atlas-css",
-			"version": "3.12.3",
+			"version": "3.12.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@microsoft/stylelint-config-atlas": "4.0.2",

--- a/site/src/components/button.md
+++ b/site/src/components/button.md
@@ -23,11 +23,11 @@ All buttons, by default, are secondary buttons. There are three gradutating seco
 2. Clear
 3. Filled
 
-| Type     | Class                      | Default State                                         | Hover                                                            |
-| -------- | -------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------- |
-| Outlined | `.button`                  | <button class="button">Default</button>               | <button class="button is-hovered">Default</button>               |
-| Clear    | `.button` `.button-clear`  | <button class="button button-clear">Default</button>  | <button class="button button-clear is-hovered">Default</button>  |
-| Filled   | `.button` `.button-filled` | <button class="button button-filled">Default</button> | <button class="button button-filled is-hovered">Default</button> |
+| Type     | Class                      | Default State                                         | Hover                                                            | Disabled                                                        |
+| -------- | -------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------- |
+| Outlined | `.button`                  | <button class="button">Default</button>               | <button class="button is-hovered">Default</button>               | <button class="button" disabled>Disabled</button>               |
+| Clear    | `.button` `.button-clear`  | <button class="button button-clear">Default</button>  | <button class="button button-clear is-hovered">Default</button>  | <button class="button button-clear " disabled>Disabled</button> |
+| Filled   | `.button` `.button-filled` | <button class="button button-filled">Default</button> | <button class="button button-filled is-hovered">Default</button> | <button class="button button-filled" disabled>Disabled</button> |
 
 ```abut-html
 <button class="button">Click me!</button>
@@ -37,11 +37,11 @@ All buttons, by default, are secondary buttons. There are three gradutating seco
 
 A visual style used to highlight only the most important actions. To avoid confusing users, don't use more than one primary button within a section or view. Note that the clear variant of primary buttons must be used on a very light background or it will not pass constrast requirements. If you run into this issue, try using [`link-button`](~/src/components/link-button.md), which defaults to a slightly darker blue for this very reason.
 
-| Type     | Class                                          | Default State                                                        | Hover                                                                           |
-| -------- | ---------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| Outlined | `.button`, `.button-primary`                   | <button class="button button-primary">Default</button>               | <button class="button button-primary is-hovered">Default</button>               |
-| Clear    | `.button`, `.button-primary`, `.button-clear`  | <button class="button button-primary button-clear">Default</button>  | <button class="button button-primary button-clear is-hovered">Default</button>  |
-| Filled   | `.button`, `.button-primary`, `.button-filled` | <button class="button button-primary button-filled">Default</button> | <button class="button button-primary button-filled is-hovered">Default</button> |
+| Type     | Class                                          | Default State                                                        | Hover                                                                           | Disabled                                                                       |
+| -------- | ---------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Outlined | `.button`, `.button-primary`                   | <button class="button button-primary">Default</button>               | <button class="button button-primary is-hovered">Default</button>               | <button class="button button-primary" disabled>Disabled</button>               |
+| Clear    | `.button`, `.button-primary`, `.button-clear`  | <button class="button button-primary button-clear">Default</button>  | <button class="button button-primary button-clear is-hovered">Default</button>  | <button class="button button-primary button-clear " disabled>Disabled</button> |
+| Filled   | `.button`, `.button-primary`, `.button-filled` | <button class="button button-primary button-filled">Default</button> | <button class="button button-primary button-filled is-hovered">Default</button> | <button class="button button-primary button-filled" disabled>Disabled</button> |
 
 ```abut-html
 <button class="button button-primary">Click me!</button>
@@ -55,11 +55,11 @@ Semantic colors denote standard value states (such as good, bad, or warning). Ea
 
 Danger buttons are red on most themes. They help reiterature that the intended action is important or potentially dangerous (e.g., deleting an item or transferring ownership).
 
-| Type     | Class                                        | Default State                                                       | Hover                                                                          |
-| -------- | -------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| Outlined | `.button`, `.button-danger`                  | <button class="button button-danger">Default</button>               | <button class="button button-danger is-hovered">Default</button>               |
-| Clear    | `.button`, `.button-danger`, `.button-clear` | <button class="button button-danger button-clear">Default</button>  | <button class="button button-danger button-clear is-hovered">Default</button>  |
-| Filled   | `.button` `.button-danger`, `.button-filled` | <button class="button button-danger button-filled">Default</button> | <button class="button button-danger button-filled is-hovered">Default</button> |
+| Type     | Class                                        | Default State                                                       | Hover                                                                          | Disabled                                                                      |
+| -------- | -------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| Outlined | `.button`, `.button-danger`                  | <button class="button button-danger">Default</button>               | <button class="button button-danger is-hovered">Default</button>               | <button class="button button-danger" disabled>Disabled</button>               |
+| Clear    | `.button`, `.button-danger`, `.button-clear` | <button class="button button-danger button-clear">Default</button>  | <button class="button button-danger button-clear is-hovered">Default</button>  | <button class="button button-danger button-clear" disabled>Disabled</button>  |
+| Filled   | `.button` `.button-danger`, `.button-filled` | <button class="button button-danger button-filled">Default</button> | <button class="button button-danger button-filled is-hovered">Default</button> | <button class="button button-danger button-filled" disabled>Disabled</button> |
 
 ```abut-html
 <button class="button button-danger">Click me!</button>
@@ -72,11 +72,11 @@ Success buttons are green on most themes. This color stands for a good, positive
 - You need to highlight a good or positive status.
 - A message contains information about a process that was finalized without any issues. Users need this information later on (for example, to copy values to another app).
 
-| Type     | Class                                         | Default State                                                        | Hover                                                                           |
-| -------- | --------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| Outlined | `.button`, `.button-success`                  | <button class="button button-success">Default</button>               | <button class="button button-success is-hovered">Default</button>               |
-| Clear    | `.button`,`.button-success`, `.button-clear`  | <button class="button button-success button-clear">Default</button>  | <button class="button button-success button-clear is-hovered">Default</button>  |
-| Filled   | `.button`, `.button-success` `.button-filled` | <button class="button button-success button-filled">Default</button> | <button class="button button-success button-filled is-hovered">Default</button> |
+| Type     | Class                                         | Default State                                                        | Hover                                                                           | Disabled                                                                       |
+| -------- | --------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Outlined | `.button`, `.button-success`                  | <button class="button button-success">Default</button>               | <button class="button button-success is-hovered">Default</button>               | <button class="button button-success" disabled>Disabled</button>               |
+| Clear    | `.button`,`.button-success`, `.button-clear`  | <button class="button button-success button-clear">Default</button>  | <button class="button button-success button-clear is-hovered">Default</button>  | <button class="button button-success button-clear" disabled>Disabled</button>  |
+| Filled   | `.button`, `.button-success` `.button-filled` | <button class="button button-success button-filled">Default</button> | <button class="button button-success button-filled is-hovered">Default</button> | <button class="button button-success button-filled" disabled>Disabled</button> |
 
 ```abut-html
 <button class="button button-success">Click me!</button>
@@ -92,11 +92,11 @@ Warning buttons are yellow on most themes. This color indicates a critical situa
 - The user input was validated and a minor problem occurred. The user can continue without fixing the problem, but might lead to an error later on.
 - A message contains information about a warning.
 
-| Type     | Class                                           | Default State                                                        | Hover                                                                           |
-| -------- | ----------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| Outlined | `.button`, `.button-warning`                    | <button class="button button-warning">Default</button>               | <button class="button button-warning is-hovered">Default</button>               |
-| Clear    | `.button`, `.button-warning`, `.button-clear`   | <button class="button button-warning button-clear">Default</button>  | <button class="button button-warning button-clear is-hovered">Default</button>  |
-| Filled   | `.button` , `.button-warning`, `.button-filled` | <button class="button button-warning button-filled">Default</button> | <button class="button button-warning button-filled is-hovered">Default</button> |
+| Type     | Class                                           | Default State                                                        | Hover                                                                           | Disabled                                                                       |
+| -------- | ----------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Outlined | `.button`, `.button-warning`                    | <button class="button button-warning">Default</button>               | <button class="button button-warning is-hovered">Default</button>               | <button class="button button-warning" disabled>Disabled</button>               |
+| Clear    | `.button`, `.button-warning`, `.button-clear`   | <button class="button button-warning button-clear">Default</button>  | <button class="button button-warning button-clear is-hovered">Default</button>  | <button class="button button-warning button-clear" disabled>Disabled</button>  |
+| Filled   | `.button` , `.button-warning`, `.button-filled` | <button class="button button-warning button-filled">Default</button> | <button class="button button-warning button-filled is-hovered">Default</button> | <button class="button button-warning button-filled" disabled>Disabled</button> |
 
 ```abut-html
 <button class="button button-warning">Click me!</button>
@@ -130,24 +130,6 @@ Ensure the user knows they need to wait for some event (like a fetch request) in
 
 ```html
 <button class="button is-loading">Primary</button>
-<button class="button button-primary is-loading">Primary</button>
-<button class="button button-success is-loading">Success</button>
-<button class="button button-warning is-loading">Warning</button>
-<button class="button button-info is-loading">Info</button>
-<button class="button button-danger is-loading">Danger</button>
-<button class="button button-clear is-loading">Primary</button>
-<button class="button button-clear button-primary is-loading">Primary</button>
-<button class="button button-clear button-success is-loading">Success</button>
-<button class="button button-clear button-warning is-loading">Warning</button>
-<button class="button button-clear button-info is-loading">Info</button>
-<button class="button button-clear button-danger is-loading">Danger</button>
-<button class="button button-filled is-loading">Primary</button>
-<button class="button button-filled button-primary is-loading">Primary</button>
-<button class="button button-filled button-success is-loading">Success</button>
-<button class="button button-filled button-warning is-loading">Warning</button>
-<button class="button button-filled button-info is-loading">Info</button>
-<button class="button button-filled button-danger is-loading">Danger</button>
-<button class="button button-clear border is-loading">Clear</button>
 ```
 
 ## Adaptive buttons

--- a/site/src/components/button.md
+++ b/site/src/components/button.md
@@ -126,10 +126,11 @@ Make a button take up the full width of a container.
 
 ### Loading buttons
 
-Ensure the user knows they need to wait for some event (like a fetch request) in order to interact with a button.
+Ensure the user knows they need to wait for some event (like a fetch request) in order to interact with a button. Can be used with the `disabled` attribute, as in the second button example below.
 
 ```html
-<button class="button is-loading">Primary</button>
+<button class="button is-loading">Loading</button>
+<button class="button button-primary button-filled is-loading" disabled>Disabled</button>
 ```
 
 ## Adaptive buttons

--- a/site/src/components/button.md
+++ b/site/src/components/button.md
@@ -17,17 +17,17 @@ Each style is explained below, detailing how and where to use them.
 
 ## Secondary
 
-All buttons, by default, are secondary buttons. There are three gradutating secondary styles.
+All buttons, by default, are secondary buttons. There are three graduating secondary styles.
 
 1. Outlined (Default)
 2. Clear
 3. Filled
 
-| Type     | Class                      | Default State                                         | Hover                                                            | Disabled                                                        |
-| -------- | -------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------- |
-| Outlined | `.button`                  | <button class="button">Default</button>               | <button class="button is-hovered">Default</button>               | <button class="button" disabled>Disabled</button>               |
-| Clear    | `.button` `.button-clear`  | <button class="button button-clear">Default</button>  | <button class="button button-clear is-hovered">Default</button>  | <button class="button button-clear " disabled>Disabled</button> |
-| Filled   | `.button` `.button-filled` | <button class="button button-filled">Default</button> | <button class="button button-filled is-hovered">Default</button> | <button class="button button-filled" disabled>Disabled</button> |
+| Type     | Class                      | Default State                                         | Hover                                                            |
+| -------- | -------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------- |
+| Outlined | `.button`                  | <button class="button">Default</button>               | <button class="button is-hovered">Default</button>               |
+| Clear    | `.button` `.button-clear`  | <button class="button button-clear">Default</button>  | <button class="button button-clear is-hovered">Default</button>  |
+| Filled   | `.button` `.button-filled` | <button class="button button-filled">Default</button> | <button class="button button-filled is-hovered">Default</button> |
 
 ```abut-html
 <button class="button">Click me!</button>
@@ -37,11 +37,11 @@ All buttons, by default, are secondary buttons. There are three gradutating seco
 
 A visual style used to highlight only the most important actions. To avoid confusing users, don't use more than one primary button within a section or view. Note that the clear variant of primary buttons must be used on a very light background or it will not pass constrast requirements. If you run into this issue, try using [`link-button`](~/src/components/link-button.md), which defaults to a slightly darker blue for this very reason.
 
-| Type     | Class                                          | Default State                                                        | Hover                                                                           | Disabled                                                                       |
-| -------- | ---------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| Outlined | `.button`, `.button-primary`                   | <button class="button button-primary">Default</button>               | <button class="button button-primary is-hovered">Default</button>               | <button class="button button-primary" disabled>Disabled</button>               |
-| Clear    | `.button`, `.button-primary`, `.button-clear`  | <button class="button button-primary button-clear">Default</button>  | <button class="button button-primary button-clear is-hovered">Default</button>  | <button class="button button-primary button-clear " disabled>Disabled</button> |
-| Filled   | `.button`, `.button-primary`, `.button-filled` | <button class="button button-primary button-filled">Default</button> | <button class="button button-primary button-filled is-hovered">Default</button> | <button class="button button-primary button-filled" disabled>Disabled</button> |
+| Type     | Class                                          | Default State                                                        | Hover                                                                           |
+| -------- | ---------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Outlined | `.button`, `.button-primary`                   | <button class="button button-primary">Default</button>               | <button class="button button-primary is-hovered">Default</button>               |
+| Clear    | `.button`, `.button-primary`, `.button-clear`  | <button class="button button-primary button-clear">Default</button>  | <button class="button button-primary button-clear is-hovered">Default</button>  |
+| Filled   | `.button`, `.button-primary`, `.button-filled` | <button class="button button-primary button-filled">Default</button> | <button class="button button-primary button-filled is-hovered">Default</button> |
 
 ```abut-html
 <button class="button button-primary">Click me!</button>
@@ -55,11 +55,11 @@ Semantic colors denote standard value states (such as good, bad, or warning). Ea
 
 Danger buttons are red on most themes. They help reiterature that the intended action is important or potentially dangerous (e.g., deleting an item or transferring ownership).
 
-| Type     | Class                                        | Default State                                                       | Hover                                                                          | Disabled                                                                      |
-| -------- | -------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| Outlined | `.button`, `.button-danger`                  | <button class="button button-danger">Default</button>               | <button class="button button-danger is-hovered">Default</button>               | <button class="button button-danger" disabled>Disabled</button>               |
-| Clear    | `.button`, `.button-danger`, `.button-clear` | <button class="button button-danger button-clear">Default</button>  | <button class="button button-danger button-clear is-hovered">Default</button>  | <button class="button button-danger button-clear" disabled>Disabled</button>  |
-| Filled   | `.button` `.button-danger`, `.button-filled` | <button class="button button-danger button-filled">Default</button> | <button class="button button-danger button-filled is-hovered">Default</button> | <button class="button button-danger button-filled" disabled>Disabled</button> |
+| Type     | Class                                        | Default State                                                       | Hover                                                                          |
+| -------- | -------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Outlined | `.button`, `.button-danger`                  | <button class="button button-danger">Default</button>               | <button class="button button-danger is-hovered">Default</button>               |
+| Clear    | `.button`, `.button-danger`, `.button-clear` | <button class="button button-danger button-clear">Default</button>  | <button class="button button-danger button-clear is-hovered">Default</button>  |
+| Filled   | `.button` `.button-danger`, `.button-filled` | <button class="button button-danger button-filled">Default</button> | <button class="button button-danger button-filled is-hovered">Default</button> |
 
 ```abut-html
 <button class="button button-danger">Click me!</button>
@@ -72,11 +72,11 @@ Success buttons are green on most themes. This color stands for a good, positive
 - You need to highlight a good or positive status.
 - A message contains information about a process that was finalized without any issues. Users need this information later on (for example, to copy values to another app).
 
-| Type     | Class                                         | Default State                                                        | Hover                                                                           | Disabled                                                                       |
-| -------- | --------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| Outlined | `.button`, `.button-success`                  | <button class="button button-success">Default</button>               | <button class="button button-success is-hovered">Default</button>               | <button class="button button-success" disabled>Disabled</button>               |
-| Clear    | `.button`,`.button-success`, `.button-clear`  | <button class="button button-success button-clear">Default</button>  | <button class="button button-success button-clear is-hovered">Default</button>  | <button class="button button-success button-clear" disabled>Disabled</button>  |
-| Filled   | `.button`, `.button-success` `.button-filled` | <button class="button button-success button-filled">Default</button> | <button class="button button-success button-filled is-hovered">Default</button> | <button class="button button-success button-filled" disabled>Disabled</button> |
+| Type     | Class                                         | Default State                                                        | Hover                                                                           |
+| -------- | --------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Outlined | `.button`, `.button-success`                  | <button class="button button-success">Default</button>               | <button class="button button-success is-hovered">Default</button>               |
+| Clear    | `.button`,`.button-success`, `.button-clear`  | <button class="button button-success button-clear">Default</button>  | <button class="button button-success button-clear is-hovered">Default</button>  |
+| Filled   | `.button`, `.button-success` `.button-filled` | <button class="button button-success button-filled">Default</button> | <button class="button button-success button-filled is-hovered">Default</button> |
 
 ```abut-html
 <button class="button button-success">Click me!</button>
@@ -92,11 +92,11 @@ Warning buttons are yellow on most themes. This color indicates a critical situa
 - The user input was validated and a minor problem occurred. The user can continue without fixing the problem, but might lead to an error later on.
 - A message contains information about a warning.
 
-| Type     | Class                                           | Default State                                                        | Hover                                                                           | Disabled                                                                       |
-| -------- | ----------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| Outlined | `.button`, `.button-warning`                    | <button class="button button-warning">Default</button>               | <button class="button button-warning is-hovered">Default</button>               | <button class="button button-warning" disabled>Disabled</button>               |
-| Clear    | `.button`, `.button-warning`, `.button-clear`   | <button class="button button-warning button-clear">Default</button>  | <button class="button button-warning button-clear is-hovered">Default</button>  | <button class="button button-warning button-clear" disabled>Disabled</button>  |
-| Filled   | `.button` , `.button-warning`, `.button-filled` | <button class="button button-warning button-filled">Default</button> | <button class="button button-warning button-filled is-hovered">Default</button> | <button class="button button-warning button-filled" disabled>Disabled</button> |
+| Type     | Class                                           | Default State                                                        | Hover                                                                           |
+| -------- | ----------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Outlined | `.button`, `.button-warning`                    | <button class="button button-warning">Default</button>               | <button class="button button-warning is-hovered">Default</button>               |
+| Clear    | `.button`, `.button-warning`, `.button-clear`   | <button class="button button-warning button-clear">Default</button>  | <button class="button button-warning button-clear is-hovered">Default</button>  |
+| Filled   | `.button` , `.button-warning`, `.button-filled` | <button class="button button-warning button-filled">Default</button> | <button class="button button-warning button-filled is-hovered">Default</button> |
 
 ```abut-html
 <button class="button button-warning">Click me!</button>
@@ -126,11 +126,28 @@ Make a button take up the full width of a container.
 
 ### Loading buttons
 
-Ensure the user knows they need to wait for some event (like a fetch request) in order to interact with a button. Can be used with the `disabled` attribute, as in the second button example below.
+Ensure the user knows they need to wait for some event (like a fetch request) in order to interact with a button.
 
 ```html
-<button class="button is-loading">Loading</button>
-<button class="button button-primary button-filled is-loading" disabled>Disabled</button>
+<button class="button is-loading">Primary</button>
+<button class="button button-primary is-loading">Primary</button>
+<button class="button button-success is-loading">Success</button>
+<button class="button button-warning is-loading">Warning</button>
+<button class="button button-info is-loading">Info</button>
+<button class="button button-danger is-loading">Danger</button>
+<button class="button button-clear is-loading">Primary</button>
+<button class="button button-clear button-primary is-loading">Primary</button>
+<button class="button button-clear button-success is-loading">Success</button>
+<button class="button button-clear button-warning is-loading">Warning</button>
+<button class="button button-clear button-info is-loading">Info</button>
+<button class="button button-clear button-danger is-loading">Danger</button>
+<button class="button button-filled is-loading">Primary</button>
+<button class="button button-filled button-primary is-loading">Primary</button>
+<button class="button button-filled button-success is-loading">Success</button>
+<button class="button button-filled button-warning is-loading">Warning</button>
+<button class="button button-filled button-info is-loading">Info</button>
+<button class="button button-filled button-danger is-loading">Danger</button>
+<button class="button button-clear border is-loading">Clear</button>
 ```
 
 ## Adaptive buttons


### PR DESCRIPTION
Task: task-531865

Link: preview-367

I accidentally implemented some incorrect logic for disabled buttons. Luckily removing certain lines of code fixes the issue. This PR also updates the documentation to more closely match the Figma.

## Testing

1. Visit: preview-367
2. Visit buttons page. Check all disabled examples.
