### PR TITLE
Introduce .text-wrap-pretty typography atomic

### DIFF
--- a/.changeset/loud-lions-drive.md
+++ b/.changeset/loud-lions-drive.md
@@ -1,5 +1,5 @@
 ---
-'@microsoft/atlas-css': patch
+'@microsoft/atlas-css': minor
 ---
 
 Introduce a .text-wrap-pretty typography atomic

--- a/.changeset/loud-lions-drive.md
+++ b/.changeset/loud-lions-drive.md
@@ -1,6 +1,5 @@
 ---
 '@microsoft/atlas-css': patch
-'@microsoft/atlas-site': patch
 ---
 
 Introduce a .text-wrap-pretty typography atomic

--- a/.changeset/loud-lions-drive.md
+++ b/.changeset/loud-lions-drive.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-css': patch
+'@microsoft/atlas-site': patch
+---
+
+Introduce a .text-wrap-pretty typography atomic

--- a/.changeset/quiet-rockets-hug.md
+++ b/.changeset/quiet-rockets-hug.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': patch
+---
+
+Document new .text-wrap-pretty typography atomic

--- a/.changeset/quiet-rockets-hug.md
+++ b/.changeset/quiet-rockets-hug.md
@@ -1,5 +1,5 @@
 ---
-'@microsoft/atlas-site': patch
+'@microsoft/atlas-site': minor
 ---
 
 Document new .text-wrap-pretty typography atomic

--- a/css/src/atomics/typography.scss
+++ b/css/src/atomics/typography.scss
@@ -190,6 +190,11 @@
 	}
 }
 
+// Text wrapping behavior
+.text-wrap-pretty {
+	text-wrap: pretty !important;
+}
+
 // Line height
 
 .line-height-normal {

--- a/css/src/atomics/typography.scss
+++ b/css/src/atomics/typography.scss
@@ -191,6 +191,7 @@
 }
 
 // Text wrapping behavior
+
 .text-wrap-pretty {
 	text-wrap: pretty !important;
 }

--- a/site/src/atomics/typography.md
+++ b/site/src/atomics/typography.md
@@ -11,6 +11,7 @@ classPrefixes:
   - text-align
   - text-decoration
   - text-transform
+  - text-wrap
   - line-height
 ---
 
@@ -27,6 +28,7 @@ The typography scale is designed for great readability across the platform. This
 | `letter-spacing`  | `wide`                                                           | N\A        |
 | `text-transform`  | `uppercase`                                                      | N\A        |
 | `text-align`      | `left`, `center`, `right`                                        | `tablet`   |
+| `text-wrap`       | `pretty`                                                         |
 | `line-height`     | `normal`                                                         | N\A        |
 
 ## Font size
@@ -114,3 +116,12 @@ Appending with `-tablet` to a text-align class will make that class applicable t
 ```html
 <p class="text-align-center-tablet">Text is centered on tablet size and above.</p>
 ```
