### PR TITLE
Updating warning text color

### DIFF
--- a/.changeset/wet-rats-rule.md
+++ b/.changeset/wet-rats-rule.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Fixing warning text color to pass color contrast requirements.

--- a/css/src/atomics/colors.scss
+++ b/css/src/atomics/colors.scss
@@ -9,12 +9,20 @@
 	$invert: nth($color-set, $color-index-invert);
 
 	.color-#{$name} {
-		color: $base !important;
+		@if $name == 'warning' {
+			color: $dark;
+		} @else {
+			color: $base !important;
+		}
 	}
 
 	a.color-#{$name} {
 		&:hover {
-			color: $hover !important;
+			@if $name == 'warning' {
+				color: $active !important;
+			} @else {
+				color: $hover !important;
+			}
 		}
 
 		@include focus-visible {

--- a/css/src/atomics/colors.scss
+++ b/css/src/atomics/colors.scss
@@ -10,7 +10,7 @@
 
 	.color-#{$name} {
 		@if $name == 'warning' {
-			color: $dark;
+			color: $active;
 		} @else {
 			color: $base !important;
 		}

--- a/site/src/components/button.md
+++ b/site/src/components/button.md
@@ -143,7 +143,7 @@ The default clear button picks up the color the text set on a container. It is b
 Note! These buttons are not intended to be full featured, but rather to work when our typical themed buttons won't satisfy color requirements for non-standard background. Use with care, and _always test for a contrast ratio of greater than 4.5:1 between foreground and background_. When using them, it is recommended that you use a static text color, or to use in conjuction with a theme class to prevent accidental effects on other themes.
 
 ```html
-<div class="padding-lg theme-light background-color-body-medium color-warning">
+<div class="padding-lg theme-light background-color-body-medium color-success">
 	<button class="button button-clear">Adaptive clear</button>
 	<button class="button button-clear border">Adaptive with border</button>
 	<button class="button button-clear border" disabled>Adaptive disabled</button>

--- a/site/src/components/button.md
+++ b/site/src/components/button.md
@@ -136,16 +136,18 @@ Ensure the user knows they need to wait for some event (like a fetch request) in
 <button class="button button-primary button-filled is-loading">Loading</button>
 ```
 
+<!--
 ## Adaptive buttons
 
 The default clear button picks up the color the text set on a container. It is best used as an color-accessible button on a color not part of one of the Atlas themes. These button do not support loading states.
 
-Note! These buttons are not intended to be full featured, but rather to work when our typical themed buttons won't satisfy color requirements for non-standard background. Use with care, and _always test for a contrast ratio of greater than 4.5:1 between foreground and background_. When using them, it is recommended that you use a static text color, or to use in conjuction with a theme class to prevent accidental effects on other themes.
+Note! These buttons are not intended to be full featured, but rather to work when our typical themed buttons won't satisfy color requirements for non-standard background. Use with care, and _always test for a contrast ratio of greater than 4.5:1 between foreground and background_. When using them, it is recommended that you use a static text color, or to use in conjunction with a theme class to prevent accidental effects on other themes.
 
 ```html
-<div class="padding-lg theme-light background-color-body-medium color-success">
+<div class="padding-lg theme-light background-color-alternate color-warning">
 	<button class="button button-clear">Adaptive clear</button>
 	<button class="button button-clear border">Adaptive with border</button>
 	<button class="button button-clear border" disabled>Adaptive disabled</button>
 </div>
 ```
+-->

--- a/site/src/components/button.md
+++ b/site/src/components/button.md
@@ -143,7 +143,7 @@ The default clear button picks up the color the text set on a container. It is b
 Note! These buttons are not intended to be full featured, but rather to work when our typical themed buttons won't satisfy color requirements for non-standard background. Use with care, and _always test for a contrast ratio of greater than 4.5:1 between foreground and background_. When using them, it is recommended that you use a static text color, or to use in conjuction with a theme class to prevent accidental effects on other themes.
 
 ```html
-<div class="padding-lg theme-light background-color-alternate color-warning">
+<div class="padding-lg theme-light background-color-body-medium color-warning">
 	<button class="button button-clear">Adaptive clear</button>
 	<button class="button button-clear border">Adaptive with border</button>
 	<button class="button button-clear border" disabled>Adaptive disabled</button>


### PR DESCRIPTION
Task: task-[work-item-number]

Link: preview-549

Updating warning color so it passes color contrast accessibility reqs.

## Testing

1. Build passes
2. Visit any page. Apply `color-warning` atomic to any element. Color passes contrast reqs (#6a4b16 on #fff background color - 7.98 : 1)
3. Apply `color-warning` atomic to any link. Hover state color also passes contrast reqs. (#966802 on #fff background color - 4.91 : 1)
