### PR TITLE
Making persona's name semibold

### DIFF
--- a/.changeset/breezy-ladybugs-whisper.md
+++ b/.changeset/breezy-ladybugs-whisper.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Updating persona's name font-weight.

--- a/css/src/components/persona.scss
+++ b/css/src/components/persona.scss
@@ -9,6 +9,7 @@ $persona-avatar-border-radius: $border-radius-rounded;
 $persona-details-font-color: $text-subtle !default;
 $persona-name-font-size: $font-size-7 !default;
 $persona-name-font-color: $text !default;
+$persona-name-font-weight: $weight-semibold !default;
 
 $persona-gap-size: $layout-1 !default;
 
@@ -43,6 +44,7 @@ $persona-gap-size: $layout-1 !default;
 		.persona-name {
 			color: $persona-name-font-color;
 			font-size: 1.3333em;
+			font-weight: $persona-name-font-weight;
 		}
 	}
 


### PR DESCRIPTION
Link: preview-577

Making persona's name semibold by default since most of the use-cases require it.

## Testing

1. Visit [Persona](https://design.learn.microsoft.com/pulls/577/components/persona.html) page, and confirm the name is semibold.

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
