### PR TITLE
Adding missed token documentation pages

### DIFF
--- a/.changeset/chilled-clouds-rush.md
+++ b/.changeset/chilled-clouds-rush.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': minor
+---
+
+Adding token documentation pages.

--- a/site/src/tokens/animation.md
+++ b/site/src/tokens/animation.md
@@ -1,0 +1,8 @@
+---
+title: Animation
+description: Atlas CSS animation tokens
+template: token
+token: animation
+---
+
+# Animation

--- a/site/src/tokens/border.md
+++ b/site/src/tokens/border.md
@@ -1,0 +1,8 @@
+---
+title: Border
+description: Atlas CSS border tokens
+template: token
+token: border
+---
+
+# Border

--- a/site/src/tokens/breakpoints.md
+++ b/site/src/tokens/breakpoints.md
@@ -1,15 +1,15 @@
 ---
-title: Breakpoints and media queries
-description: Atlas CSS breakpoints tokens
+title: Breakpoints
+description: Atlas CSS breakpoints tokens and media queries tokens
 template: token
 token: breakpoints
 ---
 
 # Breakpoints and media queries
 
-Available media queries
+Available media queries:
 
-```css
+```scss
 @mixin tablet {
 	@media screen and (min-width: $breakpoint-tablet), print {
 		@content;

--- a/site/src/tokens/breakpoints.md
+++ b/site/src/tokens/breakpoints.md
@@ -1,0 +1,8 @@
+---
+title: Breakpoints
+description: Atlas CSS breakpoints tokens
+template: token
+token: breakpoints
+---
+
+# Breakpoints

--- a/site/src/tokens/breakpoints.md
+++ b/site/src/tokens/breakpoints.md
@@ -1,8 +1,53 @@
 ---
-title: Breakpoints
+title: Breakpoints and media queries
 description: Atlas CSS breakpoints tokens
 template: token
 token: breakpoints
 ---
 
-# Breakpoints
+# Breakpoints and media queries
+
+Available media queries
+
+```css
+@mixin tablet {
+	@media screen and (min-width: $breakpoint-tablet), print {
+		@content;
+	}
+}
+
+@mixin desktop {
+	@media screen and (min-width: $breakpoint-desktop) {
+		@content;
+	}
+}
+
+@mixin widescreen {
+	@media screen and (min-width: $breakpoint-widescreen) {
+		@content;
+	}
+}
+
+// Orientation
+
+@mixin orientation-portrait {
+	@media screen and (max-aspect-ratio: 1/1),
+		screen and (min-resolution: 120dpi) and (max-aspect-ratio: 1/1) {
+		@content;
+	}
+}
+
+@mixin orientation-landscape {
+	@media screen and (min-aspect-ratio: 1/1),
+		screen and (min-resolution: 120dpi) and (min-aspect-ratio: 1/1) {
+		@content;
+	}
+}
+
+@mixin orientation-square {
+	@media screen and (aspect-ratio: 1/1),
+		screen and (min-resolution: 120dpi) and (aspect-ratio: 1/1) {
+		@content;
+	}
+}
+```

--- a/site/src/tokens/focus.md
+++ b/site/src/tokens/focus.md
@@ -1,0 +1,8 @@
+---
+title: Focus
+description: Atlas CSS focus tokens
+template: token
+token: focus
+---
+
+# Focus

--- a/site/src/tokens/font-stack.md
+++ b/site/src/tokens/font-stack.md
@@ -1,0 +1,8 @@
+---
+title: Font stack
+description: Atlas CSS font-stack tokens
+template: token
+token: font-stack
+---
+
+# Font stack

--- a/site/src/tokens/layout.md
+++ b/site/src/tokens/layout.md
@@ -1,0 +1,8 @@
+---
+title: Layout
+description: Atlas CSS layout tokens
+template: token
+token: layout
+---
+
+# Layout

--- a/site/src/tokens/palette.md
+++ b/site/src/tokens/palette.md
@@ -1,0 +1,8 @@
+---
+title: Palette
+description: Atlas CSS palette tokens
+template: token
+token: palette
+---
+
+# Palette

--- a/site/src/tokens/shadow.md
+++ b/site/src/tokens/shadow.md
@@ -1,0 +1,8 @@
+---
+title: Shadow
+description: Atlas CSS shadow tokens
+template: token
+token: shadow
+---
+
+# Shadow

--- a/site/src/tokens/spacing.md
+++ b/site/src/tokens/spacing.md
@@ -1,0 +1,8 @@
+---
+title: Spacing
+description: Atlas CSS spacing tokens
+template: token
+token: spacing
+---
+
+# Spacing

--- a/site/src/tokens/typography.md
+++ b/site/src/tokens/typography.md
@@ -1,18 +1,8 @@
 ---
 title: Typography
-description: Demonstrating the capabilities of markdown using Parcel 2
+description: Atlas CSS typography tokens
 template: token
 token: typography
 ---
 
 # Typography
-
-This is some content!
-
-## Header 2
-
-This is some more content.
-
-```js
-let hello = 'world';
-```

--- a/site/src/tokens/z-index.md
+++ b/site/src/tokens/z-index.md
@@ -1,0 +1,8 @@
+---
+title: Z-index
+description: Atlas CSS z-index tokens
+template: token
+token: z-index
+---
+
+# z-index


### PR DESCRIPTION
Task: task-768358

Link: preview-493

Adding missed token pages to the site's documentation.

[Animation](https://design.learn.microsoft.com/pulls/493/tokens/animation.html)
[Border](https://design.learn.microsoft.com/pulls/493/tokens/border.html)
[Breakpoints](https://design.learn.microsoft.com/pulls/493/tokens/breakpoints.html)
[Focus](https://design.learn.microsoft.com/pulls/493/tokens/focus.html)
[Font stack](https://design.learn.microsoft.com/pulls/493/tokens/font-stack.html)
[Layout](https://design.learn.microsoft.com/pulls/493/tokens/layout.html)
[Palette](https://design.learn.microsoft.com/pulls/493/tokens/palette.html)
[Shadow](https://design.learn.microsoft.com/pulls/493/tokens/shadow.html)
[Spacing](https://design.learn.microsoft.com/pulls/493/tokens/spacing.html)
[Z-index](https://design.learn.microsoft.com/pulls/493/tokens/z-index.html)

## Testing

1. Review pages.
