### PR TITLE
Support async form before submit handler

### DIFF
--- a/.changeset/breezy-crabs-remain.md
+++ b/.changeset/breezy-crabs-remain.md
@@ -1,6 +1,6 @@
 ---
-"@microsoft/atlas-site": patch
-"@microsoft/atlas-js": patch
+"@microsoft/atlas-site": minor
+"@microsoft/atlas-js": minor
 ---
 
 Support async form before submit handler

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -234,13 +234,18 @@ export class FormBehaviorElement extends HTMLElement {
 				detail: {
 					url,
 					init,
-					form
+					form,
+					callback: async () => {}
 				},
 				bubbles: true,
 				cancelable: true
 			});
 
 			const cancelled = !this.dispatchEvent(beforeSubmitEvent);
+			if (beforeSubmitEvent.detail.callback) {
+				await beforeSubmitEvent.detail.callback();
+			}
+
 			if (cancelled) {
 				return;
 			}

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -326,3 +326,60 @@ If there is a need to hide the validation banner on top of the form, we can appl
 	<div class="submitted-form-data-example"></div>
 </form>
 ```
+
+### Async beforesubmit handler
+
+To ensure that a submit event waits for an asynchronous beforesubmit handler to finish, you can set the event's detail callback property to your asynchronous logic. This will allow the event to wait for the completion of the asynchronous operation before proceeding with the submission.
+
+```typescript
+form.addEventListener(
+	'beforesubmit',
+	(event: CustomEventInit<{ callback: () => Promise<void> }>) => {
+		if (event.detail) {
+			event.detail.callback = async () => {
+				// TODO: Your async logic here.
+				return new Promise(resolve => setTimeout(resolve, 3000));
+			};
+		}
+	}
+);
+```
+
+```html
+<form
+	id="sample-form-simple"
+	data-form-type="question"
+	action="#"
+	method="POST"
+	novalidate=""
+	test-async-before-submit
+>
+	<form-behavior
+		new
+		navigation="reload"
+		header-x-docsauth="cookie"
+		loc-content-has-changed="Content has changed, please reload the page to get the latest changes."
+		loc-input-max-length="{inputLabel} cannot be longer than {maxLength} characters."
+		loc-input-min-length="{inputLabel} must be at least {minLength} characters."
+		loc-input-required="{inputLabel} is required."
+		loc-not-authenticated="You are not authenticated. Please refresh the page and try again. If this issue persists, please log out and log back in."
+		loc-not-authorized="You are not authorized to make this response. If you believe this to be in error, please refresh the page and try again."
+		loc-please-fix-the-following-issues="Please fix the following issues to continue:"
+		loc-there-are-no-edits-to-submit="There are no edits to submit."
+		loc-too-many-requests="You have sent too many requests. Please wait a few minutes and try again."
+		loc-we-encountered-an-unexpected-error="We encountered an unexpected error. Please try again later. If this issue continues, please contact site support."
+	></form-behavior>
+	<div class="field">
+		<button
+			type="submit"
+			class="button button-primary button-filled"
+			value="yes"
+			name="simple-form"
+			formaction="{some_url}"
+		>
+			Yes
+		</button>
+	</div>
+	<div class="submitted-form-data-example"></div>
+</form>
+```

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -347,7 +347,7 @@ form.addEventListener(
 
 ```html
 <form
-	id="sample-form-simple"
+	id="sample-async-form-simple"
 	data-form-type="question"
 	action="#"
 	method="POST"

--- a/site/src/scaffold/scripts/form-submit.ts
+++ b/site/src/scaffold/scripts/form-submit.ts
@@ -52,8 +52,19 @@ export function handleMockFormSubmit() {
 			e => {
 				e.preventDefault();
 
-				const formData = new FormData(form);
-				populateSubmittedFormData(formData, form);
+				if (form.hasAttribute('test-async-before-submit')) {
+					const customEvent = e as CustomEventInit<{ callback: () => Promise<void> }>;
+					if (customEvent.detail) {
+						customEvent.detail.callback = async () => {
+							await new Promise(resolve => setTimeout(resolve, 3000));
+							const formData = new FormData(form);
+							populateSubmittedFormData(formData, form);
+						};
+					}
+				} else {
+					const formData = new FormData(form);
+					populateSubmittedFormData(formData, form);
+				}
 			},
 			{ capture: true }
 		);


### PR DESCRIPTION
Task: task-[922469](https://dev.azure.com/ceapex/Engineering/_workitems/edit/922469/)

Link: [preview-591](https://design.docs.microsoft.com/pulls/591)

Currently the before submit event handling doesn't allow blocking submission until the handling is finished. Add a callback to support this.

Business requirement is QnA private message on sending message (submit) for the first time. It needs to call an API to create a thread and get threadId first.

## Testing

1. Visit https://design.learn.microsoft.com/pulls/591/components/form.html
2. Go to Async beforesubmit handler section and click yes button
   Expected result: The yes button keeps loading for 5 seconds and then submit.

## Additional information

[Optional]

## Contributor checklist

- [ ] Did you update the description of this pull request with a review link and test steps?
- [ ] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
