### PR TITLE
Remove href check from navigate

### DIFF
--- a/.changeset/bright-peas-itch.md
+++ b/.changeset/bright-peas-itch.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-js': patch
+'@microsoft/atlas-site': patch
+---
+
+Update navigation reload to not require href.

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -126,9 +126,7 @@ export class FormBehaviorElement extends HTMLElement {
 	}
 
 	navigate(href: string | null) {
-		if (href) {
-			navigateAfterSubmit(href, this.getAttribute('navigation') as NavigationSteps);
-		}
+		navigateAfterSubmit(href, this.getAttribute('navigation') as NavigationSteps);
 	}
 
 	scheduleCommit(event: Event) {
@@ -385,7 +383,6 @@ export class FormBehaviorElement extends HTMLElement {
 			}
 
 			if (input.hasAttribute('data-skip-validation')) {
-				this.clearValidationErrors(input);
 				const validationErrorEvent = new CustomEvent('form-validating', {
 					detail: {
 						errors,
@@ -398,7 +395,6 @@ export class FormBehaviorElement extends HTMLElement {
 			}
 
 			const isCustomElement = !!customElements.find(el => el === input);
-
 			this.runBasicValidation(input, displayValidity, errors, errorList, isCustomElement);
 			const validationErrorEvent = new CustomEvent('form-validating', {
 				detail: {
@@ -686,7 +682,7 @@ function canValidate(
 	return isValueElement(target, form) && (target as HTMLValueElement).type !== 'hidden';
 }
 
-export function navigateAfterSubmit(href: string, navigationStep: NavigationSteps) {
+export function navigateAfterSubmit(href: string | null, navigationStep: NavigationSteps) {
 	switch (navigationStep) {
 		case null:
 			// do nothing.

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -88,6 +88,7 @@ The form behavior component can accept certain HTML attributes.
 #### Custom validation
 
 Aside from basic input validation, you can use event listeners to listen for the `form-validating` custom event to inject custom validation logic.
+If you want to skip the basic validation on an input, apply a `data-skip-validation` attribute.
 
 ##### Form with edits required
 
@@ -180,6 +181,22 @@ Aside from basic input validation, you can use event listeners to listen for the
 				cols="30"
 				required
 			></textarea>
+		</div>
+	</div>
+	<div class="field">
+		<label class="field-label" for="sample-input">
+			Input
+			<span class="required-indicator"></span>
+		</label>
+		<div class="field-body">
+			<input
+				id="skip-input"
+				name="skip-input"
+				class="input"
+				type="text"
+				value=""
+				data-skip-validation
+			/>
 		</div>
 	</div>
 	<div class="display-flex">


### PR DESCRIPTION
Task: task-698189

Link: preview-459

This PR removes the href check from the navigate function as the `reload` case does not require a href. The other cases have their own href check. Also adding `data-skip-validation` attribute to the documentation.

## Testing

1. Review code. 
2. Visit https://design.docs.microsoft.com/pulls/459/components/form.html . 
