### PR TITLE
Adding !important flag to the color atomic class

### DIFF
--- a/.changeset/dull-coins-cheer.md
+++ b/.changeset/dull-coins-cheer.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Adding !important to the color atomic class.

--- a/css/src/atomics/colors.scss
+++ b/css/src/atomics/colors.scss
@@ -10,7 +10,7 @@
 
 	.color-#{$name} {
 		@if $name == 'warning' {
-			color: $active;
+			color: $active !important;
 		} @else {
 			color: $base !important;
 		}


### PR DESCRIPTION
Link: preview-550

In the [last PR](https://github.com/microsoft/atlas-design/pull/549/files) `!important` flag was accidentally removed from the atomic class. This PR brings it back

## Testing

1. Review code changes
