### PR TITLE
add check to keep is-loading class through page reload

### DIFF
--- a/.changeset/empty-mayflies-argue.md
+++ b/.changeset/empty-mayflies-argue.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': minor
+---
+
+Update form submit is-loading class based on navigation

--- a/.changeset/empty-mayflies-argue.md
+++ b/.changeset/empty-mayflies-argue.md
@@ -1,5 +1,5 @@
 ---
-'@microsoft/atlas-js': minor
+'@microsoft/atlas-js': patch
 ---
 
 Update form submit is-loading class based on navigation

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -182,7 +182,7 @@ export class FormBehaviorElement extends HTMLElement {
 			this.dispatchEvent(validationErrorEvent);
 			return;
 		}
-
+		let isLoading = false;
 		try {
 			this.submitting = true;
 			setBusySubmitButton(form, this.submitting);
@@ -230,6 +230,7 @@ export class FormBehaviorElement extends HTMLElement {
 			const request = new Request(beforeSubmitEvent.detail.url, beforeSubmitEvent.detail.init);
 			const response = await fetch(request);
 			if (response.ok) {
+				isLoading = true;
 				this.removeAttribute('new');
 				this.initialData = formData;
 				this.setDirty();
@@ -268,8 +269,10 @@ export class FormBehaviorElement extends HTMLElement {
 				errorAlert.focus();
 			}
 		} finally {
-			this.submitting = false;
-			setBusySubmitButton(form, this.submitting);
+			if (this.getAttribute('navigation') === null || !isLoading) {
+				this.submitting = false;
+				setBusySubmitButton(form, this.submitting);
+			}
 		}
 	}
 

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -269,7 +269,7 @@ export class FormBehaviorElement extends HTMLElement {
 				errorAlert.focus();
 			}
 		} finally {
-			if (this.getAttribute('navigation') === null || !isLoading) {
+			if (!this.getAttribute('navigation') || !isLoading) {
 				this.submitting = false;
 				setBusySubmitButton(form, this.submitting);
 			}

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -693,8 +693,9 @@ export function navigateAfterSubmit(href: string | null, navigationStep: Navigat
 		case 'follow':
 			if (href) {
 				location.href = href;
+				return true;
 			}
-			return true;
+			return false;
 		case 'hash-reload':
 			if (href) {
 				const search = href.includes('?') ? '' : window.location.search;
@@ -709,8 +710,9 @@ export function navigateAfterSubmit(href: string | null, navigationStep: Navigat
 		case 'replace':
 			if (href) {
 				location.replace(href);
+				return true;
 			}
-			return true;
+			return false;
 		case 'reload':
 			location.reload();
 			return true;


### PR DESCRIPTION
Task: task-[694873](https://dev.azure.com/ceapex/Engineering/_workitems/edit/694873)

Link: preview-487

This PR adds a check to keep the is-loading icon if response is ok on form submit and navigation is not null. 
These are the steps I was using to test locally

## Testing

1. git checkout main; git pull; git checkout nmarshall/qna-isloading-check; npm run build:js;
2. Copy dist folder
3. In docs-ui repo, git checkout develop; git pull
4. In node-modules/@microsoft/atlas-js, delete current dist folder and paste new dist folder
5. npm run develop + Fiddler 
6. Navigate to a test question in answersv2 
https://dev.learn.microsoft.com/en-us/answersv2/questions/42897/testing-question-post
7. Test posting an empty comment or answer (is-loading should not display/stop)
8. Test posting not enough characters comment or answer (is-loading should not display/stop)
9. Test posting a long enough comment or answer
10. Test clicking the Follow question button   
Expected result: When posting a long enough comment or answer or clicking the Follow question button, the is-loading icon should stay until the page reloads (current behavior is it will stop and then reload the page causing confusion for users on slower connections)
