### PR TITLE
Adds object-fit-cover class to image atomics

### DIFF
--- a/.changeset/fuzzy-fans-yell.md
+++ b/.changeset/fuzzy-fans-yell.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-site': patch
+'@microsoft/atlas-css': patch
+---
+
+Adds object-fit-cover css class to image atomics

--- a/css/src/atomics/image.scss
+++ b/css/src/atomics/image.scss
@@ -2,6 +2,10 @@
 	object-fit: contain !important;
 }
 
+.object-fit-cover {
+	object-fit: cover !important;
+}
+
 .object-fit-fill {
 	object-fit: fill !important;
 }

--- a/site/src/atomics/image.md
+++ b/site/src/atomics/image.md
@@ -18,6 +18,7 @@ List of all available classes:
 
 ```atomics-filter
 object-fit-contain
+object-fit-cover
 object-fit-fill
 object-position-top
 ```


### PR DESCRIPTION
Task: task-864855

Link: preview-561

object-fit: cover was missing from object-fit classes. Will be useful for full bleed images in containers and using in combination with aspect ratio atomics.

## Testing

1. Visit https://design.docs.microsoft.com/pulls/561/image.html
2. Inspect element, go to classes in css pane
   Expected result: `object-fit-cover` class exists

## Additional information

[Optional]

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
