### PR TITLE
Add `flex-basis`

### DIFF
--- a/.changeset/honest-peas-protect.md
+++ b/.changeset/honest-peas-protect.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+add support for flex-basis

--- a/css/src/atomics/flex.scss
+++ b/css/src/atomics/flex.scss
@@ -49,9 +49,8 @@ $flex-atomics: (
 	'flex-grow': (
 		0,
 		1
-	)
-	'flex-basis':
-	(
+	),
+	'flex-basis': (
 		0,
 		1
 	)

--- a/css/src/atomics/flex.scss
+++ b/css/src/atomics/flex.scss
@@ -50,6 +50,11 @@ $flex-atomics: (
 		0,
 		1
 	)
+	'flex-basis':
+	(
+		0,
+		1
+	)
 ) !default;
 
 @each $key in map.keys($flex-atomics) {

--- a/css/src/atomics/flex.scss
+++ b/css/src/atomics/flex.scss
@@ -52,7 +52,7 @@ $flex-atomics: (
 	),
 	'flex-basis': (
 		0,
-		1
+		auto
 	)
 ) !default;
 

--- a/site/src/atomics/flex.md
+++ b/site/src/atomics/flex.md
@@ -29,7 +29,7 @@ Flex atomics are useful when composing layouts and patterns containing other com
 | `align-content`   | `flex-start`, `flex-end`, `space-around`, `space-between`, `stretch`                | `tablet`   |
 | `flex-grow`       | `0`, `1`                                                                            | `tablet`   |
 | `flex-shrink`     | `0`, `1`                                                                            | `tablet`   |
-| `flex-basis`      | `0`, `1`                                                                            | `tablet`   |
+| `flex-basis`      | `0`, `auto`                                                                         | `tablet`   |
 
 ## Usage
 
@@ -91,7 +91,7 @@ The following example uses a combination of mobile-first flex atomics to achieve
 .flex-shrink-0
 .flex-shrink-1
 .flex-basis-0
-.flex-basis-1
+.flex-basis-auto
 .flex-direction-row-tablet
 .flex-direction-column-tablet
 .flex-direction-row-reverse-tablet
@@ -125,5 +125,5 @@ The following example uses a combination of mobile-first flex atomics to achieve
 .flex-shrink-0-tablet
 .flex-shrink-1-tablet
 .flex-basis-0-tablet
-.flex-basis-1-tablet
+.flex-basis-auto-tablet
 ```

--- a/site/src/atomics/flex.md
+++ b/site/src/atomics/flex.md
@@ -10,6 +10,7 @@ classPrefixes:
   - flex-direction
   - flex-grow
   - flex-shrink
+  - flex-basis
   - flex-wrap
   - justify-content
 ---
@@ -28,6 +29,7 @@ Flex atomics are useful when composing layouts and patterns containing other com
 | `align-content`   | `flex-start`, `flex-end`, `space-around`, `space-between`, `stretch`                | `tablet`   |
 | `flex-grow`       | `0`, `1`                                                                            | `tablet`   |
 | `flex-shrink`     | `0`, `1`                                                                            | `tablet`   |
+| `flex-basis`      | `0`, `1`                                                                            | `tablet`   |
 
 ## Usage
 
@@ -88,6 +90,8 @@ The following example uses a combination of mobile-first flex atomics to achieve
 .flex-grow-1
 .flex-shrink-0
 .flex-shrink-1
+.flex-basis-0
+.flex-basis-1
 .flex-direction-row-tablet
 .flex-direction-column-tablet
 .flex-direction-row-reverse-tablet
@@ -120,4 +124,6 @@ The following example uses a combination of mobile-first flex atomics to achieve
 .flex-grow-1-tablet
 .flex-shrink-0-tablet
 .flex-shrink-1-tablet
+.flex-basis-0-tablet
+.flex-basis-1-tablet
 ```


### PR DESCRIPTION
Task: task-976841

Link: [preview](http://localhost:1111/)

Add `flex-basis` to Atlas

## Testing

Inspect and paste the following in the page (such as at the end of the article) to ensure that `flex-basis-0` works. I tried it out and the input boxes became the same size after applying `flex-basis-0`. If you remove `flex-basis-0`, then the boxes end up varying sizes. 

```
<div class="display-flex flex-direction-column flex-direction-row-tablet gap-xxs margin-bottom-sm">
	<div class="flex-grow-1 flex-basis-0">	
		<input class="input">
	</div>

	<div class="flex-grow-1 flex-basis-0">
		<div class="select">
			<select></select>
		</div>
	</div>
	
	<div class="flex-grow-1 flex-basis-0">	
		<input class="input">
	</div>
</div>
```

## Additional information

[Optional]

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
