### PR TITLE
Replace references to docs.microsoft.com with learn.microsoft.com

### DIFF
--- a/.changeset/wicked-chairs-shop.md
+++ b/.changeset/wicked-chairs-shop.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': patch
+---
+
+Replace docs.microsoft.com references with learn.microsoft.com

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](<https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)>), please report it to us as described below.
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](<https://learn.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)>), please report it to us as described below.
 
 ## Reporting Security Issues
 

--- a/site/src/atomics/background.md
+++ b/site/src/atomics/background.md
@@ -20,7 +20,7 @@ First in order to apply a background pattern, specify the `--background-image-pa
 ```html
 <section
 	class="padding-lg background-image-pattern background-color-primary color-primary-invert"
-	style="--background-image-pattern: url('https://docs.microsoft.com/en-us/media/background-patterns/pixie-sticks.svg')"
+	style="--background-image-pattern: url('https://learn.microsoft.com/en-us/media/background-patterns/pixie-sticks.svg')"
 >
 	<h2 class="font-size-h2">A confetti background</h2>
 	<p>with <code>fill-opacity=".1"</code> on an svg</p>
@@ -34,13 +34,13 @@ You can adjust the look and feel of your pattern with different `background-size
 ```html
 <section
 	class="background-size-100 background-image-pattern padding-lg background-color-primary color-primary-invert"
-	style="--background-image-pattern: url('https://docs.microsoft.com/en-us/media/background-patterns/plus.svg')"
+	style="--background-image-pattern: url('https://learn.microsoft.com/en-us/media/background-patterns/plus.svg')"
 >
 	<p><code>background-size-100</code></p>
 </section>
 <section
 	class="background-size-200 background-image-pattern padding-lg margin-top-xxs background-color-primary color-primary-invert"
-	style="--background-image-pattern: url('https://docs.microsoft.com/en-us/media/background-patterns/plus.svg')"
+	style="--background-image-pattern: url('https://learn.microsoft.com/en-us/media/background-patterns/plus.svg')"
 >
 	<p><code>background-size-200</code></p>
 </section>
@@ -53,7 +53,7 @@ Be aware that a transparent svg will not be themeable, so while background color
 ```html
 <section
 	class="padding-lg background-color-primary color-primary-invert background-image-pattern background-size-100"
-	style="--background-image-pattern: url('https://docs.microsoft.com/en-us/media/background-patterns/plus.svg')"
+	style="--background-image-pattern: url('https://learn.microsoft.com/en-us/media/background-patterns/plus.svg')"
 >
 	<p><code>background-size-100</code></p>
 </section>

--- a/site/src/components/card.md
+++ b/site/src/components/card.md
@@ -83,7 +83,7 @@ The following can be used only inside `.card-template`.
 		<img
 			aria-hidden="true"
 			class="card-template-icon"
-			src="https://learn.microsoft.com/en-us/learn/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
+			src="https://learn.microsoft.com/en-us/training/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
 		/>
 		<div class="card-template-detail">
 			<p>Additional details might be listed here.</p>
@@ -144,7 +144,7 @@ The optional `.card-header` class can be used as a container to display anything
 			<img
 				aria-hidden="true"
 				class="card-template-icon"
-				src="https://learn.microsoft.com/en-us/learn/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
+				src="https://learn.microsoft.com/en-us/training/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
 			/>
 		</div>
 		<div class="position-absolute top-0 right-0 margin-top-xs margin-right-xxs">
@@ -174,7 +174,7 @@ The prescriptive `.card-template` subcomponent grows and shrinks well in this sc
 		<img
 			aria-hidden="true"
 			class="card-template-icon"
-			src="https://learn.microsoft.com/en-us/learn/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
+			src="https://learn.microsoft.com/en-us/training/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
 		/>
 		<div class="card-template-detail">
 			<p>Additional details might be listed here.</p>

--- a/site/src/components/card.md
+++ b/site/src/components/card.md
@@ -21,7 +21,7 @@ Also note that while many examples below use a width atomic, it's generally advi
 		<img
 			aria-hidden="true"
 			class="card-template-icon"
-			src="https://docs.microsoft.com/en-us/learn/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
+			src="https://learn.microsoft.com/en-us/training/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
 		/>
 		<div class="card-template-detail">
 			<p>Additional details or elements can be placed here.</p>
@@ -83,7 +83,7 @@ The following can be used only inside `.card-template`.
 		<img
 			aria-hidden="true"
 			class="card-template-icon"
-			src="https://docs.microsoft.com/en-us/learn/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
+			src="https://learn.microsoft.com/en-us/learn/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
 		/>
 		<div class="card-template-detail">
 			<p>Additional details might be listed here.</p>
@@ -138,13 +138,13 @@ The optional `.card-header` class can be used as a container to display anything
 <article class="card width-350">
 	<div
 		class="card-header position-relative background-size-100 background-image-pattern background-color-body-accent"
-		style="--background-image-pattern: url('https://docs.microsoft.com/en-us/media/background-patterns/plus.svg')"
+		style="--background-image-pattern: url('https://learn.microsoft.com/en-us/media/background-patterns/plus.svg')"
 	>
 		<div class="card-header-image">
 			<img
 				aria-hidden="true"
 				class="card-template-icon"
-				src="https://docs.microsoft.com/en-us/learn/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
+				src="https://learn.microsoft.com/en-us/learn/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
 			/>
 		</div>
 		<div class="position-absolute top-0 right-0 margin-top-xs margin-right-xxs">
@@ -174,7 +174,7 @@ The prescriptive `.card-template` subcomponent grows and shrinks well in this sc
 		<img
 			aria-hidden="true"
 			class="card-template-icon"
-			src="https://docs.microsoft.com/en-us/learn/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
+			src="https://learn.microsoft.com/en-us/learn/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
 		/>
 		<div class="card-template-detail">
 			<p>Additional details might be listed here.</p>

--- a/site/src/patterns/card.md
+++ b/site/src/patterns/card.md
@@ -21,7 +21,7 @@ This card type contains a super title labelled by the card's type, a title, an i
 		<img
 			alt="Write alt text here or if image is presentational only add aria-hidden attribute"
 			class="card-template-icon"
-			src="https://learn.microsoft.com/en-us/learn/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
+			src="https://learn.microsoft.com/en-us/training/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
 		/>
 		<div class="card-template-detail">
 			<p>Place card details items here.</p>

--- a/site/src/patterns/card.md
+++ b/site/src/patterns/card.md
@@ -21,7 +21,7 @@ This card type contains a super title labelled by the card's type, a title, an i
 		<img
 			alt="Write alt text here or if image is presentational only add aria-hidden attribute"
 			class="card-template-icon"
-			src="https://docs.microsoft.com/en-us/learn/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
+			src="https://learn.microsoft.com/en-us/learn/achievements/review-microsoft-azure-pricing-slas-lifecycles.svg"
 		/>
 		<div class="card-template-detail">
 			<p>Place card details items here.</p>

--- a/site/src/patterns/hero.md
+++ b/site/src/patterns/hero.md
@@ -15,7 +15,7 @@ This page catalogues some of the common combinations that might be used with the
 This hero can be used on hub type pages, and provides quick feed of where the user has landed.
 
 ```html-no-indent
-<section class="hero hero-xs background-color-primary color-primary-invert background-image-pattern background-size-200" style="--background-image-pattern: url('https://docs.microsoft.com/en-us/media/background-patterns/pixie-sticks.svg')">
+<section class="hero hero-xs background-color-primary color-primary-invert background-image-pattern background-size-200" style="--background-image-pattern: url('https://learn.microsoft.com/en-us/media/background-patterns/pixie-sticks.svg')">
 	<div class="hero-content">
 		<p class="letter-spacing-wide text-transform-uppercase font-size-sm">LOREM IPSUM DOLOR SIT AMET</p>
 		<h1 class="font-size-h1 font-weight-semibold">Wayfinding hero</h1>


### PR DESCRIPTION
Task: task-[work-item-number]

Link: [preview-471](https://design.docs.microsoft.com/pulls/471)

This pull request replaces references to `docs.microsoft.com` on the Atlas site with `learn.microsoft.com`. 

## Testing

1. Check that Atlas site mentions `learn.microsoft.com` instead of `docs.microsoft.com`.
2. Check that images on the Atlas site aren't broken.