### PR TITLE
lint for logical property usage, fix border related issues

### DIFF
--- a/.changeset/beige-bottles-film.md
+++ b/.changeset/beige-bottles-film.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Fix issue where border atomics did not use logical properties.

--- a/.changeset/olive-geckos-change.md
+++ b/.changeset/olive-geckos-change.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/stylelint-config-atlas': minor
+---
+
+Add linting for logical property usage.

--- a/css/src/atomics/colors.scss
+++ b/css/src/atomics/colors.scss
@@ -125,7 +125,7 @@
 }
 
 .background-color-alternating-grey {
-	border-top: 1px solid $border-white-high-contrast;
+	border-block-start: 1px solid $border-white-high-contrast;
 	outline-color: $text !important;
 
 	&:nth-of-type(even) {
@@ -140,7 +140,7 @@
 }
 
 .background-color-alternating-grey-reversed {
-	border-top: 1px solid $border-white-high-contrast;
+	border-block-start: 1px solid $border-white-high-contrast;
 	outline-color: $text !important;
 
 	&:nth-of-type(even) {

--- a/css/src/components/button.scss
+++ b/css/src/components/button.scss
@@ -110,8 +110,8 @@ $button-font-weight: $weight-semibold !default;
 			@include center(1em);
 
 			position: absolute !important;
-			border-bottom-color: $text;
-			border-left-color: $text;
+			border-block-end-color: $text;
+			border-inline-start-color: $text;
 		}
 	}
 

--- a/css/src/components/card.scss
+++ b/css/src/components/card.scss
@@ -127,7 +127,7 @@ $card-column-gap: $spacer-5 !default;
 		grid-area: title;
 
 		&:first-child {
-			margin-top: none;
+			margin-block-start: none;
 		}
 
 		&:only-child {
@@ -169,7 +169,7 @@ $card-column-gap: $spacer-5 !default;
 		display: flex;
 		flex-wrap: nowrap;
 		justify-content: space-between;
-		border-top: 1px solid $border;
+		border-block-start: 1px solid $border;
 		margin-inline: $card-padding;
 
 		// Artificial alignment of card item, intended for use on when there's only a single .card-footer-items

--- a/css/src/components/form/select.scss
+++ b/css/src/components/form/select.scss
@@ -71,14 +71,14 @@ $select-arrow-actual-width: 0.75em !default;
 		&::after {
 			display: block;
 			position: absolute;
-			top: calc(50% - $select-arrow-actual-width / 2);
+			inset-block-start: calc(50% - $select-arrow-actual-width / 2);
 			width: $select-arrow-size;
 			height: $select-arrow-size;
 			transform: rotate(-45deg);
 			transform-origin: center;
 			border: $select-arrow-border-width solid $select-color;
-			border-top: 0;
-			border-right: 0;
+			border-block-start: 0;
+			border-inline-end: 0;
 			pointer-events: none;
 			content: ' ';
 			z-index: $zindex-active;

--- a/css/src/components/media.scss
+++ b/css/src/components/media.scss
@@ -4,7 +4,7 @@
 
 	+ .media,
 	.media {
-		border-top: 1px solid $border;
+		border-block-start: 1px solid $border;
 		margin-block-start: 1rem;
 		padding-block-start: 1rem;
 	}

--- a/css/src/components/table.scss
+++ b/css/src/components/table.scss
@@ -37,7 +37,7 @@ $table-caption-spacing: $letter-spacing-medium !default;
 		display: table-cell;
 		word-wrap: break-word;
 		padding: $table-cell-vertical-padding $table-cell-horizontal-padding;
-		border-top: 1px solid $table-border-dark;
+		border-block-start: 1px solid $table-border-dark;
 		line-height: 1.5;
 		vertical-align: top;
 	}
@@ -62,11 +62,11 @@ $table-caption-spacing: $letter-spacing-medium !default;
 
 			thead tr:nth-child(1) th,
 			tbody tr:nth-child(1) td {
-				border-top: none;
+				border-block-start: none;
 			}
 
 			thead tr > th:last-child {
-				border-bottom: 1px solid $table-border-dark;
+				border-block-end: 1px solid $table-border-dark;
 			}
 		}
 	}

