### PR TITLE
Explicitly import `fill-current-color` mixin into atomics file

### DIFF
--- a/.changeset/serious-countries-chew.md
+++ b/.changeset/serious-countries-chew.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Explicitly import fill-current-color mixin in atomics

--- a/css/src/atomics/colors.scss
+++ b/css/src/atomics/colors.scss
@@ -1,3 +1,5 @@
+@import '../mixins/colors.scss';
+
 // Framework colors
 
 @each $name, $color-set in $colors {


### PR DESCRIPTION
Task: task-[555516](https://ceapex.visualstudio.com/Engineering/_workitems/edit/555516)

Link: preview-[486](https://design.learn.microsoft.com/pulls/486/components/input.html)

The Atlas version we just published is failing pipelines, due to the new `fill-current-color` mixin not being found. Based on local testing, explicitly importing the file with the new mixin seems to have fixed this.

## Testing

1. Builds should pass.
2. Regression on `fill-current-color` styles. Test steps from #481 duplicated here:

> 1. Navigate to https://design.learn.microsoft.com/pulls/486/components/input.html
> 2. Cycle through Windows' contrast themes.
>   Expected result: In every theme, the _Microsoft_ wordmark in the logo at the top of the page will be visible, using whichever color is used for hyperlinks. For inputs with icons, the icons continue to display.