### PR TITLE
Update release pipeline permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      deployments: write
+      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,12 @@ on:
 
 jobs:
   release:
+    if: github.repository == 'microsoft/atlas-design'
+    permissions:
+      contents: write # to create release (changesets/action)
+      pull-requests: write # to create pull request (changesets/action)
     name: Release
     runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      deployments: write
-      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Task: task-948407
Link: preview-600

This PR adds permissions to the release pipeline. GitHub recently updated permissions for a token to be read-only. 

https://docs.opensource.microsoft.com/github/apps/permission-changes/

https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#permissions

Release failure: https://github.com/microsoft/atlas-design/actions/runs/7994309195/job/21832057165

Example of past successful releases: 
- https://github.com/microsoft/atlas-design/actions/runs/7425887667/job/20208464196
- https://github.com/microsoft/atlas-design/actions/runs/7561909380/job/20591203403
- https://github.com/microsoft/atlas-design/actions/runs/7561705859/job/20590576913


## Testing

1. Review the links above. Review code changes.

## Additional information

[Optional]

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [ ] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
