### PR TITLE
add opacity to snap scroll items

### DIFF
--- a/css/src/components/scroll.scss
+++ b/css/src/components/scroll.scss
@@ -11,6 +11,7 @@
 }
 
 .scroll-snap-container {
+	display: flex;
 	gap: 1rem;
 	height: max-content;
 	margin-block: 1rem;
@@ -23,4 +24,9 @@
 	min-width: 80%;
 	height: auto;
 	scroll-snap-align: center;
+	opacity: 0.2;
+
+	&.is-current {
+		opacity: 1;
+	}
 }

--- a/css/src/components/scroll.scss
+++ b/css/src/components/scroll.scss
@@ -29,4 +29,8 @@
 	&.is-current {
 		opacity: 1;
 	}
+
+	@include desktop {
+		min-width: 40%;
+	}
 }

--- a/js/src/behaviors/snap-scroll.ts
+++ b/js/src/behaviors/snap-scroll.ts
@@ -46,9 +46,17 @@ export function initSnapScrollScrollListeners(element: HTMLElement) {
 			const anchor = element.querySelector(
 				`[data-snap-scroll-nav-item="${step}"]`
 			) as HTMLAnchorElement;
+			const slide = element.querySelector(`[data-snap-scroll-slide="${step}"]`) as HTMLElement;
+
 			if (!anchor) {
 				throw new Error('Anchor missing from snap scroll container');
 			}
+
+			if (!slide) {
+				throw new Error('Slide missing from snap scroll container');
+			}
+
+			updateSlideState(element, slide);
 			updatePaginationState(element, anchor);
 		}
 	}, options);
@@ -84,9 +92,10 @@ function initSnapScrollClickListeners() {
 			`[data-snap-scroll-slide="${snapScrollId}"]`
 		) as HTMLElement;
 
+		updateSlideState(parentElement, slide);
 		updatePaginationState(parentElement, target);
 
-		slide.scrollIntoView({ behavior: 'auto', block: 'nearest', inline: 'start' });
+		slide.scrollIntoView({ behavior: 'auto', block: 'nearest', inline: 'center' });
 
 		setTimeout(() => (snapScrollUpdating = false), 500);
 	});
@@ -102,4 +111,15 @@ function updatePaginationState(parentElement: HTMLElement, activeAnchor: HTMLAnc
 	}
 	// add one back
 	activeAnchor.classList.add('is-current');
+}
+function updateSlideState(parentElement: HTMLElement, activeSlide: HTMLElement) {
+	// remove is current from all slides in this container
+	const slides = Array.from(
+		parentElement.querySelectorAll('[data-snap-scroll-slide')
+	) as HTMLElement[];
+	for (const s of slides) {
+		s.classList.remove('is-current');
+	}
+	// add one back
+	activeSlide.classList.add('is-current');
 }

--- a/site/src/components/scroll.md
+++ b/site/src/components/scroll.md
@@ -79,7 +79,7 @@ Additionally, if your element is injected into the DOM after the `initSnapScroll
 
 ```html
 <section id="snap-scroll-1" class="width-full width-500-tablet display-none-widescreen" data-snap-scroll="first-one">
-	<div class="scroll-horizontal scroll-snap-container display-flex padding-bottom-xs" data-snap-scroll-slides>
+	<div class="scroll-horizontal scroll-snap-container padding-bottom-xs" data-snap-scroll-slides>
 		<article class="padding-sm border scroll-snap-item" id="one" data-snap-scroll-slide="first-one-1">
 			<h3 class="font-size-lg">1</h3>
 			<p>Description text is here and goes on for a little while.</p>

--- a/site/src/components/scroll.md
+++ b/site/src/components/scroll.md
@@ -78,7 +78,7 @@ A word of warning, if your inner elements contain focusable elements, you will n
 Additionally, if your element is injected into the DOM after the `initSnapScroll` function has been run initially, then you will need to manually run `initSnapScrollScrollListeners(yourElement)` to achieve correct pagination highlighting. See `js/behaviors/snap-scroll.ts` for relevant code.
 
 ```html
-<section id="snap-scroll-1" class="width-full width-500-tablet display-none-widescreen" data-snap-scroll="first-one">
+<section id="snap-scroll-1" class="width-full" data-snap-scroll="first-one">
 	<div class="scroll-horizontal scroll-snap-container padding-bottom-xs" data-snap-scroll-slides>
 		<article class="padding-sm border scroll-snap-item" id="one" data-snap-scroll-slide="first-one-1">
 			<h3 class="font-size-lg">1</h3>


### PR DESCRIPTION
Task: task-[721785](https://dev.azure.com/ceapex/Engineering/_sprints/taskboard/Assessments/Engineering/2022-10-05?workitem=721785)

Link: preview-[476](https://design.learn.microsoft.com/pulls/476)

## Testing

1. Navigate to [Scroll](https://design.learn.microsoft.com/pulls/476/components/scroll.html)
2. On a tablet view scroll to the snap scroll
   Expected result: current card is more visible than other cards

## Additional information

[Optional]
