### PR TITLE
Updating border radius atomics and tokens

### DIFF
--- a/.changeset/heavy-chairs-allow.md
+++ b/.changeset/heavy-chairs-allow.md
@@ -1,5 +1,6 @@
 ---
 '@microsoft/atlas-css': patch
+'@microsoft/atlas-site': patch
 ---
 
-Updating border radius atomics and tokens.
+Updating border radius atomics and tokens and relevant documentation.

--- a/.changeset/heavy-chairs-allow.md
+++ b/.changeset/heavy-chairs-allow.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Updating border radius atomics and tokens.

--- a/css/src/atomics/border.scss
+++ b/css/src/atomics/border.scss
@@ -86,8 +86,8 @@
 	border-radius: $border-radius-lg !important;
 }
 
-.border-radius-full {
-	border-radius: $border-radius-full !important;
+.border-radius-rounded {
+	border-radius: $border-radius-rounded !important;
 }
 
 // Colors

--- a/css/src/atomics/border.scss
+++ b/css/src/atomics/border.scss
@@ -74,12 +74,20 @@
 
 // Radius
 
+.border-radius-sm {
+	border-radius: $border-radius-sm !important;
+}
+
 .border-radius {
 	border-radius: $border-radius !important;
 }
 
 .border-radius-lg {
 	border-radius: $border-radius-lg !important;
+}
+
+.border-radius-full {
+	border-radius: $border-radius-full !important;
 }
 
 // Colors

--- a/css/src/components/form/checkbox.scss
+++ b/css/src/components/form/checkbox.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable selector-max-specificity, max-nesting-depth, selector-no-qualifying-type */
 
-$checkbox-border-radius: $radius-sm !default;
+$checkbox-border-radius: $border-radius-sm !default;
 $checkbox-border-width: 0.0625em !default;
 $checkbox-unchecked-border-color: $control-border !default;
 $checkbox-color: $primary !default;

--- a/css/src/components/toggle.scss
+++ b/css/src/components/toggle.scss
@@ -18,7 +18,7 @@ $toggle-circle-selected-background-color: $body-background !default;
 		transition: $input-transition-duration linear;
 		transition-property: background-color, border-color;
 		border: 0.065em solid $toggle-unselected-border-color;
-		border-radius: $radius-rounded;
+		border-radius: $border-radius-full;
 		background-color: $toggle-unselected-background-color;
 		cursor: pointer;
 
@@ -34,7 +34,7 @@ $toggle-circle-selected-background-color: $body-background !default;
 			height: $toggle-circle-size;
 			transition: $toggle-transition;
 			transition-property: inset-inline-start, border-color, background-color;
-			border-radius: $radius-rounded;
+			border-radius: $border-radius-full;
 			inset-block-start: $toggle-circle-top;
 			inset-inline-start: $toggle-circle-distance-from-border;
 			background-color: $toggle-unselected-circle-color;

--- a/css/src/components/toggle.scss
+++ b/css/src/components/toggle.scss
@@ -18,7 +18,7 @@ $toggle-circle-selected-background-color: $body-background !default;
 		transition: $input-transition-duration linear;
 		transition-property: background-color, border-color;
 		border: 0.065em solid $toggle-unselected-border-color;
-		border-radius: $border-radius-full;
+		border-radius: $border-radius-rounded;
 		background-color: $toggle-unselected-background-color;
 		cursor: pointer;
 
@@ -34,7 +34,7 @@ $toggle-circle-selected-background-color: $body-background !default;
 			height: $toggle-circle-size;
 			transition: $toggle-transition;
 			transition-property: inset-inline-start, border-color, background-color;
-			border-radius: $border-radius-full;
+			border-radius: $border-radius-rounded;
 			inset-block-start: $toggle-circle-top;
 			inset-inline-start: $toggle-circle-distance-from-border;
 			background-color: $toggle-unselected-circle-color;

--- a/css/src/mixins/control.scss
+++ b/css/src/mixins/control.scss
@@ -1,4 +1,4 @@
-$control-radius: $radius-sm !default;
+$control-radius: $border-radius-sm !default;
 
 $control-font-size: $font-size-7 !default;
 $control-sm-font-size: $font-size-8 !default;

--- a/css/src/mixins/loader.scss
+++ b/css/src/mixins/loader.scss
@@ -5,7 +5,7 @@
 	height: 1em;
 	animation: spinAround 500ms infinite linear;
 	border: 2px solid $border;
-	border-radius: $radius-rounded;
+	border-radius: $border-radius-full;
 	border-top-color: transparent;
 	border-right-color: transparent;
 	content: '';

--- a/css/src/mixins/loader.scss
+++ b/css/src/mixins/loader.scss
@@ -5,7 +5,7 @@
 	height: 1em;
 	animation: spinAround 500ms infinite linear;
 	border: 2px solid $border;
-	border-radius: $border-radius-full;
+	border-radius: $border-radius-rounded;
 	border-top-color: transparent;
 	border-right-color: transparent;
 	content: '';

--- a/css/src/tokens/border.scss
+++ b/css/src/tokens/border.scss
@@ -8,5 +8,5 @@ $border-width-lg: 0.25rem !default;
 $border-radius-sm: 0.125rem !default; // 2px
 $border-radius: 0.25rem !default; // 4px
 $border-radius-lg: 0.375rem !default; // 6px
-$border-radius-full: 290486px !default;
+$border-radius-rounded: 290486px !default;
 //@end-sass-export-section

--- a/css/src/tokens/border.scss
+++ b/css/src/tokens/border.scss
@@ -4,6 +4,9 @@
 $border-width: 1px !default;
 $border-width-md: 0.125rem !default;
 $border-width-lg: 0.25rem !default;
-$border-radius: 0.25rem !default;
-$border-radius-lg: 0.5rem !default;
+
+$border-radius-sm: 0.125rem !default; // 2px
+$border-radius: 0.25rem !default; // 4px
+$border-radius-lg: 0.375rem !default; // 6px
+$border-radius-full: 290486px !default;
 //@end-sass-export-section

--- a/css/src/tokens/index.scss
+++ b/css/src/tokens/index.scss
@@ -9,7 +9,6 @@
 @import './font-stack.scss';
 @import './layout.scss';
 @import './position.scss';
-@import './radius.scss';
 @import './schemes.scss';
 @import './shadow.scss';
 @import './spacing.scss';

--- a/css/src/tokens/radius.scss
+++ b/css/src/tokens/radius.scss
@@ -1,9 +1,0 @@
-/**
- * @sass-export-section="radius"
- */
-// Radius
-$radius-sm: 2px !default;
-$radius: 4px !default;
-$radius-lg: 6px !default;
-$radius-rounded: 290486px !default;
-//@end-sass-export-section

--- a/site/src/atomics/border.md
+++ b/site/src/atomics/border.md
@@ -58,22 +58,27 @@ Here is an example of applying border to specific side of the element:
 
 ### Radius
 
-Currently two classes are available to set border radius:
+There are a few classes available to set border radius:
 
-| class              | size      |
-| ------------------ | --------- |
-| `border-radius`    | `0.25rem` |
-| `border-radius-lg` | `0.5rem`  |
+| class                | size            |
+| -------------------- | --------------- |
+| `border-radius-sm`   | `0.125rem`      |
+| `border-radius`      | `0.25rem`       |
+| `border-radius-lg`   | `0.375rem`      |
+| `border-radius-full` | `full rounding` |
 
 ```html
-<div class="border border-radius padding-sm">
+<div class="border border-radius-sm padding-sm">
+	<p>Small radius</p>
+</div>
+<div class="border border-radius padding-sm margin-top-xs">
 	<p>Default radius</p>
 </div>
-```
-
-```html
-<div class="border border-radius-lg padding-sm">
+<div class="border border-radius-lg padding-sm margin-top-xs">
 	<p>Large radius</p>
+</div>
+<div class="border border-radius-full padding-sm margin-top-xs">
+	<p>Full radius</p>
 </div>
 ```
 

--- a/site/src/atomics/border.md
+++ b/site/src/atomics/border.md
@@ -60,12 +60,12 @@ Here is an example of applying border to specific side of the element:
 
 There are a few classes available to set border radius:
 
-| class                   | size            |
-| ----------------------- | --------------- |
-| `border-radius-sm`      | `0.125rem`      |
-| `border-radius`         | `0.25rem`       |
-| `border-radius-lg`      | `0.375rem`      |
-| `border-radius-rounded` | `full rounding` |
+| class                   | size       |
+| ----------------------- | ---------- |
+| `border-radius-sm`      | `0.125rem` |
+| `border-radius`         | `0.25rem`  |
+| `border-radius-lg`      | `0.375rem` |
+| `border-radius-rounded` | `290486px` |
 
 ```html
 <div class="border border-radius-sm padding-sm">
@@ -78,7 +78,7 @@ There are a few classes available to set border radius:
 	<p>Large radius</p>
 </div>
 <div class="border border-radius-rounded padding-sm margin-top-xs">
-	<p>Full radius</p>
+	<p>Rounded</p>
 </div>
 ```
 

--- a/site/src/atomics/border.md
+++ b/site/src/atomics/border.md
@@ -60,12 +60,12 @@ Here is an example of applying border to specific side of the element:
 
 There are a few classes available to set border radius:
 
-| class                | size            |
-| -------------------- | --------------- |
-| `border-radius-sm`   | `0.125rem`      |
-| `border-radius`      | `0.25rem`       |
-| `border-radius-lg`   | `0.375rem`      |
-| `border-radius-full` | `full rounding` |
+| class                   | size            |
+| ----------------------- | --------------- |
+| `border-radius-sm`      | `0.125rem`      |
+| `border-radius`         | `0.25rem`       |
+| `border-radius-lg`      | `0.375rem`      |
+| `border-radius-rounded` | `full rounding` |
 
 ```html
 <div class="border border-radius-sm padding-sm">
@@ -77,7 +77,7 @@ There are a few classes available to set border radius:
 <div class="border border-radius-lg padding-sm margin-top-xs">
 	<p>Large radius</p>
 </div>
-<div class="border border-radius-full padding-sm margin-top-xs">
+<div class="border border-radius-rounded padding-sm margin-top-xs">
 	<p>Full radius</p>
 </div>
 ```


### PR DESCRIPTION
Task: task-533679

Link: preview-369

Currently there are several radius atomics exist in both `tokens/border.scss` and `tokens/radius.scss` files. Current PR condences them to live only in `tokens/border`. 

The only change that happened is the values is the `$border-radius-lg` has changed from `0.5rem (8px)` to `0.375rem (6px)` to match the [Rounded corner design](https://www.figma.com/file/uVA2amRR71yJZ0GS6RI6zL/%F0%9F%8C%9E-Atlas-Design-Library?node-id=2637%3A10132).

Also, two atomics classes were added - `border-radius-sm` and `border-radius-full`.

## Testing

1. Visit [border](https://design.docs.microsoft.com/pulls/369/atomics/border.html#radius) page, the list of border-radius atomics was updated.