### PR TITLE
Fix off centered radio

### DIFF
--- a/.changeset/little-swans-smoke.md
+++ b/.changeset/little-swans-smoke.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Fix off centered radio dot.

--- a/css/src/components/form/radio.scss
+++ b/css/src/components/form/radio.scss
@@ -37,7 +37,7 @@ $radio-spacing: 0.5em !default;
 
 	&.is-hovered,
 	&:hover:not([disabled]) {
-		.radio-dot:not(:checked)::before {
+		.radio-dot:not(:checked) {
 			background: $radio-dot-hover-unchecked-color;
 		}
 	}

--- a/css/src/components/form/radio.scss
+++ b/css/src/components/form/radio.scss
@@ -17,7 +17,6 @@ $radio-spacing: 0.5em !default;
 	cursor: pointer;
 
 	.radio-dot {
-		inset-block-start: 0.0625em;
 		width: $radio-circle-size;
 		height: $radio-circle-size;
 		padding: $radio-dot-whitespace;
@@ -26,7 +25,6 @@ $radio-spacing: 0.5em !default;
 		background-clip: content-box !important;
 		background-color: $body-background;
 		color: $radio-dot-color;
-		inset: 0;
 	}
 
 	.radio-label-text {

--- a/css/src/components/form/radio.scss
+++ b/css/src/components/form/radio.scss
@@ -5,49 +5,28 @@ $radio-border-width: $control-border-width !default;
 $radio-dot-checked-color: $primary !default;
 $radio-dot-color: $text-subtle !default;
 $radio-dot-hover-unchecked-color: $control-border !default;
+$radio-dot-whitespace: 0.25em;
 $radio-timing-function: $input-timing-function !default;
 $radio-duration: $input-transition-duration !default;
 $radio-animation: boop !default;
 $radio-spacing: 0.5em !default;
 
-@mixin radio-dot {
-	position: absolute;
-	inset: 0;
-	width: $radio-dot-size;
-	height: $radio-dot-size;
-	margin: auto;
-	border-radius: $border-radius-rounded;
-	background-color: $body-background;
-	content: '';
-	overflow: hidden;
-}
-
-@mixin radio-dot-checked {
-	background: $radio-dot-checked-color;
-}
-
 .radio {
 	display: inline-flex;
-	position: relative;
-	align-items: flex-start;
 	line-height: 1.25;
 	cursor: pointer;
 
 	.radio-dot {
-		display: inline-block;
-		position: relative;
 		inset-block-start: 0.0625em;
-		flex-shrink: 0;
 		width: $radio-circle-size;
 		height: $radio-circle-size;
+		padding: $radio-dot-whitespace;
 		border: $radio-border-width solid $radio-border-color;
 		border-radius: $border-radius-rounded;
+		background-clip: content-box !important;
+		background-color: $body-background;
 		color: $radio-dot-color;
-		appearance: none;
-
-		&::before {
-			@include radio-dot;
-		}
+		inset: 0;
 	}
 
 	.radio-label-text {
@@ -82,10 +61,11 @@ $radio-spacing: 0.5em !default;
 	.radio-dot.is-checked {
 		animation: $radio-animation $radio-duration $radio-timing-function 1;
 		border-color: $radio-dot-checked-color;
+		background: $radio-dot-checked-color;
+	}
 
-		&::before {
-			@include radio-dot-checked;
-		}
+	input[type='radio'] {
+		appearance: none;
 	}
 
 	input[disabled],

--- a/css/src/components/form/radio.scss
+++ b/css/src/components/form/radio.scss
@@ -33,18 +33,7 @@ $radio-spacing: 0.5em !default;
 		margin: 0 $radio-spacing;
 	}
 
-	/* stylelint-disable selector-max-specificity */
-
-	&.is-hovered,
-	&:hover:not([disabled]) {
-		.radio-dot:not(:checked) {
-			background: $radio-dot-hover-unchecked-color;
-		}
-	}
-
-	/* stylelint-enable */
-
-	/* stylelint-disable selector-no-qualifying-type */
+	/* stylelint-disable selector-no-qualifying-type, selector-max-specificity */
 
 	input {
 		&.is-focused {
@@ -62,6 +51,17 @@ $radio-spacing: 0.5em !default;
 		animation: $radio-animation $radio-duration $radio-timing-function 1;
 		border-color: $radio-dot-checked-color;
 		background: $radio-dot-checked-color;
+	}
+
+	&.is-hovered,
+	&:hover:not([disabled]) {
+		.radio-dot:not(:checked) {
+			background: $radio-dot-hover-unchecked-color;
+		}
+
+		.radio-dot.is-checked {
+			background: $radio-dot-checked-color;
+		}
 	}
 
 	input[type='radio'] {

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
 		},
 		"js": {
 			"name": "@microsoft/atlas-js",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"license": "MIT",
 			"devDependencies": {
 				"eslint": "^8.8.0",


### PR DESCRIPTION
Task: task-[580494](https://dev.azure.com/ceapex/Engineering/_workitems/edit/580494)

Link: preview-[388](https://design.docs.microsoft.com/pulls/388/components/radio.html)

The current radio dot appears to be off-centered at times. Adding `background-clip` with padding seems to help. The use of `appearance: none` and applying custom styling eliminates the need for the `:before` pseudo element.

## Testing

1. Visit https://design.docs.microsoft.com/pulls/388/components/radio.html
2. Verify that the checked radio button dot is centered. It should stay centered even if you adjust screen size.
3. Add different font sizes to the label to test. It still looks a bit off-centered with `font-size-xs`.