### PR TITLE
lint:js should be run as part of PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Build Site and CSS
+name: Ensure build and lint
 
 # Controls when the action will run.
 on:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"codegen": "npm run codegen --workspace=@microsoft/atlas-integration",
 		"type-check": "npm run build:css && npm run type-check --workspace=@microsoft/atlas-site",
 		"prelint": "npm run build:tokens",
-		"lint": "npm run lint:css && npm run lint:site",
+		"lint": "npm run lint:css && npm run lint:site && npm run lint:js",
 		"lint:site": "npm run lint --workspace=@microsoft/atlas-site",
 		"lint:css": "npm run lint --workspace=@microsoft/atlas-css",
 		"prelint-fix": "npm run build:tokens",
@@ -68,11 +68,8 @@
 	],
 	"devDependencies": {
 		"@changesets/cli": "^2.26.2",
-		"@parcel/transformer-sass": "^2.11.0",
 		"@playwright/test": "^1.35.1",
 		"husky": "4.3.8",
-		"parcel": "^2.12.0",
-		"lightningcss": "^1.16.1",
 		"prettier": "^2.8.8",
 		"pretty-quick": "^3.1.3"
 	},


### PR DESCRIPTION
Previously it was missed that js linting was not being run on PR builds. Run should pass:

https://github.com/microsoft/atlas-design/actions/runs/9408474679/job/25916526913?pr=629

