### PR TITLE
Add outline colors to static black and white backgrounds

### DIFF
--- a/.changeset/gold-keys-join.md
+++ b/.changeset/gold-keys-join.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Supply a contrasting outline-color for background-color-white-static and background-color-black-static atomics

--- a/css/src/atomics/colors.scss
+++ b/css/src/atomics/colors.scss
@@ -179,8 +179,10 @@
 
 .background-color-white-static {
 	background-color: $white-static !important;
+	outline-color: $black-static !important;
 }
 
 .background-color-black-static {
 	background-color: $black-static !important;
+	outline-color: $white-static !important;
 }

--- a/css/src/atomics/colors.scss
+++ b/css/src/atomics/colors.scss
@@ -178,11 +178,11 @@
 }
 
 .background-color-white-static {
-	background-color: $white-static !important;
 	outline-color: $black-static !important;
+	background-color: $white-static !important;
 }
 
 .background-color-black-static {
-	background-color: $black-static !important;
 	outline-color: $white-static !important;
+	background-color: $black-static !important;
 }


### PR DESCRIPTION
Task: task-[943198](https://ceapex.visualstudio.com/Engineering/_workitems/edit/943198)

Link: preview-606

To ensure focus outlines always have the necessary contrast against their backgrounds, we generally couple the `outline-color` declarations to the `background-color` declarations, and allow inheritance to take it from there.

This pull request extends that approach to the `.background-color-white-static` and `.background-color-black-static` atomics, which currently did not declare an `outline-color`.

## Testing

1. Navigate to https://design.learn.microsoft.com/pulls/606/tokens/colors.html
2. Inject the following markup into the page:
```html
<div class="background-color-white-static padding-xl">
    <p class="font-size-h4 font-weight-bold margin-bottom-xs">body <a href="#">with link</a></p>
</div>
<div class="background-color-black-static padding-xl">
    <p class="font-size-h4 font-weight-bold margin-bottom-xs">body <a href="#">with link</a></p>
</div>
```
3. Tab to the link in the white static `div`. **The focus outline should be black.**
4. Tab to the link in the black static `div`. **The focus outline should be white.**
5. Cycle through the themes and tab to the links again. **The focus outline in these two `div`s should not update based on theme.**

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
