### PR TITLE
Set hero-image direction to avoid rtl flip

### DIFF
--- a/.changeset/fast-panthers-end.md
+++ b/.changeset/fast-panthers-end.md
@@ -2,4 +2,4 @@
 '@microsoft/atlas-css': minor
 ---
 
-Set hero image direction as ltr to prevent image flipping for rtl
+Set hero image direction to prevent image flipping for rtl

--- a/.changeset/fast-panthers-end.md
+++ b/.changeset/fast-panthers-end.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Set hero image direction as ltr to prevent image flipping for rtl

--- a/.changeset/wet-ladybugs-poke.md
+++ b/.changeset/wet-ladybugs-poke.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': minor
+---
+
+Update hero documentation

--- a/css/src/components/hero.scss
+++ b/css/src/components/hero.scss
@@ -100,6 +100,12 @@ $hero-image-width-widescreen: calc((100% - 2 * $layout-widescreen-gap) * 0.55) !
 		}
 	}
 
+	&.hero-image {
+		// Set direction to prevent image flip for rtl
+
+		direction: ltr;
+	}
+
 	&.hero-image::before {
 		display: none;
 		position: absolute;

--- a/css/src/components/hero.scss
+++ b/css/src/components/hero.scss
@@ -30,15 +30,12 @@ $hero-image-width-widescreen: calc((100% - 2 * $layout-widescreen-gap) * 0.55) !
 			width: $hero-content-fluid-width;
 			min-height: $hero-min-height-default;
 			padding-block: $hero-padding-default;
-			// not using logical properties here to avoid spacing issues for RTL
-			padding-right: $hero-padding-sm; /* stylelint-disable-line csstools/use-logical */
+			padding-inline-end: $hero-padding-sm;
 		}
 	}
 
 	&:not(.hero-image) {
 		.hero-content {
-			margin: auto;
-
 			@include desktop {
 				width: 100%;
 				max-width: $hero-content-width;
@@ -148,6 +145,11 @@ $hero-image-width-widescreen: calc((100% - 2 * $layout-widescreen-gap) * 0.55) !
 
 		.hero-content {
 			direction: rtl;
+
+			@include desktop {
+				padding-inline-end: unset;
+				padding-inline-start: $hero-padding-sm;
+			}
 		}
 	}
 }

--- a/css/src/components/hero.scss
+++ b/css/src/components/hero.scss
@@ -148,4 +148,12 @@ $hero-direction: ltr !default;
 			--hero-background-image: none;
 		}
 	}
+
+	&.hero-image:dir(rtl) {
+		direction: ltr;
+
+		.hero-content {
+			direction: rtl;
+		}
+	}
 }

--- a/css/src/components/hero.scss
+++ b/css/src/components/hero.scss
@@ -30,7 +30,8 @@ $hero-image-width-widescreen: calc((100% - 2 * $layout-widescreen-gap) * 0.55) !
 			width: $hero-content-fluid-width;
 			min-height: $hero-min-height-default;
 			padding-block: $hero-padding-default;
-			padding-inline-end: $hero-padding-sm;
+			// not using logical properties here to avoid spacing issues for RTL
+			padding-right: $hero-padding-sm; /* stylelint-disable-line csstools/use-logical */
 		}
 	}
 

--- a/css/src/components/hero.scss
+++ b/css/src/components/hero.scss
@@ -12,7 +12,6 @@ $hero-content-width: $reading-max-width !default;
 $hero-content-fluid-width: 45% !default;
 $hero-image-width: calc((100% - 2 * $layout-gap) * 0.55) !default;
 $hero-image-width-widescreen: calc((100% - 2 * $layout-widescreen-gap) * 0.55) !default;
