### PR TITLE
card horizontal needs flex-shrink on footer

### DIFF
--- a/.changeset/loud-turkeys-dream.md
+++ b/.changeset/loud-turkeys-dream.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-css': patch
+'@microsoft/atlas-site': patch
+---
+
+Card horiztonal needs flex-shrink in card footer.

--- a/css/src/components/card.scss
+++ b/css/src/components/card.scss
@@ -245,7 +245,7 @@ $card-column-gap: $spacer-5 !default;
 
 			.card-footer {
 				flex-grow: 1;
-				flex-shrink: 0;
+				flex-shrink: 1;
 				width: 100%;
 			}
 		}

--- a/site/src/components/card.md
+++ b/site/src/components/card.md
@@ -199,5 +199,25 @@ Another available option is using the `.card-content` inner container, and placi
 		<a class="card-title">The title of your content item here.</a>
 		<p>Additional metadata can be placed here.</p>
 	</div>
+	<div class="card-footer">
+		<div class="card-footer-item">
+			<span class="color-success">
+				<span>Completed</span>
+				<span class="icon">
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 448" class="fill-current-color">
+						<path
+							d="M160 397.255L9.373 246.627l45.255-45.254L160 306.745 393.373 73.373l45.254 45.255L160 397.255z"
+						/>
+					</svg>
+				</span>
+			</span>
+		</div>
+		<div class="card-footer-item">
+			<div class="buttons">
+				<button class="button button-clear button-sm">Share</button>
+				<button class="button button-primary button-sm">Save</button>
+			</div>
+		</div>
+	</div>
 </article>
 ```

--- a/site/src/components/card.md
+++ b/site/src/components/card.md
@@ -203,7 +203,7 @@ Another available option is using the `.card-content` inner container, and placi
 		<div class="card-footer-item">
 			<span class="color-success">
 				<span>Completed</span>
-				<span class="icon">
+				<span class="icon" aria-hidden="true">
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 448" class="fill-current-color">
 						<path
 							d="M160 397.255L9.373 246.627l45.255-45.254L160 306.745 393.373 73.373l45.254 45.255L160 397.255z"

--- a/site/src/components/card.md
+++ b/site/src/components/card.md
@@ -215,7 +215,7 @@ Another available option is using the `.card-content` inner container, and placi
 		<div class="card-footer-item">
 			<div class="buttons">
 				<button class="button button-clear button-sm">Share</button>
-				<button class="button button-primary button-sm">Save</button>
+				<button class="button button-clear button-primary button-sm">Save</button>
 			</div>
 		</div>
 	</div>

--- a/site/src/patterns/card.md
+++ b/site/src/patterns/card.md
@@ -43,7 +43,7 @@ This card type contains a super title labelled by the card's type, a title, an i
 		<div class="card-footer-item">
 			<div class="buttons">
 				<button class="button button-clear button-sm">Share</button>
-				<button class="button button-primary button-sm">Save</button>
+				<button class="button button-clear button-primary button-sm">Save</button>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Task: task-[work-item-number]

Link: preview-463

Fixes but with `.card.card-horizontal` where footer items on tablet view expand too far beyond card's boundaries.

## Testing

1. Section "A wide card using .card-horizontal" should have a card footer and no items in that footer should expand beyond the boundaries of the card.

## Additional information

Issue:

<img width="836" alt="image" src="https://user-images.githubusercontent.com/30843002/188223201-1ab8fc39-2e43-4972-88b7-56082eed623f.png">
