### PR TITLE
Updating button's icon sizes to use em

### DIFF
--- a/.changeset/eleven-rules-sort.md
+++ b/.changeset/eleven-rules-sort.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Updating button's icon size.

--- a/css/src/components/button.scss
+++ b/css/src/components/button.scss
@@ -6,9 +6,7 @@ $button-background-color: $body-background !default;
 $button-lg-font-size: $font-size-6 !default;
 $button-sm-font-size: $font-size-8 !default;
 
-$button-icon-font-size: $font-size-8 !default;
-$button-icon-sm-font-size: $font-size-9 !default;
-$button-icon-lg-font-size: $font-size-7 !default;
+$button-icon-font-size: 0.875em !default;
 
 $button-border-color: $text-subtle !default;
 $button-border-width: $control-border-width !default;
@@ -80,25 +78,13 @@ $button-font-weight: $weight-semibold !default;
 
 	// Sizes
 
-	/* stylelint-disable no-descending-specificity */
-
 	&.button-sm {
 		font-size: $button-sm-font-size;
-
-		.icon {
-			font-size: $button-icon-sm-font-size;
-		}
 	}
 
 	&.button-lg {
 		font-size: $button-lg-font-size;
-
-		.icon {
-			font-size: $button-icon-lg-font-size;
-		}
 	}
-
-	/* stylelint-enable no-descending-specificity */
 
 	// Modifiers
 


### PR DESCRIPTION
Link: preview-514

Changing the approach from defining exact icon sizes to relative em's.

## Testing

1. Review code
2. Visit [icon page](https://design.learn.microsoft.com/pulls/514/components/icon.html). Icons should be smaller than the button's text.
