### PR TITLE
update form behavior locale strings

### DIFF
--- a/.changeset/forty-onions-sell.md
+++ b/.changeset/forty-onions-sell.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': patch
+---
+
+Update when the locale strings get updated during initization

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -18,7 +18,7 @@ export class FormBehaviorElement extends HTMLElement {
 	toDispose: (() => void)[] = [];
 	isDirty = false;
 	commitTimeout = 0;
-	locStrings = defaultMessageStrings;
+	locStrings = this.getLocaleStrings(this);
 
 	validators: Validator[] = [
 		this.validateMinLength.bind(this), // min length before required

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -90,7 +90,7 @@ export class FormBehaviorElement extends HTMLElement {
 				map[kebabToCamelCase(a.name.substring(4)) as keyof LocStrings] = a.value;
 				return map;
 			}, {});
-			
+
 		return Object.assign({}, defaultMessageStrings, formLocaleStrings);
 	}
 

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -1,20 +1,16 @@
 import { generateElementId, kebabToCamelCase } from '../utilities/util';
 
-export const defaultMessageStrings = {
+const defaultMessageStrings = {
 	contentHasChanged: 'Content has changed, please reload the page to get the latest changes.',
 	inputMaxLength: '{inputLabel} cannot be longer than {maxLength} characters.',
 	inputMinLength: '{inputLabel} must be at least {minLength} characters.',
 	inputRequired: '{inputLabel} is required.',
-	notAuthenticated:
-		'You are not authenticated. Please refresh the page and try again. If this issue persists, please log out and log back in.',
-	notAuthorized:
-		'You are not authorized to make this response. If you believe this to be in error, please refresh the page and try again.',
 	pleaseFixTheFollowingIssues: 'Please fix the following issues to continue:',
 	thereAreNoEditsToSubmit: 'There are no edits to submit.',
-	tooManyRequests: 'You have sent too many requests. Please wait a few minutes and try again.',
 	weEncounteredAnUnexpectedError:
 		'We encountered an unexpected error. Please try again later. If this issue continues, please contact site support.'
 };
+
 // <form-behavior>
 export class FormBehaviorElement extends HTMLElement {
 	submitting = false as boolean;
@@ -22,16 +18,7 @@ export class FormBehaviorElement extends HTMLElement {
 	toDispose: (() => void)[] = [];
 	isDirty = false;
 	commitTimeout = 0;
-	locStrings = Object.assign(
-		{},
-		defaultMessageStrings,
-		Array.from(this.attributes)
-			.filter(a => a.name.startsWith('loc-'))
-			.reduce((map: { [key: string]: string }, a) => {
-				map[kebabToCamelCase(a.name.substring(4)) as keyof LocStrings] = a.value;
-				return map;
-			}, {})
-	);
+	locStrings = defaultMessageStrings;
 
 	validators: Validator[] = [
 		this.validateMinLength.bind(this), // min length before required
@@ -41,7 +28,6 @@ export class FormBehaviorElement extends HTMLElement {
 
 	constructor() {
 		super();
-		this.locStrings = this.locStrings;
 	}
 
 	get canSave() {
@@ -67,7 +53,7 @@ export class FormBehaviorElement extends HTMLElement {
 		if (!(form instanceof HTMLFormElement)) {
 			return;
 		}
-
+		this.locStrings = this.getLocaleStrings(this);
 		form.setAttribute('novalidate', '');
 		const errorSummaryContainer = document.createElement('div');
 		errorSummaryContainer.setAttribute('data-form-error-container', '');
@@ -95,6 +81,17 @@ export class FormBehaviorElement extends HTMLElement {
 		for (const dispose of this.toDispose) {
 			dispose();
 		}
+	}
+
+	getLocaleStrings(form: FormBehaviorElement) {
+		const formLocaleStrings = Array.from(form.attributes)
+			.filter(a => a.name.startsWith('loc-'))
+			.reduce((map: { [key: string]: string }, a) => {
+				map[kebabToCamelCase(a.name.substring(4)) as keyof LocStrings] = a.value;
+				return map;
+			}, {});
+			
+		return Object.assign({}, defaultMessageStrings, formLocaleStrings);
 	}
 
 	subscribe(target: EventTarget, type: string, listener: EventListenerObject) {

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -5,8 +5,13 @@ const defaultMessageStrings = {
 	inputMaxLength: '{inputLabel} cannot be longer than {maxLength} characters.',
 	inputMinLength: '{inputLabel} must be at least {minLength} characters.',
 	inputRequired: '{inputLabel} is required.',
+	notAuthenticated:
+		'You are not authenticated. Please refresh the page and try again. If this issue persists, please log out and log back in.',
+	notAuthorized:
+		'You are not authorized to make this response. If you believe this to be in error, please refresh the page and try again.',
 	pleaseFixTheFollowingIssues: 'Please fix the following issues to continue:',
 	thereAreNoEditsToSubmit: 'There are no edits to submit.',
+	tooManyRequests: 'You have sent too many requests. Please wait a few minutes and try again.',
 	weEncounteredAnUnexpectedError:
 		'We encountered an unexpected error. Please try again later. If this issue continues, please contact site support.'
 };
@@ -18,7 +23,7 @@ export class FormBehaviorElement extends HTMLElement {
 	toDispose: (() => void)[] = [];
 	isDirty = false;
 	commitTimeout = 0;
-	locStrings = this.getLocaleStrings();
+	locStrings = defaultMessageStrings;
 
 	validators: Validator[] = [
 		this.validateMinLength.bind(this), // min length before required

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -18,7 +18,7 @@ export class FormBehaviorElement extends HTMLElement {
 	toDispose: (() => void)[] = [];
 	isDirty = false;
 	commitTimeout = 0;
-	locStrings = this.getLocaleStrings(this);
+	locStrings = this.getLocaleStrings();
 
 	validators: Validator[] = [
 		this.validateMinLength.bind(this), // min length before required
@@ -53,7 +53,7 @@ export class FormBehaviorElement extends HTMLElement {
 		if (!(form instanceof HTMLFormElement)) {
 			return;
 		}
-		this.locStrings = this.getLocaleStrings(this);
+		this.locStrings = this.getLocaleStrings();
 		form.setAttribute('novalidate', '');
 		const errorSummaryContainer = document.createElement('div');
 		errorSummaryContainer.setAttribute('data-form-error-container', '');
@@ -83,8 +83,8 @@ export class FormBehaviorElement extends HTMLElement {
 		}
 	}
 
-	getLocaleStrings(form: FormBehaviorElement) {
-		const formLocaleStrings = Array.from(form.attributes)
+	getLocaleStrings() {
+		const formLocaleStrings = Array.from(this.attributes)
 			.filter(a => a.name.startsWith('loc-'))
 			.reduce((map: { [key: string]: string }, a) => {
 				map[kebabToCamelCase(a.name.substring(4)) as keyof LocStrings] = a.value;


### PR DESCRIPTION
Task: task-[866250](https://ceapex.visualstudio.com/Engineering/_sprints/taskboard/Q%20and%20A/Engineering/2023-07-12?workitem=866250)

Link: preview-[562](https://design.learn.microsoft.com/pulls/562)

We found that the form-behavior is bein initiated before the contents loads and when the locStrings tries to run there are no attributes yet.

So the thought is to have the locaStrings run in the `connectedCallback` instead of the constructor so the content can be loaded before the locStrings update.

## Testing

1. Step one
2. Step two
   Expected result: You should not see any visible difference

## Additional information

[Optional]

## Contributor checklist

- [ ] Did you update the description of this pull request with a review link and test steps?
- [ ] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
