### PR TITLE
[UX Wins] Optimize font stack for Windows 11 system font

### DIFF
--- a/.changeset/strong-bags-cry.md
+++ b/.changeset/strong-bags-cry.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': major
+---
+
+Update the default font on Windows from Segoe UI to Segoe UI Variable

--- a/css/src/tokens/font-stack.scss
+++ b/css/src/tokens/font-stack.scss
@@ -3,8 +3,8 @@
  */
 $monospace-font-stack: 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', 'Courier',
 	monospace !default;
-$normal-font-stack: -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
-	'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif,
-	'Apple Color Emoji', 'Segoe UI Emoji' !default;
+$normal-font-stack: -apple-system, 'BlinkMacSystemFont', 'Segoe UI Variable Text', 'Roboto',
+	'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Helvetica', 'Arial',
+	sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji' !default;
 $quote-font-stack: 'Arial', 'Helvetica Neue', 'Helvetica', sans-serif !default;
 //@end-sass-export-section

--- a/css/src/tokens/font-stack.scss
+++ b/css/src/tokens/font-stack.scss
@@ -3,8 +3,8 @@
  */
 $monospace-font-stack: 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', 'Courier',
 	monospace !default;
-$normal-font-stack: -apple-system, 'BlinkMacSystemFont', 'Segoe UI Variable Text', 'Roboto',
-	'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Helvetica', 'Arial',
-	sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji' !default;
+$normal-font-stack: -apple-system, 'BlinkMacSystemFont', 'Segoe UI Variable Text', 'Segoe UI',
+	'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+	'Helvetica', 'Arial', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji' !default;
 $quote-font-stack: 'Arial', 'Helvetica Neue', 'Helvetica', sans-serif !default;
 //@end-sass-export-section


### PR DESCRIPTION
Task: task-487561

Link: preview-607

Windows 11 ships with a new default font: "Segoe UI Variable".
https://docs.microsoft.com/en-us/windows/apps/design/signature-experiences/typography

However, we can't simply use `Segoe UI Variable` in CSS, we have to use `Segoe UI Variable Text` instead. Additional information provided in the linked work item. 

## Testing

1. In Edge and Chrome, go to the preview link, inspect, and check that `Segoe UI Variable Text` is in the list of fonts.
2. In Firefox, open the preview link and look for `Segoe UI Variable Text` in the font section of the inspector:
![image](https://github.com/microsoft/atlas-design/assets/47698191/189259f5-1ab3-44fd-b68a-0aeab8ffb580)

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
