### PR TITLE
add target-text color and url

### DIFF
--- a/.changeset/tricky-months-tie.md
+++ b/.changeset/tricky-months-tie.md
@@ -1,0 +1,5 @@
+---
+"@microsoft/atlas-css": patch
+---
+
+For browsers that support target-text, update the text color to make text and URLs more visible when highlighted

--- a/.changeset/tricky-months-tie.md
+++ b/.changeset/tricky-months-tie.md
@@ -2,4 +2,4 @@
 "@microsoft/atlas-css": minor
 ---
 
-For browsers that support target-text, update the text color to make text and URLs more visible when highlighted
+For browsers that support target-text, update the background color to make text and URLs more visible when highlighted

--- a/.changeset/tricky-months-tie.md
+++ b/.changeset/tricky-months-tie.md
@@ -1,5 +1,5 @@
 ---
-"@microsoft/atlas-css": patch
+"@microsoft/atlas-css": minor
 ---
 
 For browsers that support target-text, update the text color to make text and URLs more visible when highlighted

--- a/css/src/core/bare-elements.scss
+++ b/css/src/core/bare-elements.scss
@@ -38,6 +38,10 @@ fieldset {
 	color: $info-dark;
 }
 
-a > ::target-text {
-	color: $info-dark;
+:where(a)::target-text {
+	color: $hyperlink;
+}
+
+:where(a:visited)::target-text {
+	color: $visited;
 }

--- a/css/src/core/bare-elements.scss
+++ b/css/src/core/bare-elements.scss
@@ -32,3 +32,12 @@ fieldset {
 	min-width: 0; // as a replaced element min-width:0 is required to enable it to work in responsive layouts
 	border: none;
 }
+
+::target-text {
+	background-color: $info-background;
+	color: $info-dark;
+}
+
+a > ::target-text {
+	color: $info-dark;
+}

--- a/css/src/core/bare-elements.scss
+++ b/css/src/core/bare-elements.scss
@@ -34,14 +34,5 @@ fieldset {
 }
 
 ::target-text {
-	background-color: $info-background;
-	color: $info-dark;
-}
-
-:where(a)::target-text {
-	color: $hyperlink;
-}
-
-:where(a:visited)::target-text {
-	color: $visited;
+	background-color: $code-highlight-background;
 }


### PR DESCRIPTION
Task: [task-794609](https://ceapex.visualstudio.com/Engineering/_sprints/backlog/Docs/Engineering/2023-04-05?workitem=794609)

Link: [preview-528](https://design.learn.microsoft.com/pulls/528)

Change the color of the highlighted target text to meet accessibility requirements. Also, if a link is highlighted, make it clear to the reader that there is a link available (underline, on hover). 

## Testing

1. Highlight some text by adding a parameter to the URL:.
- For example: https://design.learn.microsoft.com/pulls/528#:~:text=Ensure%20git%20is%20installed
2. Ensure that text and links are visible in different color palettes and before/after clicking on a link. 