### PR TITLE
Ensure forced colors mode doesn't interfere with fill: currentColor

### DIFF
--- a/.changeset/tame-crabs-look.md
+++ b/.changeset/tame-crabs-look.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-css': minor
+'@microsoft/atlas-site': minor
+---
+
+Ensure forced colors mode doesn't interfere with fill: currentColor

--- a/css/src/atomics/colors.scss
+++ b/css/src/atomics/colors.scss
@@ -86,7 +86,7 @@
 }
 
 .fill-current-color {
-	fill: currentColor !important;
+	@include fill-current-color();
 }
 
 .outline-color-text {

--- a/css/src/components/form/input.scss
+++ b/css/src/components/form/input.scss
@@ -108,12 +108,13 @@ $input-icon-active-color: $secondary !default;
 		}
 
 		+ .icon {
+			@include fill-current-color();
+
 			position: absolute;
 			inset-block-start: 0;
 			inset-inline-start: 0;
 			width: $input-icon-size;
 			height: 100%;
-			fill: currentColor;
 			color: $input-icon-color;
 			pointer-events: none;
 			z-index: $zindex-multi;

--- a/css/src/mixins/colors.scss
+++ b/css/src/mixins/colors.scss
@@ -1,0 +1,6 @@
+@mixin fill-current-color {
+	fill: currentColor !important;
+
+	// Ensure SVG paths can adapt to forced colors theming
+	forced-color-adjust: auto;
+}

--- a/css/src/mixins/index.scss
+++ b/css/src/mixins/index.scss
@@ -1,5 +1,6 @@
 @import './media-queries.scss';
 @import './code-block.scss';
+@import './colors.scss';
 @import './control.scss';
 @import './center.scss';
 @import './focus.scss';

--- a/site/src/scaffold/styles/form.scss
+++ b/site/src/scaffold/styles/form.scss
@@ -7,8 +7,8 @@
 	margin-inline-end: $spacer-3;
 
 	svg {
-		fill: currentColor;
-		forced-color-adjust: auto;
+		@include fill-current-color();
+
 		width: 1rem;
 		height: auto;
 	}

--- a/site/src/scaffold/styles/form.scss
+++ b/site/src/scaffold/styles/form.scss
@@ -8,6 +8,7 @@
 
 	svg {
 		fill: currentColor;
+		forced-color-adjust: auto;
 		width: 1rem;
 		height: auto;
 	}


### PR DESCRIPTION
Task: task-[555516](https://ceapex.visualstudio.com/Engineering/_workitems/edit/555516)

Link: preview-[481](https://design.learn.microsoft.com/pulls/481/components/input.html)

Sometimes, the operating system forced colors mode and `fill: currentColor;` will clash, where the browser will show an SVG path in its non-forced color. If that non-forced color doesn't stand out against the forced color background, that part of the SVG won't be visible.

Applying `forced-color-adjust: auto` to the SVG path makes the browser use the forced colors decided by the parent, ensuring the SVG displays in colors suitable for the user.

## Testing

1. Navigate to https://design.learn.microsoft.com/pulls/481/components/input.html
2. Cycle through Windows' contrast themes.
   Expected result: In every theme, the _Microsoft_ wordmark in the logo at the top of the page will be visible, using whichever color is used for hyperlinks. For inputs with icons, the icons continue to display.

## Additional information

[Optional]
