### PR TITLE
Persona follow up - locking line-height

### DIFF
--- a/.changeset/rotten-weeks-compete.md
+++ b/.changeset/rotten-weeks-compete.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Updating line-height value in persona component.

--- a/css/src/components/persona.scss
+++ b/css/src/components/persona.scss
@@ -17,6 +17,7 @@ $persona-gap-size: $layout-1 !default;
 	position: relative;
 	gap: $persona-gap-size;
 	font-size: $persona-font-size-md;
+	line-height: $line-height-normal;
 
 	.persona-avatar {
 		flex-shrink: 0;


### PR DESCRIPTION
Link: preview-573

Locking the `line-height` value to eliminate the effect from the parent elements.

## Testing

1. Review Persona component page
2. Review code
