### PR TITLE
Add nounload attribute handling to form behavior

### DIFF
--- a/.changeset/modern-dolls-jog.md
+++ b/.changeset/modern-dolls-jog.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': minor
+---
+
+Add noUnload attribute handling to form behavior for disabling browser message on page unload.

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -39,17 +39,22 @@ class FormBehaviorElement extends HTMLElement {
 		this.locStrings = this.locStrings;
 	}
 
-	// use the new attribute when you want to ignore isDirty validation (for example, if the only user action on the form is to click a button)
-	get isNew() {
-		return this.hasAttribute('new');
-	}
-
 	get canSave() {
 		return this.isDirty || this.isNew;
 	}
 
 	get form() {
 		return this.closest(`form`);
+	}
+
+	// disable browser message when leaving page
+	get hideUnloadMessage() {
+		return this.hasAttribute('noUnload');
+	}
+
+	// use the new attribute when you want to ignore isDirty validation (for example, if the only user action on the form is to click a button)
+	get isNew() {
+		return this.hasAttribute('new');
 	}
 
 	connectedCallback() {
@@ -150,7 +155,7 @@ class FormBehaviorElement extends HTMLElement {
 
 	async handleUnloadEvent(event: BeforeUnloadEvent) {
 		this.setDirty();
-		if (!this.isDirty) {
+		if (!this.isDirty || this.hideUnloadMessage) {
 			return;
 		}
 

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -49,7 +49,7 @@ class FormBehaviorElement extends HTMLElement {
 
 	// disable browser message when leaving page
 	get hideUnloadMessage() {
-		return this.hasAttribute('noUnload');
+		return this.hasAttribute('nounload');
 	}
 
 	// use the new attribute when you want to ignore isDirty validation (for example, if the only user action on the form is to click a button)

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -75,13 +75,14 @@ When the form does not require any edits (i.e the only action is to submit), you
 
 The form behavior component can accept certain HTML attributes.
 
-- `navigation` handles different navigation options after form submission.
+- `navigation` - handles different navigation options after form submission. It can have the following values:
   - `hash-reload` - add a hash and reload the current page while navigating to the hash.
   - `follow` - redirect to the url provided by the API response header or `navigation-href` attribute value.
   - `reload` - reload the current page
   - `replace` - replaces the current page with the url provided by the API response header or `navigation-href` attribute value.
 - `navigation-href` - the url to navigate to.
 - `header-` - attribute values are added to the submit request header.
+- `nounload` - disables the browser warning message that appears when you try to navigate away from the current page with a partially filled out form.
 
 ##### Form with edits required
 

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -75,14 +75,15 @@ When the form does not require any edits (i.e the only action is to submit), you
 
 The form behavior component can accept certain HTML attributes.
 
-- `navigation` - handles different navigation options after form submission. It can have the following values:
-  - `hash-reload` - add a hash and reload the current page while navigating to the hash.
-  - `follow` - redirect to the url provided by the API response header or `navigation-href` attribute value.
-  - `reload` - reload the current page
-  - `replace` - replaces the current page with the url provided by the API response header or `navigation-href` attribute value.
-- `navigation-href` - the url to navigate to.
-- `header-` - attribute values are added to the submit request header.
-- `nounload` - disables the browser warning message that appears when you try to navigate away from the current page with a partially filled out form.
+| Attribute                | Description                                                                                                                             |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| navigation="hash-reload" | After form submission, add a hash and reload the current page while navigating to the hash.                                             |
+| navigation="follow"      | After form submission, redirect to the url provided by the API response header or `navigation-href` attribute value.                    |
+| navigation="reload"      | After form submission, reload the current page.                                                                                         |
+| navigation="replace"     | After form submission, replace the current page with the url provided by the API response header or `navigation-href` attribute value.  |
+| navigation-href=         | The url to navigate to.                                                                                                                 |
+| header-\*=               | For attributes that start with `header-`, the name after `header-` and its value is added to the submit request header.                 |
+| nounload                 | Disables the browser warning message that appears when you try to navigate away from the current page with a partially filled out form. |
 
 ##### Form with edits required
 

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -82,7 +82,7 @@ The form behavior component can accept certain HTML attributes.
 | navigation="reload"      | After form submission, reload the current page.                                                                                         |
 | navigation="replace"     | After form submission, replace the current page with the url provided by the API response header or `navigation-href` attribute value.  |
 | navigation-href=         | The url to navigate to.                                                                                                                 |
-| header-\*=               | For attributes that start with `header-`, the name after `header-` and its value is added to the submit request header.                 |
+| header-\*=               | For attributes that start with `header-`, the name after `header-` and the attribute value is added to the submit request header.       |
 | nounload                 | Disables the browser warning message that appears when you try to navigate away from the current page with a partially filled out form. |
 
 ##### Form with edits required

--- a/site/src/scaffold/scripts/form-submit.ts
+++ b/site/src/scaffold/scripts/form-submit.ts
@@ -31,10 +31,11 @@ export function handleMockFormSubmit() {
 				</svg>`;
 
 		form.addEventListener(
-			'validationerror',
+			'form-validating',
 			e => {
 				e.preventDefault();
 				const container = form.querySelector('.form-error-container');
+				console.log('container', container);
 				const warningIconContainer =
 					container?.firstElementChild?.querySelector('.warning-icon-container');
 

--- a/site/src/scaffold/scripts/form-submit.ts
+++ b/site/src/scaffold/scripts/form-submit.ts
@@ -35,7 +35,6 @@ export function handleMockFormSubmit() {
 			e => {
 				e.preventDefault();
 				const container = form.querySelector('.form-error-container');
-				console.log('container', container);
 				const warningIconContainer =
 					container?.firstElementChild?.querySelector('.warning-icon-container');
 


### PR DESCRIPTION
Task: task-686384

Link: preview-433

This PR adds a `nounload` attribute for form behavior to disable browser message of unsaved changes and reflects the changes made in https://dev.azure.com/ceapex/Engineering/_git/docs-ui/pullrequest/553286

## Testing

1. Visit https://design.docs.microsoft.com/pulls/433/components/form.html . Scroll down to form behavior section. Type a value into the first input. In the browser, hit the back button and you will see a warning message saying that your changes may not be saved.
2. Inspect the form and add `nounload` attribute to its form behavior element. Hit the back button again and it will navigate away without the warning message.
