### PR TITLE
Remove bonus classes / move margin from holder div to child

### DIFF
--- a/.changeset/few-shoes-help.md
+++ b/.changeset/few-shoes-help.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': patch
+---
+
+Adjust margin classes on form behavior error container

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -65,7 +65,6 @@ export class FormBehaviorElement extends HTMLElement {
 
 		form.setAttribute('novalidate', '');
 		const errorSummaryContainer = document.createElement('div');
-		errorSummaryContainer.classList.add('margin-bottom-sm', 'background-color-danger-light');
 		errorSummaryContainer.setAttribute('data-form-error-container', '');
 		this.insertAdjacentElement('afterend', errorSummaryContainer);
 
@@ -276,7 +275,9 @@ export class FormBehaviorElement extends HTMLElement {
 		}
 	}
 
-	createErrorAlert(form: HTMLFormElement): {
+	createErrorAlert(
+		form: HTMLFormElement
+	): {
 		errorAlert: HTMLDivElement;
 		errorList: HTMLUListElement;
 	} {
@@ -284,7 +285,8 @@ export class FormBehaviorElement extends HTMLElement {
 		const alertId = generateElementId();
 
 		const errorAlert = document.createElement('div');
-		errorAlert.className = 'help help-danger border border-color-danger border-radius padding-xs';
+		errorAlert.className =
+			'help help-danger border border-color-danger border-radius padding-xs margin-bottom-sm';
 		errorAlert.setAttribute('data-form-error-alert', '');
 		errorAlert.setAttribute('role', 'alert');
 		errorAlert.setAttribute('aria-labelledby', alertId);

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -275,9 +275,7 @@ export class FormBehaviorElement extends HTMLElement {
 		}
 	}
 
-	createErrorAlert(
-		form: HTMLFormElement
-	): {
+	createErrorAlert(form: HTMLFormElement): {
 		errorAlert: HTMLDivElement;
 		errorList: HTMLUListElement;
 	} {

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -284,7 +284,7 @@ export class FormBehaviorElement extends HTMLElement {
 
 		const errorAlert = document.createElement('div');
 		errorAlert.className =
-			'help help-danger border border-color-danger border-radius padding-xs margin-bottom-sm';
+			'help help-danger background-color-danger-light border border-color-danger border-radius padding-xs margin-bottom-sm';
 		errorAlert.setAttribute('data-form-error-alert', '');
 		errorAlert.setAttribute('role', 'alert');
 		errorAlert.setAttribute('aria-labelledby', alertId);


### PR DESCRIPTION
Task: task-[work-item-number]

Link: [preview-454](https://github.com/microsoft/atlas-design/pull/454)

The margin on the parent error container, which is always present, is missaligning elements in the UI.
- Removes margin and background classes from parent container
- Adds margin to alert, alert already has background / border applied

## Testing

Visit https://design.docs.microsoft.com/pulls/454/components/form.html and trigger an error. The spacing / background should be correct.
