### PR TITLE
update .card-template to have flex-grow

### DIFF
--- a/.changeset/tough-lobsters-flow.md
+++ b/.changeset/tough-lobsters-flow.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Add flex-grow to .card-template. That container needs to grow to push the footer down.

--- a/css/src/components/card.scss
+++ b/css/src/components/card.scss
@@ -31,8 +31,8 @@ $card-column-gap: $spacer-5 !default;
 
 	.card-template {
 		display: grid;
-		padding: $card-padding;
 		flex-grow: 1;
+		padding: $card-padding;
 		grid-template: auto / 1fr $spacer-10;
 		gap: $card-row-gap $card-column-gap;
 		grid-template-areas:

--- a/css/src/components/card.scss
+++ b/css/src/components/card.scss
@@ -32,6 +32,7 @@ $card-column-gap: $spacer-5 !default;
 	.card-template {
 		display: grid;
 		padding: $card-padding;
+		flex-grow: 1;
 		grid-template: auto / 1fr $spacer-10;
 		gap: $card-row-gap $card-column-gap;
 		grid-template-areas:


### PR DESCRIPTION
Link: preview-462

No diff in its original context: https://design.docs.microsoft.com/pulls/462/components/card.html

Recent bug was unearthed that shows if a card with .card-template is used in a auto grid type of setting, then the footer is not pushed down to the bottom of the card.

