### PR TITLE
add check to set is-loading on submitted button

### DIFF
--- a/.changeset/healthy-forks-promise.md
+++ b/.changeset/healthy-forks-promise.md
@@ -1,5 +1,0 @@
----
-'@microsoft/atlas-js': minor
----
-
-Update setBusySubmitButton to check for submitter button

--- a/.changeset/healthy-forks-promise.md
+++ b/.changeset/healthy-forks-promise.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': minor
+---
+
+Update setBusySubmitButton to check for submitter button

--- a/.changeset/silly-turkeys-count.md
+++ b/.changeset/silly-turkeys-count.md
@@ -2,4 +2,4 @@
 '@microsoft/atlas-js': patch
 ---
 
-Update setBusySubmitButton to check for submitter button
+Add submitter check to ensure only one submit button displays loading state on forms with multiple submit buttons.

--- a/.changeset/silly-turkeys-count.md
+++ b/.changeset/silly-turkeys-count.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': patch
+---
+
+Update setBusySubmitButton to check for submitter button

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -626,13 +626,10 @@ function normalizeInputValue(target: EventTarget | null) {
 }
 
 function setBusySubmitButton(event: Event, form: HTMLFormElement, isLoading: boolean) {
-	const submitter =
-		(event as SubmitEvent).submitter instanceof HTMLButtonElement
-			? (event as SubmitEvent).submitter
-			: null;
+	const submitter = (event as SubmitEvent).submitter;
 	Array.from(form.elements).forEach(element => {
 		if (element instanceof HTMLButtonElement && element.type === 'submit') {
-			if (!submitter || submitter === element) {
+			if (submitter && submitter === element) {
 				element.classList.toggle('is-loading', isLoading);
 			} else {
 				element.disabled = isLoading;

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -189,7 +189,7 @@ export class FormBehaviorElement extends HTMLElement {
 		let isNavigating = false;
 		try {
 			this.submitting = true;
-			setBusySubmitButton(form, this.submitting);
+			setBusySubmitButton(event, form, this.submitting);
 			const result = await this.validateForm(form);
 			if (!result.valid) {
 				return;
@@ -275,7 +275,7 @@ export class FormBehaviorElement extends HTMLElement {
 			}
 		} finally {
 			this.submitting = isNavigating;
-			setBusySubmitButton(form, this.submitting);
+			setBusySubmitButton(event, form, this.submitting);
 		}
 	}
 
@@ -625,10 +625,18 @@ function normalizeInputValue(target: EventTarget | null) {
 	}
 }
 
-function setBusySubmitButton(form: HTMLFormElement, isLoading: boolean) {
+function setBusySubmitButton(event: Event, form: HTMLFormElement, isLoading: boolean) {
+	const submitter =
+		(event as SubmitEvent).submitter instanceof HTMLButtonElement
+			? (event as SubmitEvent).submitter
+			: null;
 	Array.from(form.elements).forEach(element => {
 		if (element instanceof HTMLButtonElement && element.type === 'submit') {
-			element.classList.toggle('is-loading', isLoading);
+			if (!submitter || submitter === element) {
+				element.classList.toggle('is-loading', isLoading);
+			} else {
+				element.disabled = isLoading;
+			}
 		}
 	});
 }


### PR DESCRIPTION
Task: [task-834886](https://dev.azure.com/ceapex/Engineering/_workitems/edit/834886)

Currently if there is more than one submit button on a form (Q&A answer rating and Q&A moderator edit forms for example), when one submit button is clicked, they both display `is-loading` class, which is confusing to users. This PR adds a check to `setBusySubmitButton` to check for the submitter button to add `is-loading` class to that button and `disabled` status to the remaining submit buttons.

## Testing

This is how I tested this on the Q&A site:
1. `git checkout main; git pull; git checkout nmarshall/qna-update-setbusysubmitbutton; npm run build:js`
2. Copy the `js/dist` folder
3. In `docs-ui`, delete the existing `node_modules/@microsoft/atlas-js/dist` folder
4. **Note**: you may need to run `git clean -fxd; npm i; then do the above step
5. `npm run dev` and go to Q&A https://learn-microsoft-com.local/en-us/answers/questions/
6. Test various forms, below I've listed Q&A form examples, but please test elsewhere too
- Ask a question/add answer/add comment/follow/etc. -- Should be no change
- Editing as a moderator, which has two buttons -- The clicked button should have `is-loading`, the other should be disabled
- On your own question with answers from others (feel free to ping me if you need answers), rate Yes or No on the answer rating form -- The clicked button should have `is-loading`, the other should be disabled

## Contributor checklist

- [X] Did you update the description of this pull request with a review link and test steps?
- [X] Did you submit a changeset? Changesets are required for all code changes.
- [X] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
