### PR TITLE
add .is-focused for allow for optional programmatic focus handling

### DIFF
--- a/.changeset/great-queens-mate.md
+++ b/.changeset/great-queens-mate.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': patch
+---
+
+Full screen button needn't show up on mobile.

--- a/.changeset/shiny-teachers-cough.md
+++ b/.changeset/shiny-teachers-cough.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+add a where(.is-focused) class to allow for programatic management of focus

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,10 +28,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js 18.12.1
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18.12.1'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js 18.12.1
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18.12.1'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18.12.1
           registry-url: https://registry.npmjs.org

--- a/css/src/core/focus.scss
+++ b/css/src/core/focus.scss
@@ -33,3 +33,13 @@
 		}
 	}
 }
+
+:where(.is-focused) {
+	@extend %focus;
+
+	&.has-inner-focus,
+	&.inner-focus {
+		outline-color: currentColor;
+		outline-offset: -$focus-width;
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 		},
 		"css": {
 			"name": "@microsoft/atlas-css",
-			"version": "3.27.1",
+			"version": "3.27.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@microsoft/stylelint-config-atlas": "4.0.2",
@@ -99,7 +99,7 @@
 			"version": "1.3.0",
 			"license": "ISC",
 			"devDependencies": {
-				"@playwright/test": "^1.26.1",
+				"@playwright/test": "^1.29.2",
 				"@types/fs-extra": "9.0.13",
 				"@types/normalize-path": "^3.0.0",
 				"@types/pixelmatch": "^5.2.4",
@@ -2316,19 +2316,22 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.27.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.0.tgz",
-			"integrity": "sha512-L4BswoJvGkFsEHhEgzVNHBnkFB1FbnBQn3QmvTl7+AouoJQ4a8tLwZKvytdovCsNi7B5cXuRo58yGvfM5PnExw==",
+			"version": "1.31.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.1.tgz",
+			"integrity": "sha512-IsytVZ+0QLDh1Hj83XatGp/GsI1CDJWbyDaBGbainsh0p2zC7F4toUocqowmjS6sQff2NGT3D9WbDj/3K2CJiA==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
-				"playwright-core": "1.27.0"
+				"playwright-core": "1.31.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
 				"node": ">=14"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
 			}
 		},
 		"node_modules/@swc/helpers": {
@@ -8335,9 +8338,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.27.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.0.tgz",
-			"integrity": "sha512-VBKaaFUVKDo3akW+o4DwbK1ZyXh46tcSwQKPK3lruh8IJd5feu55XVZx4vOkbb2uqrNdIF51sgsadYT533SdpA==",
+			"version": "1.31.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.1.tgz",
+			"integrity": "sha512-JTyX4kV3/LXsvpHkLzL2I36aCdml4zeE35x+G5aPc4bkLsiRiQshU5lWeVpHFAuC8xAcbI6FDcw/8z3q2xtJSQ==",
 			"dev": true,
 			"bin": {
 				"playwright": "cli.js"
@@ -12132,7 +12135,7 @@
 		"@microsoft/atlas-integration": {
 			"version": "file:integration",
 			"requires": {
-				"@playwright/test": "^1.26.1",
+				"@playwright/test": "^1.29.2",
 				"@types/fs-extra": "9.0.13",
 				"@types/normalize-path": "^3.0.0",
 				"@types/pixelmatch": "^5.2.4",
@@ -13175,13 +13178,14 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.27.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.0.tgz",
-			"integrity": "sha512-L4BswoJvGkFsEHhEgzVNHBnkFB1FbnBQn3QmvTl7+AouoJQ4a8tLwZKvytdovCsNi7B5cXuRo58yGvfM5PnExw==",
+			"version": "1.31.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.1.tgz",
+			"integrity": "sha512-IsytVZ+0QLDh1Hj83XatGp/GsI1CDJWbyDaBGbainsh0p2zC7F4toUocqowmjS6sQff2NGT3D9WbDj/3K2CJiA==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
-				"playwright-core": "1.27.0"
+				"fsevents": "2.3.2",
+				"playwright-core": "1.31.1"
 			}
 		},
 		"@swc/helpers": {
@@ -17470,9 +17474,9 @@
 			}
 		},
 		"playwright-core": {
-			"version": "1.27.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.0.tgz",
-			"integrity": "sha512-VBKaaFUVKDo3akW+o4DwbK1ZyXh46tcSwQKPK3lruh8IJd5feu55XVZx4vOkbb2uqrNdIF51sgsadYT533SdpA==",
+			"version": "1.31.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.1.tgz",
+			"integrity": "sha512-JTyX4kV3/LXsvpHkLzL2I36aCdml4zeE35x+G5aPc4bkLsiRiQshU5lWeVpHFAuC8xAcbI6FDcw/8z3q2xtJSQ==",
 			"dev": true
 		},
 		"please-upgrade-node": {

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -69,7 +69,7 @@
 				</a>
 				<button
 					aria-label="Full screen main content"
-					class="button button-clear"
+					class="button button-clear display-none display-block-tablet"
 					data-full-screen-main>
 						<span class="icon" aria-hidden="true">
 							<svg class="fill-current-color" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2048 2048"><path d="M1664 1664v-384h128v512h-512v-128h384zM1280 256h512v512h-128V384h-384V256zM256 768V256h512v128H384v384H256zm128 512v384h384v128H256v-512h128z"/></svg>


### PR DESCRIPTION
Task: task-790605

Link: preview-505

Discovering that some downstream use cases require the ability to display a focus style on a particular element. This PR enables that, though the class should be used sparingly at most.

## Testing

1. Visit test link.
2. Use JS to force a focus style: `document.querySelectorAll('a,button').forEach(elt => elt.classList.add('is-focused'))`
