### PR TITLE
update form behavior locale strings

### DIFF
--- a/.changeset/strange-goats-compare.md
+++ b/.changeset/strange-goats-compare.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': patch
+---
+
+Update when the locale strings get updated during initization

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -22,16 +22,7 @@ export class FormBehaviorElement extends HTMLElement {
 	toDispose: (() => void)[] = [];
 	isDirty = false;
 	commitTimeout = 0;
-	locStrings = Object.assign(
-		{},
-		defaultMessageStrings,
-		Array.from(this.attributes)
-			.filter(a => a.name.startsWith('loc-'))
-			.reduce((map: { [key: string]: string }, a) => {
-				map[kebabToCamelCase(a.name.substring(4)) as keyof LocStrings] = a.value;
-				return map;
-			}, {})
-	);
+	locStrings = defaultMessageStrings;
 
 	validators: Validator[] = [
 		this.validateMinLength.bind(this), // min length before required
@@ -68,6 +59,7 @@ export class FormBehaviorElement extends HTMLElement {
 			return;
 		}
 
+		this.locStrings = this.getLocaleStrings();
 		form.setAttribute('novalidate', '');
 		const errorSummaryContainer = document.createElement('div');
 		errorSummaryContainer.setAttribute('data-form-error-container', '');
@@ -95,6 +87,17 @@ export class FormBehaviorElement extends HTMLElement {
 		for (const dispose of this.toDispose) {
 			dispose();
 		}
+	}
+
+	getLocaleStrings() {
+		const formLocaleStrings = Array.from(this.attributes)
+			.filter(a => a.name.startsWith('loc-'))
+			.reduce((map: { [key: string]: string }, a) => {
+				map[kebabToCamelCase(a.name.substring(4)) as keyof LocStrings] = a.value;
+				return map;
+			}, {});
+
+		return Object.assign({}, defaultMessageStrings, formLocaleStrings);
 	}
 
 	subscribe(target: EventTarget, type: string, listener: EventListenerObject) {


### PR DESCRIPTION
Task: task-[866250](https://ceapex.visualstudio.com/Engineering/_sprints/taskboard/Q%20and%20A/Engineering/2023-07-12?workitem=866250)

Link: preview-[562](https://design.learn.microsoft.com/pulls/562)

We found that the form-behavior is bein initiated before the contents loads and when the locStrings tries to run there are no attributes yet.

So the thought is to have the locaStrings run in the `connectedCallback` instead of the constructor so the content can be loaded before the locStrings update.
