### PR TITLE
Reorder font stack to prefer Segoe

### DIFF
--- a/.changeset/hip-parrots-tap.md
+++ b/.changeset/hip-parrots-tap.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Updating font on Mac and Linux to Segoe UI Variable

--- a/css/src/tokens/font-stack.scss
+++ b/css/src/tokens/font-stack.scss
@@ -3,7 +3,7 @@
  */
 $monospace-font-stack: 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', 'Courier',
 	monospace !default;
-$normal-font-stack: -apple-system, 'BlinkMacSystemFont', 'Segoe UI Variable Text', 'Segoe UI',
+$normal-font-stack: 'Segoe UI', 'Segoe UI Variable Text', -apple-system, 'BlinkMacSystemFont',
 	'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
 	'Helvetica', 'Arial', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji' !default;
 $quote-font-stack: 'Arial', 'Helvetica Neue', 'Helvetica', sans-serif !default;


### PR DESCRIPTION
Task: task-487561

Link: preview-622

On Windows computers, use `Segoe UI`. `Segoe UI` is not available on Mac and Linux, so fallback to `Segoe UI Variable Text`. After that, fallback to the remaining fonts in the font stack. 

## Testing

1. Review changes. 
2. Checkout `ellyn/fonts` and `npm start`. On Windows, you should see that the font is still `Segoe UI`.

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
