### PR TITLE
fix handleSubmitButtonAction formAction default

### DIFF
--- a/.changeset/four-news-type.md
+++ b/.changeset/four-news-type.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': patch
+---
+
+Fix formAction behavior

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -744,7 +744,9 @@ function clearInputErrorBorder(input: HTMLValueElement) {
 function handleSubmitButtonAction(event: Event) {
 	const submitter = (event as SubmitEvent).submitter;
 	const formAction =
-		submitter instanceof HTMLButtonElement && submitter.formAction ? submitter.formAction : null;
+		submitter instanceof HTMLButtonElement && submitter.formAction !== window.location.href
+			? submitter.formAction
+			: null;
 
 	return formAction;
 }


### PR DESCRIPTION
Task: [task-696605](https://dev.azure.com/ceapex/Engineering/_workitems/edit/696605)

Link: [preview-455](https://github.com/microsoft/atlas-design/pull/455)

Querying .formAction on a button without an action attribute will default to the page url. We need to adjust our lookup to account for that. https://www.w3schools.com/jsref/prop_pushbutton_formaction.asp

## Testing
View issue trying to POST question on this page: https://dev.docs.microsoft.com/en-us/answersv2/questions/ask/. It will 404 because the endpoint is defaulting to the page url.