-$hero-direction: ltr !default;
 
 .hero {
 	@extend %layout-gap;

--- a/css/src/components/hero.scss
+++ b/css/src/components/hero.scss
@@ -12,6 +12,7 @@ $hero-content-width: $reading-max-width !default;
 $hero-content-fluid-width: 45% !default;
 $hero-image-width: calc((100% - 2 * $layout-gap) * 0.55) !default;
 $hero-image-width-widescreen: calc((100% - 2 * $layout-widescreen-gap) * 0.55) !default;
+$hero-direction: ltr !default;
 
 .hero {
 	@extend %layout-gap;
@@ -103,7 +104,11 @@ $hero-image-width-widescreen: calc((100% - 2 * $layout-widescreen-gap) * 0.55) !
 	&.hero-image {
 		// Set direction to prevent image flip for rtl
 
-		direction: ltr;
+		direction: $hero-direction;
+
+		.hero-content {
+			direction: $user-text-direction;
+		}
 	}
 
 	&.hero-image::before {

--- a/css/src/components/hero.scss
+++ b/css/src/components/hero.scss
@@ -37,6 +37,8 @@ $hero-direction: ltr !default;
 
 	&:not(.hero-image) {
 		.hero-content {
+			margin: auto;
+
 			@include desktop {
 				width: 100%;
 				max-width: $hero-content-width;
@@ -101,16 +103,6 @@ $hero-direction: ltr !default;
 		}
 	}
 
-	&.hero-image {
-		// Set direction to prevent image flip for rtl
-
-		direction: $hero-direction;
-
-		.hero-content {
-			direction: $user-text-direction;
-		}
-	}
-
 	&.hero-image::before {
 		display: none;
 		position: absolute;
@@ -148,6 +140,8 @@ $hero-direction: ltr !default;
 			--hero-background-image: none;
 		}
 	}
+
+	// Set direction to prevent image flip for rtl
 
 	&.hero-image:dir(rtl) {
 		direction: ltr;

--- a/site/src/components/hero.md
+++ b/site/src/components/hero.md
@@ -98,6 +98,8 @@ Hero images are hidden in forced colors mode.
 
 **Images are currently not intended to scale or shrink. They are not shown on smaller or zoomed screens. For this reason, it's required that these images are presentational only. They should not contain words, subjects that might look naff if cut off, or anything essential to understanding the material of the page.**
 
+On RTL, the position of the hero image will remain on the right. The text within the hero content will be right aligned.
+
 ```html-no-indent
 <section
     class="hero hero-image border"

--- a/site/src/components/hero.md
+++ b/site/src/components/hero.md
@@ -98,7 +98,7 @@ Hero images are hidden in forced colors mode.
 
 **Images are currently not intended to scale or shrink. They are not shown on smaller or zoomed screens. For this reason, it's required that these images are presentational only. They should not contain words, subjects that might look naff if cut off, or anything essential to understanding the material of the page.**
 
-On RTL, the position of the hero image will remain on the right. The text within the hero content will be right aligned.
+On pages with right to left direction, the position of the hero image will remain on the right. The text within the hero content will be right aligned. This behavior prevents any unintended negative side effects when the position of the image and content is reversed. 
 
 ```html-no-indent
 <section


### PR DESCRIPTION
Task: task-922683

Link: [preview-598](https://design.learn.microsoft.com/pulls/598/components/hero.html)

https://developer.mozilla.org/en-US/docs/Web/CSS/:dir

JsFiddle demonstrating how the `dir(rtl)` should work: https://jsfiddle.net/ua8ksr1z/

This PR sets the .hero-image direction as `ltr` to prevent the flipping the hero image on RTL pages. The hero content still respects the user's text direction.

Note: In the JSFiddle environment above, the matched rule is `div dir:rtl`, while the matched rule in Atlas and elsewhere is `:lang()` instead. 

![image](https://github.com/microsoft/atlas-design/assets/94572161/b3d7bba8-7031-4698-b177-c154b2509e6a)

![image](https://github.com/microsoft/atlas-design/assets/94572161/cae4c96e-00fc-4b99-a948-4913c3b1bfa7)


## Testing

1. Visit https://design.learn.microsoft.com/pulls/598/components/hero.html . Scroll down to the hero image section. The image should be on the left side and the content text should be on the right side. 
2. Inspect the page with DevTools. For the top level `html` element, change the `lang` attribute to `ar-sa` and add `dir="rtl"` attribute. The hero content should remain on the left and the hero image should remain on the right.

## Contributor checklist

- [ ] Did you update the description of this pull request with a review link and test steps?
- [ ] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
