### PR TITLE
readme link fix and badge size inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Looking for information about the Atlas CSS framework? Start in `/css`!
 | **Release Pipeline**     | [![Release](https://github.com/microsoft/atlas-design/actions/workflows/release.yml/badge.svg)](https://github.com/microsoft/atlas-design/actions/workflows/release.yml)                                |
 | **PR Builds**            | [![CI](https://github.com/microsoft/atlas-design/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/microsoft/atlas-design/actions/workflows/main.yml)                                |
 
+![Atlas-css package size (gzip)](https://img.badgesize.io/https:/unpkg.com/@microsoft/atlas-css/dist/index.css?label=css%20gzip%20size&compression=gzip)
+![Atlas-css package size (uncompressed)](<https://img.badgesize.io/https:/unpkg.com/@microsoft/atlas-css/dist/index.css?label=css%20size%20(uncompressed)>)
+
 ## Development
 
 - Ensure [git](https://git-scm.com/) is installed.

--- a/css/README.md
+++ b/css/README.md
@@ -18,7 +18,7 @@ npm install --save @microsoft/atlas-css
 Alternatively, you may access our scss directly for prototyping purposes at the following url:
 
 ```http
-https://unpkg.com/browse/@microsoft/atlas-css/index.scss
+https://unpkg.com/@microsoft/atlas-css/dist/index.css
 ```
 
 ## Project Structure


### PR DESCRIPTION
Small readme update to include the size of the css bundle and update a broken link.


https://github.com/microsoft/atlas-design/pull/594/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5