### PR TITLE
Fix input-sm padding

### DIFF
--- a/.changeset/stale-lions-rhyme.md
+++ b/.changeset/stale-lions-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Remove input-sm default padding.

--- a/css/src/components/form/input.scss
+++ b/css/src/components/form/input.scss
@@ -126,8 +126,6 @@ $input-icon-active-color: $secondary !default;
 		}
 
 		&.input-sm {
-			padding-inline-start: 2.75em;
-
 			~ .icon svg {
 				width: 0.875em;
 				height: 0.875em;

--- a/css/src/components/form/input.scss
+++ b/css/src/components/form/input.scss
@@ -55,8 +55,6 @@ $input-icon-active-color: $secondary !default;
 
 	&.input-sm {
 		@include control-sm;
-
-		padding-inline-start: 2.75em;
 	}
 
 	&.input-lg {
@@ -128,6 +126,8 @@ $input-icon-active-color: $secondary !default;
 		}
 
 		&.input-sm {
+			padding-inline-start: 2.75em;
+
 			~ .icon svg {
 				width: 0.875em;
 				height: 0.875em;


### PR DESCRIPTION
Task: task-[680298](https://dev.azure.com/ceapex/Engineering/_workitems/edit/680298)

Link: preview-[428](https://design.docs.microsoft.com/pulls/428/components/input.html)

This PR removes the excessive padding for input-sm

## Testing

1. Visit https://design.docs.microsoft.com/pulls/428/components/input.html . Go to the Sizes section and type something in the first input (input-sm).

Expected result: The left padding of the text should be minimal.

![image](https://user-images.githubusercontent.com/94572161/181598451-fd7deb38-1561-4f5d-a46e-3798784ae0d0.png)
