### PR TITLE
Update form behavior skip validation

### DIFF
--- a/.changeset/selfish-birds-camp.md
+++ b/.changeset/selfish-birds-camp.md
@@ -3,4 +3,4 @@
 '@microsoft/atlas-site': patch
 ---
 
-Adding data attribute for form behavior error summary icon. Removing alert class from form behavior error summary.
+Add logic to skip validation for data-skip-validation attribute. Add data attribute for form behavior error summary icon. Remove alert class from form behavior error summary.

--- a/.changeset/selfish-birds-camp.md
+++ b/.changeset/selfish-birds-camp.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-js': patch
+'@microsoft/atlas-site': patch
+---
+
+Remove alert class from form behavior error summary.

--- a/.changeset/selfish-birds-camp.md
+++ b/.changeset/selfish-birds-camp.md
@@ -3,4 +3,4 @@
 '@microsoft/atlas-site': patch
 ---
 
-Add logic to skip validation for data-skip-validation attribute. Add data attribute for form behavior error summary icon. Remove alert class from form behavior error summary.
+Update form behavior to skip validation for data-skip-validation attribute.

--- a/.changeset/selfish-birds-camp.md
+++ b/.changeset/selfish-birds-camp.md
@@ -3,4 +3,4 @@
 '@microsoft/atlas-site': patch
 ---
 
-Remove alert class from form behavior error summary.
+Adding data attribute for form behavior error summary icon. Removing alert class from form behavior error summary.

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -284,8 +284,8 @@ export class FormBehaviorElement extends HTMLElement {
 		const alertId = generateElementId();
 
 		const errorAlert = document.createElement('div');
-		errorAlert.className =
-			'alert help help-danger border border-color-danger border-radius padding-xs';
+		errorAlert.className = 'help help-danger border border-color-danger border-radius padding-xs';
+		errorAlert.setAttribute('data-form-error-alert', '');
 		errorAlert.setAttribute('role', 'alert');
 		errorAlert.setAttribute('aria-labelledby', alertId);
 		errorAlert.setAttribute('tabindex', '-1');
@@ -307,7 +307,7 @@ export class FormBehaviorElement extends HTMLElement {
 	}
 
 	getErrorAlert(form: HTMLFormElement) {
-		const errorAlert = form.querySelector<HTMLDivElement>('[data-form-error-container] .alert');
+		const errorAlert = form.querySelector<HTMLDivElement>('[data-form-error-alert]');
 		if (errorAlert) {
 			return {
 				errorAlert,

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -384,8 +384,15 @@ export class FormBehaviorElement extends HTMLElement {
 				continue;
 			}
 
-			// Don't check markdown editor attachment input
-			if (input.id === 'attachment-count') {
+			if (input.hasAttribute('data-skip-validation')) {
+				const validationErrorEvent = new CustomEvent('form-validating', {
+					detail: {
+						errors,
+						form
+					},
+					bubbles: true
+				});
+				this.dispatchEvent(validationErrorEvent);
 				continue;
 			}
 

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -385,6 +385,7 @@ export class FormBehaviorElement extends HTMLElement {
 			}
 
 			if (input.hasAttribute('data-skip-validation')) {
+				this.clearValidationErrors(input);
 				const validationErrorEvent = new CustomEvent('form-validating', {
 					detail: {
 						errors,

--- a/site/src/scaffold/scripts/form-submit.ts
+++ b/site/src/scaffold/scripts/form-submit.ts
@@ -1,6 +1,7 @@
 export function handleMockFormSubmit() {
 	const warningIcon = document.createElement('span');
 	warningIcon.classList.add('warning-icon-container');
+	warningIcon.setAttribute('data-warning-icon-container', '');
 	warningIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="13" viewBox="0 0 15 13">
 			<path d="M7.50781 0.109375C7.23698 0.109375 6.98177 0.182292 6.74219 0.328125C6.5026 0.46875 6.31771 0.658854 6.1875 
 			0.898438L0.859375 10.7891C0.739583 11.013 0.679688 11.25 0.679688 11.5C0.679688 11.7031 0.721354 11.8958 0.804688 
@@ -35,8 +36,9 @@ export function handleMockFormSubmit() {
 			e => {
 				e.preventDefault();
 				const container = form.querySelector('[data-form-error-container]');
-				const warningIconContainer =
-					container?.firstElementChild?.querySelector('.warning-icon-container');
+				const warningIconContainer = container?.firstElementChild?.querySelector(
+					'[data-warning-icon-container]'
+				);
 
 				if (!warningIconContainer) {
 					container?.firstElementChild?.prepend(warningIcon);


### PR DESCRIPTION
Task: task-694306

Link: preview-450

This PR allows form behavior to skip its validation when an input has the `data-skip-validation` attribute.

## Testing

1. Visit https://design.docs.microsoft.com/pulls/450/components/form.html and go to the form behavior section. Click the Submit button and you should see an error about the textarea needing at least 10 characters. Inspect the form, find the textarea element, add `data-skip-validation` attribute. Click Submit button again and you should not see any errors about the text area not having enough characters.

