### PR TITLE
add .netrc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ toc.json
 test-results/
 playwright-report/
 .wireit
+.netrc


### PR DESCRIPTION
Seems that the changeset bot is creating a .netrc file during the course of its versioning/release work. This really shouldn't happen, but adding that file to gitignore anyway.

