### PR TITLE
[Message] Prevent content from expanding grid items

### DIFF
--- a/.changeset/tidy-rings-matter.md
+++ b/.changeset/tidy-rings-matter.md
@@ -1,0 +1,5 @@
+---
+"@microsoft/atlas-css": patch
+---
+
+Prevent message content from expanding grid items

--- a/css/src/components/message.scss
+++ b/css/src/components/message.scss
@@ -21,7 +21,7 @@ $message-content-padding-sm: 0.875rem !default;
 	grid-template:
 		'. message-time'
 		'message-persona message-content';
-	grid-template-columns: max-content 1fr;
+	grid-template-columns: max-content minmax(0, 1fr);
 	gap: $message-gap-size;
 	font-size: $message-font-size-md;
 	line-height: $line-height-normal;


### PR DESCRIPTION
Task: task-[922469](https://dev.azure.com/ceapex/Engineering/_workitems/edit/922469/)

Link: [preview-592](https://design.learn.microsoft.com/pulls/592/components/message.html)

Stackoverflow answer [Prevent content from expanding grid items](https://stackoverflow.com/questions/43311943/prevent-content-from-expanding-grid-items)

## Testing

1. Visit the preview link
2. F12 and append the following html code after the message content
`<pre class="scroll-horizontal"><code>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut</code></pre>`

   Expected result: The content is scrollable
![image](https://github.com/microsoft/atlas-design/assets/52647802/cfe49446-54c2-49f5-ba7d-f98d0aee9e2c)

Before this fix: content break out of the container
![image](https://github.com/microsoft/atlas-design/assets/52647802/0136d6e6-8070-4d96-8a25-089e49dfdf75)


## Additional information

[Optional]

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
