### PR TITLE
Updates uses of focus-visible class instances with mixin that can piv…

### DIFF
--- a/.changeset/sharp-parrots-wink.md
+++ b/.changeset/sharp-parrots-wink.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Updates uses of focus-visible class instances with mixin that can pivot between psuedo-selector and class.

--- a/css/src/atomics/colors.scss
+++ b/css/src/atomics/colors.scss
@@ -13,8 +13,11 @@
 	}
 
 	a.color-#{$name} {
-		&:hover,
-		&.focus-visible {
+		&:hover {
+			color: $hover !important;
+		}
+
+		@include focus-visible {
 			color: $hover !important;
 		}
 

--- a/css/src/components/buttons.scss
+++ b/css/src/components/buttons.scss
@@ -64,11 +64,18 @@
 				z-index: $zindex-hover;
 			}
 
-			&.focus-visible,
 			&.is-focused,
 			&:active,
 			&.is-active,
 			&.is-selected {
+				z-index: $zindex-focus;
+
+				&:hover {
+					z-index: $zindex-multi;
+				}
+			}
+
+			@include focus-visible {
 				z-index: $zindex-focus;
 
 				&:hover {

--- a/css/src/components/form/radio.scss
+++ b/css/src/components/form/radio.scss
@@ -66,9 +66,14 @@ $radio-spacing: 0.5em !default;
 
 	/* stylelint-disable selector-no-qualifying-type */
 
-	input.focus-visible,
-	input.is-focused {
-		@extend %focus;
+	input {
+		&.is-focused {
+			@extend %focus;
+		}
+
+		@include focus-visible {
+			@extend %focus;
+		}
 	}
 
 	input.is-checked,

--- a/css/src/components/link-button.scss
+++ b/css/src/components/link-button.scss
@@ -16,10 +16,14 @@
 		text-decoration: underline !important;
 	}
 
-	&.focus-visible,
 	&.is-focused,
 	&:hover,
 	&.is-hovered {
+		color: $primary-hover;
+		text-decoration: underline !important;
+	}
+
+	@include focus-visible {
 		color: $primary-hover;
 		text-decoration: underline !important;
 	}

--- a/css/src/mixins/transparency.scss
+++ b/css/src/mixins/transparency.scss
@@ -4,7 +4,8 @@
 	appearance: none;
 
 	&:not(:hover),
-	&:not(.focus-visible) {
+	&:not(.focus-visible),
+	&:not(:focus-visible) {
 		background-color: transparent;
 	}
 }


### PR DESCRIPTION
Task: task-572109

Link: preview-371

Near the beginning of this project, we tried to be friendly to the forthcoming support of `:focus-visible` by using a mixin to allow builds to pivot between the polyfill (which uses `.focus-visible`) and the psuedo-selector by setting a feature flag. At some point we all collectively forgot about that best practice. Luckily, we've not come very far away from it - and with Safari now supporting the psuedo-selector, it's important that we get the mixin up and running to ensure a smooth transition.

## Testing

1. Tab through links in next section
2. Read code

## Additional information

[Button](https://design.docs.microsoft.com/pulls/371/components/button.html)
[Link Button](https://design.docs.microsoft.com/pulls/371/components/link-button.html)
[Radio](https://design.docs.microsoft.com/pulls/371/components/radio.html)