### PR TITLE
Fix radio off-centered dot and background colors

### DIFF
--- a/.changeset/ninety-bugs-tap.md
+++ b/.changeset/ninety-bugs-tap.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Fix radio off-centered dot and background color issues.

--- a/css/src/components/form/radio.scss
+++ b/css/src/components/form/radio.scss
@@ -1,4 +1,5 @@
 $radio-circle-size: 1.25em !default;
+$radio-dot-size: 0.625em !default;
 $radio-border-color: $control-border !default;
 $radio-border-width: $control-border-width !default;
 $radio-dot-checked-color: $primary !default;
@@ -8,6 +9,17 @@ $radio-timing-function: $input-timing-function !default;
 $radio-duration: $input-transition-duration !default;
 $radio-animation: boop !default;
 $radio-spacing: 0.5em !default;
+
+@mixin radio-dot {
+	position: absolute;
+	inset: 0;
+	width: $radio-dot-size;
+	height: $radio-dot-size;
+	margin: auto;
+	border-radius: $border-radius-rounded;
+	content: '';
+	overflow: hidden;
+}
 
 @mixin radio-dot-checked {
 	background: $radio-dot-checked-color;
@@ -21,6 +33,7 @@ $radio-spacing: 0.5em !default;
 
 	.radio-dot {
 		display: inline-block;
+		position: relative;
 		inset-block-start: 0.0625em;
 		flex-shrink: 0;
 		width: $radio-circle-size;
@@ -31,6 +44,12 @@ $radio-spacing: 0.5em !default;
 		color: $radio-dot-color;
 		appearance: none;
 		content: '';
+
+		@media (forced-colors: active) {
+			&::before {
+				@include radio-dot;
+			}
+		}
 	}
 
 	.radio-label-text {
@@ -56,6 +75,12 @@ $radio-spacing: 0.5em !default;
 
 		animation: $radio-animation $radio-duration $radio-timing-function 1;
 		border-color: $radio-dot-checked-color;
+
+		@media (forced-colors: active) {
+			&::before {
+				background-color: ButtonText !important;
+			}
+		}
 	}
 
 	&.is-hovered,
@@ -63,6 +88,12 @@ $radio-spacing: 0.5em !default;
 		.radio-dot:not(:checked) {
 			background: $radio-dot-hover-unchecked-color;
 			box-shadow: inset 0 0 0 0.25em $body-background;
+		}
+
+		@media (forced-colors: active) {
+			.radio-dot:not(:checked)::before {
+				background-color: ButtonText !important;
+			}
 		}
 
 		.radio-dot.is-checked {

--- a/css/src/components/form/radio.scss
+++ b/css/src/components/form/radio.scss
@@ -44,7 +44,6 @@ $radio-spacing: 0.5em !default;
 		color: $radio-dot-color;
 		cursor: pointer;
 		appearance: none;
-		content: '';
 
 		@include forced-colors {
 			border-color: CanvasText !important;

--- a/css/src/components/form/radio.scss
+++ b/css/src/components/form/radio.scss
@@ -1,5 +1,4 @@
 $radio-circle-size: 1.25em !default;
-$radio-dot-size: 0.625em !default;
 $radio-border-color: $control-border !default;
 $radio-border-width: $control-border-width !default;
 $radio-dot-checked-color: $primary !default;
@@ -10,19 +9,9 @@ $radio-duration: $input-transition-duration !default;
 $radio-animation: boop !default;
 $radio-spacing: 0.5em !default;
 
-@mixin radio-dot {
-	position: absolute;
-	inset: 0;
-	width: $radio-dot-size;
-	height: $radio-dot-size;
-	margin: auto;
-	border-radius: $border-radius-rounded;
-	content: '';
-	overflow: hidden;
-}
-
 @mixin radio-dot-checked {
 	background: $radio-dot-checked-color;
+	box-shadow: inset 0 0 0 0.25em $body-background;
 }
 
 .radio {
@@ -32,7 +21,6 @@ $radio-spacing: 0.5em !default;
 
 	.radio-dot {
 		display: inline-block;
-		position: relative;
 		inset-block-start: 0.0625em;
 		flex-shrink: 0;
 		width: $radio-circle-size;
@@ -42,10 +30,7 @@ $radio-spacing: 0.5em !default;
 		background-color: $body-background;
 		color: $radio-dot-color;
 		appearance: none;
-
-		&::before {
-			@include radio-dot;
-		}
+		content: '';
 	}
 
 	.radio-label-text {
@@ -67,17 +52,15 @@ $radio-spacing: 0.5em !default;
 	input.is-checked,
 	input:checked,
 	.radio-dot.is-checked {
+		@include radio-dot-checked;
+
 		animation: $radio-animation $radio-duration $radio-timing-function 1;
 		border-color: $radio-dot-checked-color;
-
-		&::before {
-			@include radio-dot-checked;
-		}
 	}
 
 	&.is-hovered,
 	&:hover:not([disabled]) {
-		.radio-dot:not(:checked)::before {
+		.radio-dot:not(:checked) {
 			background: $radio-dot-hover-unchecked-color;
 		}
 

--- a/css/src/components/form/radio.scss
+++ b/css/src/components/form/radio.scss
@@ -42,6 +42,7 @@ $radio-spacing: 0.5em !default;
 		border-radius: $border-radius-rounded;
 		background-color: $body-background;
 		color: $radio-dot-color;
+		cursor: pointer;
 		appearance: none;
 		content: '';
 

--- a/css/src/components/form/radio.scss
+++ b/css/src/components/form/radio.scss
@@ -45,7 +45,10 @@ $radio-spacing: 0.5em !default;
 		appearance: none;
 		content: '';
 
-		@media (forced-colors: active) {
+		@include forced-colors {
+			border-color: CanvasText !important;
+			background-color: unset !important;
+
 			&::before {
 				@include radio-dot;
 			}
@@ -56,7 +59,7 @@ $radio-spacing: 0.5em !default;
 		margin: 0 $radio-spacing;
 	}
 
-	/* stylelint-disable selector-max-specificity, selector-no-qualifying-type */
+	/* stylelint-disable selector-max-specificity, selector-no-qualifying-type, max-nesting-depth */
 
 	input {
 		&.is-focused {
@@ -76,9 +79,13 @@ $radio-spacing: 0.5em !default;
 		animation: $radio-animation $radio-duration $radio-timing-function 1;
 		border-color: $radio-dot-checked-color;
 
-		@media (forced-colors: active) {
+		@include forced-colors {
+			border-color: CanvasText !important;
+			background-color: unset !important;
+			box-shadow: none !important;
+
 			&::before {
-				background-color: ButtonText !important;
+				background-color: CanvasText !important;
 			}
 		}
 	}
@@ -88,11 +95,14 @@ $radio-spacing: 0.5em !default;
 		.radio-dot:not(:checked) {
 			background: $radio-dot-hover-unchecked-color;
 			box-shadow: inset 0 0 0 0.25em $body-background;
-		}
 
-		@media (forced-colors: active) {
-			.radio-dot:not(:checked)::before {
-				background-color: ButtonText !important;
+			@include forced-colors {
+				background-color: unset !important;
+				box-shadow: none !important;
+
+				&::before {
+					background-color: CanvasText !important;
+				}
 			}
 		}
 

--- a/css/src/components/form/radio.scss
+++ b/css/src/components/form/radio.scss
@@ -17,7 +17,6 @@ $radio-spacing: 0.5em !default;
 	height: $radio-dot-size;
 	margin: auto;
 	border-radius: $border-radius-rounded;
-	background-color: $body-background;
 	content: '';
 	overflow: hidden;
 }
@@ -28,8 +27,6 @@ $radio-spacing: 0.5em !default;
 
 .radio {
 	display: inline-flex;
-	position: relative;
-	align-items: flex-start;
 	line-height: 1.25;
 	cursor: pointer;
 
@@ -42,6 +39,7 @@ $radio-spacing: 0.5em !default;
 		height: $radio-circle-size;
 		border: $radio-border-width solid $radio-border-color;
 		border-radius: $border-radius-rounded;
+		background-color: $body-background;
 		color: $radio-dot-color;
 		appearance: none;
 
@@ -54,18 +52,7 @@ $radio-spacing: 0.5em !default;
 		margin: 0 $radio-spacing;
 	}
 
-	/* stylelint-disable selector-max-specificity */
-
-	&.is-hovered,
-	&:hover:not([disabled]) {
-		.radio-dot:not(:checked)::before {
-			background: $radio-dot-hover-unchecked-color;
-		}
-	}
-
-	/* stylelint-enable */
-
-	/* stylelint-disable selector-no-qualifying-type */
+	/* stylelint-disable selector-max-specificity, selector-no-qualifying-type */
 
 	input {
 		&.is-focused {
@@ -84,6 +71,17 @@ $radio-spacing: 0.5em !default;
 		border-color: $radio-dot-checked-color;
 
 		&::before {
+			@include radio-dot-checked;
+		}
+	}
+
+	&.is-hovered,
+	&:hover:not([disabled]) {
+		.radio-dot:not(:checked)::before {
+			background: $radio-dot-hover-unchecked-color;
+		}
+
+		.radio-dot.is-checked {
 			@include radio-dot-checked;
 		}
 	}

--- a/css/src/components/form/radio.scss
+++ b/css/src/components/form/radio.scss
@@ -62,6 +62,7 @@ $radio-spacing: 0.5em !default;
 	&:hover:not([disabled]) {
 		.radio-dot:not(:checked) {
 			background: $radio-dot-hover-unchecked-color;
+			box-shadow: inset 0 0 0 0.25em $body-background;
 		}
 
 		.radio-dot.is-checked {

--- a/css/src/mixins/force-colors.scss
+++ b/css/src/mixins/force-colors.scss
@@ -1,6 +1,4 @@
 @mixin forced-colors() {
-	forced-color-adjust: none;
-
 	@media (forced-colors: active) {
 		@content;
 	}

--- a/css/src/mixins/force-colors.scss
+++ b/css/src/mixins/force-colors.scss
@@ -1,4 +1,6 @@
 @mixin forced-colors() {
+	forced-color-adjust: none;
+
 	@media (forced-colors: active) {
 		@content;
 	}


### PR DESCRIPTION
Task: task-[580494](https://dev.azure.com/ceapex/Engineering/_workitems/edit/580494/)

Link: preview-[394](https://design.docs.microsoft.com/pulls/394/components/radio.html)

This PR addresses three issues for radios:
- Sometimes the radio dot is off-centered when checked, depending on screen size and zoom level. This approach fills the entire radio, then uses box shadow to add the white space. 
- The body background color wasn't filling the entire unchecked radio when paired with a container with `background-color-body-medium`. The entire radio should be white when unchecked.
- The color on hover on `is-checked` was not matching the checked color. The hover color should be the same.

## Testing

1. Visit https://design.docs.microsoft.com/pulls/394/components/radio.html .
2. Try different screen sizes and zoom levels. The dot should stay in the center. 
3. Add `background-color-body-medium` on a radio's parent container. The entire circle should have a white background when unchecked.
4. Add `is-checked` to an unchecked radio. There should be no color change on hover.
5. Test with OS high contrast or browser forced colors