+
+## Text wrapping
+
+The `.text-wrap-pretty` atomic can be used to prevent [orphans](https://en.wikipedia.org/wiki/Widows_and_orphans), or situations where a line breaks and just one small word ends up on the next line. When the `.text-wrap-pretty` atomic is applied, the browser will instead try to cut the line so the break looks a little more balanced.
+
+`.text-wrap-pretty` has two caveats:
+
+- **Support:** As of March 2024, [support is mainly available in Chromium browsers](https://en.wikipedia.org/wiki/Widows_and_orphans). Browsers which don't support this rule will ignore it and break lines as usual. Treat this as a progressive enhancement.
+- **Performance:** Calculating optimal line breaks can be expensive, especially for larger blocks of text. Use, but use sparingly.

--- a/site/src/atomics/typography.md
+++ b/site/src/atomics/typography.md
@@ -132,5 +132,5 @@ If your browser supports pretty text-wrapping, resize your browser window and no
 
 `.text-wrap-pretty` has two caveats:
 
-- **Support:** As of March 2024, [support is mainly available in Chromium browsers](https://en.wikipedia.org/wiki/Widows_and_orphans). Browsers which don't support this rule will ignore it and break lines as usual. Treat this as a progressive enhancement.
+- **Support:** As of March 2024, [support is mainly available in Chromium browsers](https://caniuse.com/mdn-css_properties_text-wrap_pretty). Browsers which don't support this rule will ignore it and break lines as usual. Treat this as a progressive enhancement.
 - **Performance:** Calculating optimal line breaks can be expensive, especially for larger blocks of text. Use, but use sparingly.

--- a/site/src/atomics/typography.md
+++ b/site/src/atomics/typography.md
@@ -121,6 +121,15 @@ Appending with `-tablet` to a text-align class will make that class applicable t
 
 The `.text-wrap-pretty` atomic can be used to prevent [orphans](https://en.wikipedia.org/wiki/Widows_and_orphans), or situations where a line breaks and just one small word ends up on the next line. When the `.text-wrap-pretty` atomic is applied, the browser will instead try to cut the line so the break looks a little more balanced.
 
+Resize your browser, and notice the differences between how these two paragraphs break.
+
+```html
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut.</p>
+<p class="text-wrap-pretty">
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut.
+</p>
+```
+
 `.text-wrap-pretty` has two caveats:
 
 - **Support:** As of March 2024, [support is mainly available in Chromium browsers](https://en.wikipedia.org/wiki/Widows_and_orphans). Browsers which don't support this rule will ignore it and break lines as usual. Treat this as a progressive enhancement.

--- a/site/src/atomics/typography.md
+++ b/site/src/atomics/typography.md
@@ -121,7 +121,7 @@ Appending with `-tablet` to a text-align class will make that class applicable t
 
 The `.text-wrap-pretty` atomic can be used to prevent [orphans](https://en.wikipedia.org/wiki/Widows_and_orphans), or situations where a line breaks and just one small word ends up on the next line. When the `.text-wrap-pretty` atomic is applied, the browser will instead try to cut the line so the break looks a little more balanced.
 
-Resize your browser, and notice the differences between how these two paragraphs break.
+If your browser supports pretty text-wrapping, resize your browser window and notice the differences between how these two paragraphs break.
 
 ```html
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut.</p>

--- a/site/src/atomics/typography.md
+++ b/site/src/atomics/typography.md
@@ -28,7 +28,7 @@ The typography scale is designed for great readability across the platform. This
 | `letter-spacing`  | `wide`                                                           | N\A        |
 | `text-transform`  | `uppercase`                                                      | N\A        |
 | `text-align`      | `left`, `center`, `right`                                        | `tablet`   |
-| `text-wrap`       | `pretty`                                                         |
+| `text-wrap`       | `pretty`                                                         | N\A        |
 | `line-height`     | `normal`                                                         | N\A        |
 
 ## Font size
@@ -125,7 +125,7 @@ If your browser supports pretty text-wrapping, resize your browser window and no
 
 ```html
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut.</p>
-<p class="text-wrap-pretty">
+<p class="text-wrap-pretty margin-top-xxs">
 	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut.
 </p>
 ```


### PR DESCRIPTION
Task: task-[956415](https://ceapex.visualstudio.com/Engineering/_workitems/edit/956415)

Link: preview-608

Introduces the `.text-wrap-pretty` atomic, which can be applied as a progressive enhancement to bodies of text to encourage browsers to avoid orphaning words on the last line break.

## Testing

1. **In a Chromium browser,** open [the typography atomics page](https://design.learn.microsoft.com/pulls/608/atomics/typography.html) and scroll down to the _Text wrapping_ section at the bottom.
2. Resize the browser window and observe how the lines break.
__Expected result:__ For the `.text-wrap-pretty` paragraph, whenever the "ut." needs to break onto a new line, the "incidunt" goes with it, even if there's room for the "incidunt" on the previous line.

![Demo of two paragraphs of lorem-ipsum text, both of which have wrapped onto a second line. The first, default behavior just shows 'ut.' on the second line. The second paragraph has pretty wrapping, putting 'incidunt ut.' on the second line to make the wrap look more balanced.](https://github.com/microsoft/atlas-design/assets/18060369/db31572d-2edd-4c05-a360-ed87455dd1a5)

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
