### PR TITLE
Adds gradient to .gradient-text

### DIFF
--- a/.changeset/neat-lizards-fix.md
+++ b/.changeset/neat-lizards-fix.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-site': patch
+'@microsoft/atlas-css': patch
+---
+
+Adds new color theme to gradient-text-\* base class.

--- a/css/src/components/gradient.scss
+++ b/css/src/components/gradient.scss
@@ -75,16 +75,11 @@ $border-gradient-direction: (
 	}
 }
 
-// Text color gradients cannot be quite so programmatic
+@each $name, $gradient in $gradients {
+	$colorStart: nth($gradient, $gradient-color-start-index);
+	$colorEnd: nth($gradient, $gradient-color-end-index);
 
-.gradient-text-purple-blue {
-	/* stylelint-disable */
-	-webkit-background-clip: text;
-	/* stylelint-enable */
-	background-clip: text;
-	background-color: $gradient-text-purple;
-	background-image: linear-gradient(90deg, $gradient-text-purple, $gradient-text-blue);
-	color: transparent;
-	-webkit-text-fill-color: transparent;
-	line-height: 1.4; // required because of background clip, avoid "g" and "y" getting cut off
+	.gradient-text-#{$name} {
+		@include gradient-text($colorStart, $colorEnd);
+	}
 }

--- a/css/src/mixins/gradient.scss
+++ b/css/src/mixins/gradient.scss
@@ -1,0 +1,11 @@
+@mixin gradient-text($startColor, $endColor) {
+	/* stylelint-disable */
+	-webkit-background-clip: text;
+	/* stylelint-enable */
+	background-clip: text;
+	background-color: $startColor;
+	background-image: linear-gradient(90deg, $startColor, $endColor);
+	color: transparent;
+	-webkit-text-fill-color: transparent;
+	line-height: 1.4; // required because of background clip, avoid "g" and "y" getting cut off
+}

--- a/css/src/mixins/index.scss
+++ b/css/src/mixins/index.scss
@@ -4,6 +4,7 @@
 @import './control.scss';
 @import './center.scss';
 @import './focus.scss';
+@import './gradient.scss';
 @import './loader.scss';
 @import './line-clamp.scss';
 @import './layout-gap.scss';

--- a/css/src/tokens/colors.scss
+++ b/css/src/tokens/colors.scss
@@ -242,9 +242,8 @@ $gradient-color-end-index: 2;
 // 	$colorStart: nth($gradient, $gradient-color-start-index);
 // 	$colorEnd: nth($gradient, $gradient-color-end-index);
 
-// 	.border-color-#{$name} {
-// 		@include border-gradient($colorStart, $colorEnd);
-// 	}
+// 	.gradient-text-#{$name} {
+// 		@include gradient-text($colorStart, $colorEnd);
 // }
 
 //@end-sass-export-section

