### PR TITLE
Add hash reload

### DIFF
--- a/.changeset/famous-queens-allow.md
+++ b/.changeset/famous-queens-allow.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': minor
+---
+
+Add form behavior hash reload handling.

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -124,7 +124,7 @@ class FormBehaviorElement extends HTMLElement {
 
 	navigate(href: string | null) {
 		if (href) {
-			navigateAfterSubmit(href, this.getAttribute('navigation'));
+			navigateAfterSubmit(href, this.getAttribute('navigation') as NavigationSteps);
 		}
 	}
 
@@ -558,6 +558,8 @@ interface LocStrings {
 	youMustSelectBetweenMinAndMaxTags: string;
 }
 
+type NavigationSteps = 'follow' | 'hash-reload' | 'replace' | 'reload' | null;
+
 export interface FormValidationError {
 	message: string;
 	input: HTMLValueElement;
@@ -670,7 +672,7 @@ function canValidate(
 	return isValueElement(target, form) && (target as HTMLValueElement).type !== 'hidden';
 }
 
-export function navigateAfterSubmit(href: string, navigationStep: string | null) {
+export function navigateAfterSubmit(href: string, navigationStep: NavigationSteps) {
 	switch (navigationStep) {
 		case null:
 			// do nothing.

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -507,17 +507,6 @@ class FormBehaviorElement extends HTMLElement {
 				a.textContent = message;
 				a.classList.add('help', 'help-danger');
 
-				/* a.addEventListener('click', e => {
-					console.log('e', e.target);
-					if (isCustomElement) {
-						const link = (e.target as HTMLAnchorElement).getAttribute('href');
-						if (link) {
-							console.log('click', document.querySelector(link));
-							(document.querySelector(link) as HTMLElement).focus();
-						}
-					}
-				}); */
-
 				child.appendChild(a);
 				errorList.appendChild(child);
 
@@ -689,6 +678,16 @@ export function navigateAfterSubmit(href: string, navigationStep: string | null)
 		case 'follow':
 			if (href) {
 				location.href = href;
+			}
+			break;
+		case 'hash-reload':
+			if (href) {
+				const search = href.includes('?') ? '' : window.location.search;
+				if (href !== search + window.location.hash) {
+					const state = (history.state || {}) as Record<string, any>;
+					window.history.pushState(state, document.title, window.location.pathname + search + href); // prevents scrolling to spot until reload
+				}
+				location.reload();
 			}
 			break;
 		case 'replace':

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -76,6 +76,7 @@ When the form does not require any edits (i.e the only action is to submit), you
 The form behavior component can accept certain HTML attributes.
 
 - `navigation` handles different navigation options after form submission.
+  - `hash-reload` - add a hash and reload the current page while navigating to the hash.
   - `follow` - redirect to the url provided by the API response header or `navigation-href` attribute value.
   - `reload` - reload the current page
   - `replace` - replaces the current page with the url provided by the API response header or `navigation-href` attribute value.


### PR DESCRIPTION
Task: task-[654492](https://dev.azure.com/ceapex/Engineering/_sprints/taskboard/Docs/Engineering/2022-06-26?workitem=654492)

Link: preview-[418](https://design.docs.microsoft.com/pulls/418/components/form.html)

This PR adds hash reload to form behavior. The goal is to add hash, then reload the page showing the updated info.

## Testing

1. Review code changes.
2. Visit https://design.docs.microsoft.com/pulls/418/components/input.html to verify form behavior still works.