--- a/css/src/mixins/center.scss
+++ b/css/src/mixins/center.scss
@@ -2,10 +2,10 @@
 	position: absolute;
 
 	@if $height != 0 {
-		top: calc(50% - (#{$height} / 2));
-		left: calc(50% - (#{$width} / 2));
+		inset-block-start: calc(50% - (#{$height} / 2));
+		inset-inline-start: calc(50% - (#{$width} / 2));
 	} @else {
-		top: calc(50% - (#{$width} / 2));
-		left: calc(50% - (#{$width} / 2));
+		inset-block-start: calc(50% - (#{$width} / 2));
+		inset-inline-start: calc(50% - (#{$width} / 2));
 	}
 }

--- a/css/src/mixins/loader.scss
+++ b/css/src/mixins/loader.scss
@@ -6,8 +6,8 @@
 	animation: spinAround 500ms infinite linear;
 	border: 2px solid $border;
 	border-radius: $border-radius-rounded;
-	border-top-color: transparent;
-	border-right-color: transparent;
+	border-block-start-color: transparent;
+	border-inline-end-color: transparent;
 	content: '';
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 		},
 		"css": {
 			"name": "@microsoft/atlas-css",
-			"version": "3.30.0",
+			"version": "3.32.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@microsoft/stylelint-config-atlas": "4.0.2",
@@ -96,7 +96,7 @@
 		},
 		"integration": {
 			"name": "@microsoft/atlas-integration",
-			"version": "1.3.0",
+			"version": "1.4.0",
 			"license": "ISC",
 			"devDependencies": {
 				"@axe-core/playwright": "^4.6.1",
@@ -9062,9 +9062,9 @@
 			}
 		},
 		"node_modules/quicktype-core/node_modules/yaml": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
-			"integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+			"integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
 			"dev": true,
 			"engines": {
 				"node": ">= 14"
@@ -10215,6 +10215,17 @@
 				"stylelint": "^14.5.1 || ^15.0.0"
 			}
 		},
+		"node_modules/stylelint-use-logical": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/stylelint-use-logical/-/stylelint-use-logical-2.1.0.tgz",
+			"integrity": "sha512-DN1boOPI6IMYTlu2KeQpH5hDEiCODHhd+AtXU0InO37wkWAuELiPwuv59HrTg2m9PYmqGTTO/QWdMBafYVPfew==",
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"stylelint": ">= 11 < 16"
+			}
+		},
 		"node_modules/stylelint/node_modules/balanced-match": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
@@ -11328,10 +11339,10 @@
 		},
 		"plugins/parcel-transformer-markdown-html": {
 			"name": "@microsoft/parcel-transformer-markdown-html",
-			"version": "2.6.0",
+			"version": "2.6.1",
 			"license": "MIT",
 			"dependencies": {
-				"@microsoft/atlas-css": "^3.30.0",
+				"@microsoft/atlas-css": "^3.31.0",
 				"@parcel/plugin": "^2.8.3",
 				"@parcel/utils": "^2.8.3",
 				"front-matter": "^4.0.2",
@@ -11354,18 +11365,19 @@
 				"stylelint-config-recommended-scss": "^8.0.0",
 				"stylelint-config-standard": "^29.0.0",
 				"stylelint-order": "^6.0.3",
-				"stylelint-scss": "^4.6.0"
+				"stylelint-scss": "^4.6.0",
+				"stylelint-use-logical": "^2.1.0"
 			}
 		},
 		"site": {
 			"name": "@microsoft/atlas-site",
-			"version": "0.36.0",
+			"version": "0.37.1",
 			"license": "MIT",
 			"dependencies": {
 				"@microsoft/atlas-js": "^1.5.5"
 			},
 			"devDependencies": {
-				"@microsoft/atlas-css": "^3.30.0",
+				"@microsoft/atlas-css": "^3.31.0",
 				"@microsoft/parcel-transformer-markdown-html": "^2.6.0",
 				"@parcel/transformer-sass": "^2.8.3",
 				"@typescript-eslint/eslint-plugin": "^5.58.0",
@@ -12280,7 +12292,7 @@
 		"@microsoft/atlas-site": {
 			"version": "file:site",
 			"requires": {
-				"@microsoft/atlas-css": "^3.30.0",
+				"@microsoft/atlas-css": "^3.31.0",
 				"@microsoft/atlas-js": "^1.5.5",
 				"@microsoft/parcel-transformer-markdown-html": "^2.6.0",
 				"@parcel/transformer-sass": "^2.8.3",
@@ -12312,7 +12324,7 @@
 		"@microsoft/parcel-transformer-markdown-html": {
 			"version": "file:plugins/parcel-transformer-markdown-html",
 			"requires": {
-				"@microsoft/atlas-css": "^3.30.0",
+				"@microsoft/atlas-css": "^3.31.0",
 				"@parcel/plugin": "^2.8.3",
 				"@parcel/utils": "^2.8.3",
 				"front-matter": "^4.0.2",
@@ -12329,7 +12341,8 @@
 				"stylelint-config-recommended-scss": "^8.0.0",
 				"stylelint-config-standard": "^29.0.0",
 				"stylelint-order": "^6.0.3",
-				"stylelint-scss": "^4.6.0"
+				"stylelint-scss": "^4.6.0",
+				"stylelint-use-logical": "^2.1.0"
 			}
 		},
 		"@mischnic/json-sourcemap": {
@@ -17775,9 +17788,9 @@
 					}
 				},
 				"yaml": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
-					"integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+					"integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
 					"dev": true
 				}
 			}
@@ -18701,6 +18714,12 @@
 				"postcss-selector-parser": "^6.0.11",
 				"postcss-value-parser": "^4.2.0"
 			}
+		},
+		"stylelint-use-logical": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/stylelint-use-logical/-/stylelint-use-logical-2.1.0.tgz",
+			"integrity": "sha512-DN1boOPI6IMYTlu2KeQpH5hDEiCODHhd+AtXU0InO37wkWAuELiPwuv59HrTg2m9PYmqGTTO/QWdMBafYVPfew==",
+			"requires": {}
 		},
 		"supports-color": {
 			"version": "5.5.0",

--- a/plugins/stylelint-config-atlas/index.js
+++ b/plugins/stylelint-config-atlas/index.js
@@ -1,10 +1,14 @@
 'use strict';
 
 module.exports = {
-	plugins: ['stylelint-scss', 'stylelint-order'],
+	plugins: ['stylelint-scss', 'stylelint-order', 'stylelint-use-logical'],
 	extends: ['stylelint-config-standard', 'stylelint-config-recommended-scss'],
 	customSyntax: 'postcss-scss',
 	rules: {
+		'csstools/use-logical': [
+			'always',
+			{ except: ['width', 'height', 'max-height', 'min-height', 'max-width', 'min-width'] }
+		],
 		'number-leading-zero': 'never',
 		'selector-list-comma-newline-after': 'always',
 		'rule-empty-line-before': ['always', { except: ['first-nested'] }],

--- a/plugins/stylelint-config-atlas/package.json
+++ b/plugins/stylelint-config-atlas/package.json
@@ -22,7 +22,8 @@
 		"stylelint-order": "^6.0.3",
 		"stylelint-config-standard": "^29.0.0",
 		"stylelint-config-recommended-scss": "^8.0.0",
-		"stylelint": "^14.16.1"
+		"stylelint": "^14.16.1",
+		"stylelint-use-logical": "^2.1.0"
 	},
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Adds logical property linting to the repository. Omits width and height related rules, as I wasn't sure what the implications would be.

## Testing

1. `git checkout wbb/logical-props-linting; npm i; npm run lint;`
2. Change some instance of a rule to not use logical properties. Run again. See lint failure.

## Additional information

[Optional]

## Contributor checklist

- [ ] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