--- a/css/src/tokens/colors.scss
+++ b/css/src/tokens/colors.scss
@@ -237,13 +237,3 @@ $gradients: (
 
 $gradient-color-start-index: 1;
 $gradient-color-end-index: 2;
-
-// @each $name, $gradient in $gradients {
-// 	$colorStart: nth($gradient, $gradient-color-start-index);
-// 	$colorEnd: nth($gradient, $gradient-color-end-index);
-
-// 	.gradient-text-#{$name} {
-// 		@include gradient-text($colorStart, $colorEnd);
-// }
-
-//@end-sass-export-section

--- a/css/src/tokens/colors.scss
+++ b/css/src/tokens/colors.scss
@@ -224,4 +224,27 @@ $color-index-background-glow-high-contrast: 8;
 // 	$box-shadow: nth($color-set, $color-index-box-shadow);
 //}
 
+$gradients: (
+	'vivid': (
+		$gradient-vivid-start,
+		$gradient-vivid-end
+	),
+	'purple-blue': (
+		$gradient-text-purple,
+		$gradient-text-blue
+	)
+);
+
+$gradient-color-start-index: 1;
+$gradient-color-end-index: 2;
+
+// @each $name, $gradient in $gradients {
+// 	$colorStart: nth($gradient, $gradient-color-start-index);
+// 	$colorEnd: nth($gradient, $gradient-color-end-index);
+
+// 	.border-color-#{$name} {
+// 		@include border-gradient($colorStart, $colorEnd);
+// 	}
+// }
+
 //@end-sass-export-section

--- a/site/src/components/gradients.md
+++ b/site/src/components/gradients.md
@@ -17,7 +17,7 @@ There are two main types of gradients.
 
 ## Text color gradients
 
-Gradients transitions take up the entire width of a particular element, it's recommended to highlight inline elements, icons, or a portion of a heading, not the entire heading itself.
+Because gradient transitions take up the entire width of a particular element. It's recommended to highlight inline elements, icons, or a portion of a heading, and not the entire heading itself.
 
 | base class name             | interpolated value     |
 | --------------------------- | ---------------------- |
@@ -25,7 +25,7 @@ Gradients transitions take up the entire width of a particular element, it's rec
 
 ```html
 <h3 class="font-size-h3 font-weight-bold">
-	A dark gradient from <span class="gradient-text-purple-blue">purple to blue</span>
+	A muted gradient from <span class="gradient-text-purple-blue">purple to blue</span>
 </h3>
 <h3 class="font-size-h3 font-weight-bold">
 	A vivid gradient from <span class="gradient-text-vivid">purple to blue</span>

--- a/site/src/components/gradients.md
+++ b/site/src/components/gradients.md
@@ -17,12 +17,19 @@ There are two main types of gradients.
 
 ## Text color gradients
 
-Currently there is only one available gradient for text. Because gradients transitions take up the entire width of a particular element, it's recommended to highlight inline elements or a portion of a heading, not the entire heading itself.
+Gradients transitions take up the entire width of a particular element, it's recommended to highlight inline elements, icons, or a portion of a heading, not the entire heading itself.
+
+| base class name             | interpolated value     |
+| --------------------------- | ---------------------- |
+| `gradient-text-<colorname>` | `purple-blue`, `vivid` |
 
 ```html
 <h3 class="font-size-h3 font-weight-bold">
-	A gradient from <span class="gradient-text-purple-blue">purple to blue</span>
-</h2>
+	A dark gradient from <span class="gradient-text-purple-blue">purple to blue</span>
+</h3>
+<h3 class="font-size-h3 font-weight-bold">
+	A vivid gradient from <span class="gradient-text-vivid">purple to blue</span>
+</h3>
 ```
 
 ## Gradient borders usage

--- a/site/src/components/gradients.md
+++ b/site/src/components/gradients.md
@@ -17,7 +17,7 @@ There are two main types of gradients.
 
 ## Text color gradients
 
-Because gradient transitions take up the entire width of a particular element. It's recommended to highlight inline elements, icons, or a portion of a heading, and not the entire heading itself.
+Because gradient transitions take up the entire width of a particular element, it's recommended to highlight inline elements, icons, or a portion of a heading, and not the entire heading itself.
 
 | base class name             | interpolated value     |
 | --------------------------- | ---------------------- |


### PR DESCRIPTION
Task: task-828986

Link: preview-538

Adds new gradient colors to the existing `gradient-text*` class. Includes an update to make adding a gradient set for creating loops for gradient themes across components and a `mixin` to programmatically extend the gradient-text class for any new gradients added to the set. Context, gradient used across Copilot branding on Learn. Text gradient used for docon colors.

## Testing

1. Visit https://design.learn.microsoft.com/pulls/538/components/gradients.html
2. Validate `text-gradient-vivid` class is available. Confirm table and text updates to the site match Atlas standards and patterns.
   Expected result: ![image](https://github.com/microsoft/atlas-design/assets/38262647/af8e4348-6a5a-4beb-bfdc-b310caadc7c5)


## Additional information

Context: Used in Learn Copilot branding, same gradient used by the gradient-card component that is in flight. Used for a docon icon, current purple-blue gradient is too dark to notice the gradient and doesn't match the branding.

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
