### PR TITLE
Add a nosubmit attribute to form-behavior

### DIFF
--- a/.changeset/lazy-cooks-learn.md
+++ b/.changeset/lazy-cooks-learn.md
@@ -1,0 +1,6 @@
+---
+"@microsoft/atlas-site": minor
+"@microsoft/atlas-js": minor
+---
+
+Add a nosubmit attribute to form-behavior

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -53,6 +53,12 @@ export class FormBehaviorElement extends HTMLElement {
 		return this.hasAttribute('new');
 	}
 
+	// Currently only used for Feedback form-behavior.
+	// Use the `nosubmit` attibute to bypass automatic form submission if a form contains a body but does not need to send a POST request.
+	get noSubmit() {
+		return this.hasAttribute('nosubmit');
+	}
+
 	connectedCallback() {
 		const form = this.parentElement;
 		if (!(form instanceof HTMLFormElement)) {
@@ -199,7 +205,7 @@ export class FormBehaviorElement extends HTMLElement {
 			this.submitting = true;
 			setBusySubmitButton(event, form, this.submitting);
 			const result = await this.validateForm(form);
-			if (!result.valid) {
+			if (!result.valid || this.noSubmit) {
 				return;
 			}
 

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -90,6 +90,7 @@ The form behavior component can accept certain HTML attributes.
 | header-\*=               | For attributes that start with `header-`, the name after `header-` and the attribute value is added to the submit request header.       |
 | nounload                 | Disables the browser warning message that appears when you try to navigate away from the current page with a partially filled out form. |
 | new                      | When the form does not require any edits (i.e the only action is to submit), adding the `new` attribute will override the validation.   |
+| nosubmit                 | Use the `nosubmit` attibute to bypass automatic form submission if a form contains a body but does not need to send a POST request.     |
 
 ### Custom validation
 


### PR DESCRIPTION
Task: task-874257

Link: preview-568

Add a `nosubmit` attribute to `form-behavior` to allow submit buttons to be clicked without sending a POST request. This is currently only used for user feedback.
 
## Testing

1. Visit the from component page in the preview link: [https://design.learn.microsoft.com/pulls/568/components/form.html](https://design.learn.microsoft.com/pulls/568/components/form.html).
2. Scroll down and find a form that has a submit button. For example, `sample-form-hide-validation-banner`. 
3. Fill out the form and click submit. Note the message "The following data will be submitted: ...".
4. Now, add the `nosubmit` attribute under `form-behavior`. 
6. Edit the form input slightly and click on the submit button again. The message should not change, indicating that the default behavior for the submit button has been stopped. 

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
