### PR TITLE
Add the Atlas logo as the site favicon

### DIFF
--- a/.changeset/wise-rocks-rhyme.md
+++ b/.changeset/wise-rocks-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': patch
+---
+
+Add site favicon

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -11,6 +11,7 @@
 		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-src 'self' https://www.figma.com/; img-src data: 'self' https://github.com/ https://badge.fury.io/ https://*.cloudfront.net https://dev.azure.com https://via.placeholder.com https://docs.microsoft.com https://learn.microsoft.com; style-src 'self' 'unsafe-inline'" >
 		<link rel="stylesheet" href="~/src/scaffold/index.scss">
 		<script type="module" src="~/src/scaffold/index.ts"></script>
+		<link rel="icon" href="~/src/atlas-light.svg" type="image/svg+xml">
 	</head>
 	<body id="body">
 		<header id="header" class="border-bottom">


### PR DESCRIPTION
Task: task-[work-item-number]

Link: preview-[477](https://design.learn.microsoft.com/pulls/477)

We recently added a site logo SVG to the project. This PR uses that SVG as a site favicon, too, so that Atlas can be a little bit easier to find among your tabs.

## Testing

1. Navigate to the site.
   Expected result: The pink Atlas logo is used as the favicon.
