### PR TITLE
Aa/minor hero css updates

### DIFF
--- a/.changeset/brave-knives-accept.md
+++ b/.changeset/brave-knives-accept.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Removing a superfluous width property on hero-content

--- a/css/src/components/hero.scss
+++ b/css/src/components/hero.scss
@@ -33,10 +33,6 @@ $hero-image-width-widescreen: calc((100% - 2 * $layout-widescreen-gap) * 0.55) !
 		z-index: $zindex-active;
 		padding-block: $hero-padding-sm;
 
-		@include tablet {
-			max-width: $hero-content-half-width;
-		}
-
 		@include desktop {
 			width: $hero-content-fluid-width;
 			min-height: $hero-min-height-default;


### PR DESCRIPTION
Task: task-953272

Link: preview-618

Found a bug on Docs-ui Vis Diff where all tablet width heros adjusted.  This mitigates that issue.

## Testing

1. Pull and Run
2. Open the Hero Component or Hero Patterns Pages
3. Make screen full-width and drop viewport size down to 768px or smaller.
4. When you adjust the screen size, verify that:
    -  the heros without the right content show full width text 
    - AND the hero with the right content is 50-50 at tablet, then 100% each on mobile.

## Additional information

[Optional]

## Contributor checklist

- [ ] Did you update the description of this pull request with a review link and test steps?
- [ ] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
