### PR TITLE
Fixing notification title's icon appearance

### DIFF
--- a/.changeset/mean-icons-travel.md
+++ b/.changeset/mean-icons-travel.md
@@ -2,4 +2,4 @@
 '@microsoft/atlas-css': patch
 ---
 
-Fixing title's icon and first element in banner and notification components apppearance.
+Fixing notification's icon position.

--- a/.changeset/mean-icons-travel.md
+++ b/.changeset/mean-icons-travel.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Fixing title's icon and first element in banner and notification components apppearance.

--- a/.changeset/modern-tools-grow.md
+++ b/.changeset/modern-tools-grow.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Fixing notification and banner components line-heights.

--- a/css/src/atomics/typography.scss
+++ b/css/src/atomics/typography.scss
@@ -193,5 +193,5 @@
 // Line height
 
 .line-height-normal {
-	line-height: 1.3;
+	line-height: $line-height-normal;
 }

--- a/css/src/components/banner.scss
+++ b/css/src/components/banner.scss
@@ -36,6 +36,10 @@ $banner-border-width: $border-width !default;
 		}
 	}
 
+	> :first-child {
+		margin-block-start: 0;
+	}
+
 	a:not(.button) {
 		color: currentColor;
 		font-weight: $weight-semibold;

--- a/css/src/components/banner.scss
+++ b/css/src/components/banner.scss
@@ -20,6 +20,7 @@ $banner-border-width: $border-width !default;
 	word-wrap: break-word;
 	word-break: break-word;
 	border-block: $banner-border-width solid $banner-border-color;
+	line-height: $line-height-normal;
 
 	&.is-loading {
 		color: transparent;
@@ -34,10 +35,6 @@ $banner-border-width: $border-width !default;
 			position: absolute;
 			border-color: transparent transparent $banner-color $banner-color;
 		}
-	}
-
-	> :first-child {
-		margin-block-start: 0;
 	}
 
 	a:not(.button) {

--- a/css/src/components/notification.scss
+++ b/css/src/components/notification.scss
@@ -54,10 +54,15 @@ $notification-border-radius: $border-radius !default;
 		}
 	}
 
+	> :first-child {
+		margin-block-start: 0;
+	}
+
 	.notification-title,
 	a:not(.button) {
 		color: currentColor;
 		font-weight: $weight-semibold;
+		line-height: 1.15;
 	}
 
 	a:not(.button) {

--- a/css/src/components/notification.scss
+++ b/css/src/components/notification.scss
@@ -9,7 +9,7 @@ $notification-border-width: $border-width !default;
 $notification-border-radius: $border-radius !default;
 
 $notification-icon-inline-spacing: 0.375em !default;
-$notification-icon-block-spacing: 0.1em !default;
+$notification-icon-block-spacing: 0.2em !default;
 
 .notification {
 	display: block;
@@ -62,7 +62,6 @@ $notification-icon-block-spacing: 0.1em !default;
 	a:not(.button) {
 		color: currentColor;
 		font-weight: $weight-semibold;
-		line-height: 1.15;
 	}
 
 	a:not(.button) {

--- a/css/src/components/notification.scss
+++ b/css/src/components/notification.scss
@@ -8,6 +8,9 @@ $notification-border-color: $control-border !default;
 $notification-border-width: $border-width !default;
 $notification-border-radius: $border-radius !default;
 
+$notification-icon-inline-spacing: 0.375em !default;
+$notification-icon-block-spacing: 0.1em !default;
+
 .notification {
 	display: block;
 	position: relative;
@@ -20,6 +23,7 @@ $notification-border-radius: $border-radius !default;
 	font-size: $notification-font-size;
 	word-wrap: break-word;
 	word-break: break-word;
+	line-height: $line-height-normal;
 
 	@each $name, $color-set in $colors {
 		$base: nth($color-set, $color-index-base);
@@ -54,10 +58,6 @@ $notification-border-radius: $border-radius !default;
 		}
 	}
 
-	> :first-child {
-		margin-block-start: 0;
-	}
-
 	.notification-title,
 	a:not(.button) {
 		color: currentColor;
@@ -80,7 +80,8 @@ $notification-border-radius: $border-radius !default;
 		.icon {
 			flex-shrink: 0;
 			align-self: start;
-			margin-inline-end: 0.375em;
+			margin-inline-end: $notification-icon-inline-spacing;
+			margin-block-start: $notification-icon-block-spacing;
 		}
 	}
 }

--- a/css/src/tokens/typography.scss
+++ b/css/src/tokens/typography.scss
@@ -26,4 +26,8 @@ $weight-bold: 700;
 // Letter spacing
 $letter-spacing-medium: 0.125rem;
 $letter-spacing-wide: 0.225rem;
+
+// Line height
+$line-height-normal: 1.3;
+
 //@end-sass-export-section


### PR DESCRIPTION
Task: task-819350

Link: preview-530

Updating both components with fixed `line-height` value (normal)
Updating `notification`'s icon appearance so it's nicely centered with the first line of text located next to it regardless of title's size.

## Testing

1. Visit [banner](https://design.learn.microsoft.com/pulls/530/components/banner.html) and [notification](https://design.learn.microsoft.com/pulls/530/components/banner.html) pages. Inspect both components. You should see `line-height: 1.3` assigned to both of them.
2. Icon on the notification page should look centered with the text next to it.
