### PR TITLE
Form Behavior Labels - Radios

### DIFF
--- a/.changeset/eight-turkeys-invent.md
+++ b/.changeset/eight-turkeys-invent.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-site': patch
+'@microsoft/atlas-js': patch
+---
+
+Minor update to the form behavior scripts that improves error messaging on radio input

--- a/.changeset/eight-turkeys-invent.md
+++ b/.changeset/eight-turkeys-invent.md
@@ -1,6 +1,6 @@
 ---
-'@microsoft/atlas-site': patch
-'@microsoft/atlas-js': patch
+'@microsoft/atlas-site': minor
+'@microsoft/atlas-js': minor
 ---
 
-Minor update to the form behavior scripts that improves error messaging on radio input
+Added form behavior radio group labeling and error handling.

--- a/integration/tests/form-behavior.spec.ts
+++ b/integration/tests/form-behavior.spec.ts
@@ -81,9 +81,21 @@ test.describe('form behavior validation', () => {
 		await submitBtn.click();
 
 		expect(errorContainer).toContainText('Please fix the following issues to continue:');
-		expect(errorContainer).toContainText([
-			`At least one selection from ${groupLabel} is required.`
-		]);
+		expect(errorContainer).toContainText([`A selection for "${groupLabel}" is required.`]);
+	});
+
+	test('show inputGroupRequired message when checkbox group is missing a selection', async ({
+		page,
+		errorContainer,
+		submitBtn
+	}) => {
+		const input = page.locator('#sample-multi-checkbox-2');
+		const groupLabel = await input.getAttribute('aria-label');
+
+		await submitBtn.click();
+
+		expect(errorContainer).toContainText('Please fix the following issues to continue:');
+		expect(errorContainer).toContainText([`A selection for "${groupLabel}" is required.`]);
 	});
 
 	test('show thereAreNoEditsToSubmit message when no edits are made on the form', async ({

--- a/integration/tests/form-behavior.spec.ts
+++ b/integration/tests/form-behavior.spec.ts
@@ -70,18 +70,54 @@ test.describe('form behavior validation', () => {
 		expect(errorContainer).toContainText([`${label} is required.`]);
 	});
 
-	test('show inputGroupRequired message when radio group is missing a selection', async ({
+	test('show required message with label from legend when radio group is missing a selection', async ({
 		page,
 		errorContainer,
 		submitBtn
 	}) => {
-		const input = page.locator('#question-id-1');
-		const groupLabel = await input.getAttribute('aria-label');
+		const input = await page.locator('#question-id-1');
+		const inputField = page.locator('fieldset', { has: input });
+		const groupLabel = inputField.locator('legend');
+		const label = (await groupLabel.textContent())?.trim();
 
 		await submitBtn.click();
 
 		expect(errorContainer).toContainText('Please fix the following issues to continue:');
-		expect(errorContainer).toContainText([`A selection for "${groupLabel}" is required.`]);
+		expect(errorContainer).toContainText([`A selection for "${label}" is required.`]);
+	});
+
+	test('show required message with label from aria-label when radio group is missing a selection', async ({
+		page,
+		errorContainer,
+		submitBtn
+	}) => {
+		const input = await page.locator('#question-id-1');
+		const inputField = page.locator('fieldset', { has: input });
+
+		// remove legend from inputField
+		const inputLabel = inputField.locator('legend');
+		inputLabel.evaluate(el => el.remove());
+		const label = await input.getAttribute('aria-label');
+
+		await submitBtn.click();
+
+		expect(errorContainer).toContainText('Please fix the following issues to continue:');
+		expect(errorContainer).toContainText([`A selection for "${label}" is required.`]);
+	});
+
+	// Checkbox
+	test('show inputGroupRequired field label message when checkbox group is missing a aria-label', async ({
+		page,
+		errorContainer,
+		submitBtn
+	}) => {
+		const inputLabel = page.locator('label', { has: page.locator('#sample-checkbox') });
+		const label = (await inputLabel.textContent())?.trim();
+
+		await submitBtn.click();
+
+		expect(errorContainer).toContainText('Please fix the following issues to continue:');
+		expect(errorContainer).toContainText([`A selection for "${label}" is required.`]);
 	});
 
 	test('show inputGroupRequired message when checkbox group is missing a selection', async ({

--- a/integration/tests/form-behavior.spec.ts
+++ b/integration/tests/form-behavior.spec.ts
@@ -70,6 +70,22 @@ test.describe('form behavior validation', () => {
 		expect(errorContainer).toContainText([`${label} is required.`]);
 	});
 
+	test('show inputGroupRequired message when radio group is missing a selection', async ({
+		page,
+		errorContainer,
+		submitBtn
+	}) => {
+		const input = page.locator('#question-id-1');
+		const groupLabel = await input.getAttribute('aria-label');
+
+		await submitBtn.click();
+
+		expect(errorContainer).toContainText('Please fix the following issues to continue:');
+		expect(errorContainer).toContainText([
+			`At least one selection from ${groupLabel} is required.`
+		]);
+	});
+
 	test('show thereAreNoEditsToSubmit message when no edits are made on the form', async ({
 		page,
 		errorContainer,

--- a/integration/tests/form-behavior.spec.ts
+++ b/integration/tests/form-behavior.spec.ts
@@ -117,7 +117,7 @@ test.describe('form behavior validation', () => {
 		await submitBtn.click();
 
 		expect(errorContainer).toContainText('Please fix the following issues to continue:');
-		expect(errorContainer).toContainText([`A selection for "${label}" is required.`]);
+		expect(errorContainer).toContainText([`${label} is required.`]);
 	});
 
 	test('show inputGroupRequired message when checkbox group is missing a selection', async ({
@@ -131,7 +131,7 @@ test.describe('form behavior validation', () => {
 		await submitBtn.click();
 
 		expect(errorContainer).toContainText('Please fix the following issues to continue:');
-		expect(errorContainer).toContainText([`A selection for "${groupLabel}" is required.`]);
+		expect(errorContainer).toContainText([`${groupLabel} is required.`]);
 	});
 
 	test('show thereAreNoEditsToSubmit message when no edits are made on the form', async ({

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -27,7 +27,7 @@ export class FormBehaviorElement extends HTMLElement {
 
 	validators: Validator[] = [
 		this.validateMinLength.bind(this), // min length before required
-		this.validateGroupRequired.bind(this), // Checkbox or Radio groups
+		// this.validateGroupRequired.bind(this), // Checkbox or Radio groups
 		this.validateRequired.bind(this),
 		this.validateMaxLength.bind(this)
 	];
@@ -360,25 +360,10 @@ export class FormBehaviorElement extends HTMLElement {
 		if (input.validity.valueMissing) {
 			return this.locStrings.inputRequired.replace(
 				'{inputLabel}',
-				customElements.get(input.localName) ? `A selection for "${label}"` : label
+				customElements.get(input.localName) || input.type === 'radio' || input.type === 'checkbox'
+					? `A selection for "${label}"`
+					: label
 			);
-		}
-		return null;
-	}
-
-	validateGroupRequired(input: HTMLValueElement, label: string): string | null {
-		if (input.type === 'radio' || input.type === 'checkbox') {
-			const group = getField(input);
-			const inputs = Array.from(group.querySelectorAll<HTMLInputElement>('input'));
-			// Return null if a single checkbox, so that validateRequired can handle it
-			if (inputs.length === 1 && inputs[0].type === 'checkbox') {
-				return null;
-			}
-
-			const hasCheckedInput = inputs.some(input => input.checked);
-			if (!hasCheckedInput) {
-				return this.locStrings.inputGroupRequired.replace('{inputGroup}', label);
-			}
 		}
 		return null;
 	}
@@ -544,7 +529,6 @@ export class FormBehaviorElement extends HTMLElement {
 			return;
 		}
 
-		// TODO make label aware of radio and where label can live.
 		const label = getLabel(input);
 		const group = getField(input);
 

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -683,36 +683,17 @@ function setBusySubmitButton(event: Event, form: HTMLFormElement, isLoading: boo
 }
 
 export function getLabel(input: HTMLValueElement): string {
-	// Get input type
-	const type = input.getAttribute('type');
-
-	// Define a function to get the label based on input type
-	const getLabelBasedOnType = (): string | null => {
-		// If the input is a radio or checkbox, use the 'error-label' attribute.
-		if (type === 'radio' || type === 'checkbox') {
-			return input.getAttribute('data-error-label') || null;
-		}
-
-		// Use the first label's text content if available
-		if (input.labels && input.labels.length > 0) {
-			return input.labels[0].textContent;
-		}
-
-		// Fallback to 'aria-label' attribute if present
-		return input.getAttribute('aria-label');
-	};
-
-	// Call the function to get the label
-	const label = getLabelBasedOnType();
-
-	// Check if label is found, if not throw an error
-	if (label === null || label.trim() === '') {
+	const label =
+		input.type === 'radio'
+			? input.getAttribute('data-error-label')
+			: input.labels && input.labels.length
+			? input.labels[0].textContent
+			: input.getAttribute('aria-label');
+	if (!label) {
 		throw new Error(
 			`${input.nodeName} name="${input.name}" id="${input.id}" has no associated label.`
 		);
 	}
-
-	// Return the trimmed label
 	return label.trim();
 }
 

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -683,12 +683,16 @@ function setBusySubmitButton(event: Event, form: HTMLFormElement, isLoading: boo
 }
 
 export function getLabel(input: HTMLValueElement): string {
-	const label =
-		input.type === 'radio'
-			? input.getAttribute('data-error-label')
-			: input.labels && input.labels.length
-			? input.labels[0].textContent
-			: input.getAttribute('aria-label');
+	let label: string | null = null;
+
+	if (input.type === 'radio') {
+		label = input.getAttribute('data-error-label');
+	} else if (input.labels?.length) {
+		label = input.labels[0].textContent;
+	} else {
+		label = input.getAttribute('aria-label');
+	}
+
 	if (!label) {
 		throw new Error(
 			`${input.nodeName} name="${input.name}" id="${input.id}" has no associated label.`

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -27,7 +27,6 @@ export class FormBehaviorElement extends HTMLElement {
 
 	validators: Validator[] = [
 		this.validateMinLength.bind(this), // min length before required
-		// this.validateGroupRequired.bind(this), // Checkbox or Radio groups
 		this.validateRequired.bind(this),
 		this.validateMaxLength.bind(this)
 	];

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -686,7 +686,7 @@ export function getLabel(input: HTMLValueElement): string {
 	let label: string | null = null;
 
 	if (input.type === 'radio') {
-		label = input.getAttribute('data-error-label');
+		label = input.getAttribute('data-validation-label');
 	} else if (input.labels?.length) {
 		label = input.labels[0].textContent;
 	} else {

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -27,8 +27,8 @@ export class FormBehaviorElement extends HTMLElement {
 
 	validators: Validator[] = [
 		this.validateMinLength.bind(this), // min length before required
-		this.validateRequired.bind(this),
 		this.validateGroupRequired.bind(this), // Checkbox or Radio groups
+		this.validateRequired.bind(this),
 		this.validateMaxLength.bind(this)
 	];
 
@@ -367,11 +367,18 @@ export class FormBehaviorElement extends HTMLElement {
 	}
 
 	validateGroupRequired(input: HTMLValueElement, label: string): string | null {
-		const group = getField(input);
-		const inputs = Array.from(group.querySelectorAll<HTMLInputElement>('input'));
-		const hasCheckedInput = inputs.some(input => input.checked);
-		if (!hasCheckedInput) {
-			return this.locStrings.inputGroupRequired.replace('{inputGroup}', label);
+		if (input.type === 'radio' || input.type === 'checkbox') {
+			const group = getField(input);
+			const inputs = Array.from(group.querySelectorAll<HTMLInputElement>('input'));
+			// Return null if a single checkbox, so that validateRequired can handle it
+			if (inputs.length === 1 && inputs[0].type === 'checkbox') {
+				return null;
+			}
+
+			const hasCheckedInput = inputs.some(input => input.checked);
+			if (!hasCheckedInput) {
+				return this.locStrings.inputGroupRequired.replace('{inputGroup}', label);
+			}
 		}
 		return null;
 	}

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -419,6 +419,8 @@ export class FormBehaviorElement extends HTMLElement {
 				continue;
 			}
 
+			// Apply validation to the first radio in a group
+			// This is to prevent duplicate validation messages for each radio in a group
 			if (input.type === 'radio') {
 				const radioGroup = form.querySelectorAll<HTMLInputElement>(`input[name="${input.name}"]`);
 				if (radioGroup.length > 1 && radioGroup[0] !== input) {

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -531,10 +531,10 @@ export class FormBehaviorElement extends HTMLElement {
 		const label = getLabel(input);
 		const group = getField(input);
 
-		if (displayValidity) {
-			setValidationMessage(input, '');
-			group.classList.remove('errored');
-		}
+		// if (displayValidity) {
+		// 	setValidationMessage(input, '');
+		// 	group.classList.remove('errored');
+		// }
 
 		for (const validator of this.validators) {
 			const message = validator(input, label);

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -531,11 +531,6 @@ export class FormBehaviorElement extends HTMLElement {
 		const label = getLabel(input);
 		const group = getField(input);
 
-		// if (displayValidity) {
-		// 	setValidationMessage(input, '');
-		// 	group.classList.remove('errored');
-		// }
-
 		for (const validator of this.validators) {
 			const message = validator(input, label);
 			if (!message) {

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -359,7 +359,7 @@ export class FormBehaviorElement extends HTMLElement {
 		if (input.validity.valueMissing) {
 			return this.locStrings.inputRequired.replace(
 				'{inputLabel}',
-				customElements.get(input.localName) || input.type === 'radio' || input.type === 'checkbox'
+				customElements.get(input.localName) || input.type === 'radio'
 					? `A selection for "${label}"`
 					: label
 			);

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -2,7 +2,7 @@ import { generateElementId, kebabToCamelCase } from '../utilities/util';
 
 export const defaultMessageStrings = {
 	contentHasChanged: 'Content has changed, please reload the page to get the latest changes.',
-	inputGroupRequired: 'At least one selection for {inputLabel} is required.',
+	inputGroupRequired: 'At least one selection for {inputGroup} is required.',
 	inputMaxLength: '{inputLabel} cannot be longer than {maxLength} characters.',
 	inputMinLength: '{inputLabel} must be at least {minLength} characters.',
 	inputRequired: '{inputLabel} is required.',
@@ -358,10 +358,10 @@ export class FormBehaviorElement extends HTMLElement {
 
 	validateRequired(input: HTMLValueElement, label: string): string | null {
 		if (input.validity.valueMissing) {
-			return `${this.locStrings.inputRequired.replace(
+			return this.locStrings.inputRequired.replace(
 				'{inputLabel}',
 				customElements.get(input.localName) ? `A selection for "${label}"` : label
-			)}`;
+			);
 		}
 		return null;
 	}
@@ -369,9 +369,9 @@ export class FormBehaviorElement extends HTMLElement {
 	validateGroupRequired(input: HTMLValueElement, label: string): string | null {
 		const group = getField(input);
 		const inputs = Array.from(group.querySelectorAll<HTMLInputElement>('input'));
-		const selected = inputs.some(input => input.checked);
-		if (!selected) {
-			return `${this.locStrings.inputGroupRequired.replace('{inputLabel}', label)}`;
+		const hasCheckedInput = inputs.some(input => input.checked);
+		if (!hasCheckedInput) {
+			return this.locStrings.inputGroupRequired.replace('{inputGroup}', label);
 		}
 		return null;
 	}
@@ -381,9 +381,9 @@ export class FormBehaviorElement extends HTMLElement {
 			(input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement) &&
 			(input.validity.tooShort || (input.minLength > 0 && input.value.length < input.minLength))
 		) {
-			return `${this.locStrings.inputMinLength
+			return this.locStrings.inputMinLength
 				.replace('{inputLabel}', label)
-				.replace('{minLength}', input.minLength.toString())}`;
+				.replace('{minLength}', input.minLength.toString());
 		}
 		return null;
 	}
@@ -393,9 +393,9 @@ export class FormBehaviorElement extends HTMLElement {
 			(input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement) &&
 			(input.validity.tooLong || (input.maxLength > 0 && input.value.length > input.maxLength))
 		) {
-			return `${this.locStrings.inputMaxLength
+			return this.locStrings.inputMaxLength
 				.replace('{inputLabel}', label)
-				.replace('{maxLength}', input.maxLength.toString())}`;
+				.replace('{maxLength}', input.maxLength.toString());
 		}
 		return null;
 	}

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -395,6 +395,7 @@ export class FormBehaviorElement extends HTMLElement {
 	): Promise<FormValidationResult> {
 		const errors: FormValidationError[] = [];
 		const { errorAlert, errorList } = this.getErrorAlert(form);
+		let prevInputName: string = ''; // Used for Radios that share the same name
 
 		if (displayValidity || form.hasAttribute('data-hide-validation-banner')) {
 			errorAlert.hidden = true;
@@ -421,6 +422,11 @@ export class FormBehaviorElement extends HTMLElement {
 				continue;
 			}
 
+			// For Radios where name is the same across options, only validate the first one
+			if (prevInputName !== undefined && input.name === prevInputName) {
+				continue;
+			}
+
 			if (input.hasAttribute('data-skip-validation')) {
 				const validationErrorEvent = new CustomEvent('form-validating', {
 					detail: {
@@ -434,7 +440,9 @@ export class FormBehaviorElement extends HTMLElement {
 			}
 
 			const isCustomElement = !!customElements.find(el => el === input);
+
 			this.runBasicValidation(input, displayValidity, errors, errorList, isCustomElement);
+			prevInputName = input.name;
 			const validationErrorEvent = new CustomEvent('form-validating', {
 				detail: {
 					errors,
@@ -675,15 +683,36 @@ function setBusySubmitButton(event: Event, form: HTMLFormElement, isLoading: boo
 }
 
 export function getLabel(input: HTMLValueElement): string {
-	const label =
-		input.labels && input.labels.length
-			? input.labels[0].textContent
-			: input.getAttribute('aria-label');
-	if (!label) {
+	// Get input type
+	const type = input.getAttribute('type');
+
+	// Define a function to get the label based on input type
+	const getLabelBasedOnType = (): string | null => {
+		// If the input is a radio or checkbox, use the 'error-label' attribute.
+		if (type === 'radio' || type === 'checkbox') {
+			return input.getAttribute('data-error-label') || null;
+		}
+
+		// Use the first label's text content if available
+		if (input.labels && input.labels.length > 0) {
+			return input.labels[0].textContent;
+		}
+
+		// Fallback to 'aria-label' attribute if present
+		return input.getAttribute('aria-label');
+	};
+
+	// Call the function to get the label
+	const label = getLabelBasedOnType();
+
+	// Check if label is found, if not throw an error
+	if (label === null || label.trim() === '') {
 		throw new Error(
 			`${input.nodeName} name="${input.name}" id="${input.id}" has no associated label.`
 		);
 	}
+
+	// Return the trimmed label
 	return label.trim();
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,8 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@changesets/cli": "^2.26.2",
-				"@parcel/transformer-sass": "^2.11.0",
 				"@playwright/test": "^1.35.1",
 				"husky": "4.3.8",
-				"lightningcss": "^1.16.1",
-				"parcel": "^2.12.0",
 				"prettier": "^2.8.8",
 				"pretty-quick": "^3.1.3"
 			},
@@ -32,7 +29,7 @@
 		},
 		"css": {
 			"name": "@microsoft/atlas-css",
-			"version": "3.43.0",
+			"version": "3.44.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@microsoft/stylelint-config-atlas": "4.1.0",
@@ -489,7 +486,7 @@
 		},
 		"js": {
 			"name": "@microsoft/atlas-js",
-			"version": "1.10.0",
+			"version": "1.10.1",
 			"license": "MIT",
 			"devDependencies": {
 				"eslint": "^8.43.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,11 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@changesets/cli": "^2.26.2",
+				"@parcel/transformer-sass": "^2.11.0",
 				"@playwright/test": "^1.35.1",
 				"husky": "4.3.8",
+				"lightningcss": "^1.16.1",
+				"parcel": "^2.12.0",
 				"prettier": "^2.8.8",
 				"pretty-quick": "^3.1.3"
 			},
@@ -29,7 +32,7 @@
 		},
 		"css": {
 			"name": "@microsoft/atlas-css",
-			"version": "3.44.1",
+			"version": "3.43.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@microsoft/stylelint-config-atlas": "4.1.0",
@@ -486,7 +489,7 @@
 		},
 		"js": {
 			"name": "@microsoft/atlas-js",
-			"version": "1.10.1",
+			"version": "1.10.0",
 			"license": "MIT",
 			"devDependencies": {
 				"eslint": "^8.43.0",

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -108,6 +108,7 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 		header-content-type="application/json"
 		header-x-docsauth="cookie"
 		loc-content-has-changed="Content has changed, please reload the page to get the latest changes."
+		loc-input-group-required="At least one selection from {inputGroup} is required."
 		loc-input-max-length="{inputLabel} cannot be longer than {maxLength} characters."
 		loc-input-min-length="{inputLabel} must be at least {minLength} characters."
 		loc-input-required="{inputLabel} is required."
@@ -128,6 +129,7 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 			<input id="sample-input" name="input" class="input" type="text" value="" required />
 		</div>
 	</div>
+
 	<div class="field">
 		<label class="field-label" for="sample-input-min">
 			Input with min/max length
@@ -151,6 +153,7 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 			/>
 		</div>
 	</div>
+
 	<div class="field">
 		<label class="field-label" for="sample-select">
 			Select
@@ -170,6 +173,7 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 			</select>
 		</div>
 	</div>
+
 	<div class="field">
 		<label class="label" for="sample-text-area">
 			Textarea
@@ -187,6 +191,7 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 			></textarea>
 		</div>
 	</div>
+
 	<div class="field">
 		<label class="field-label" for="sample-skip-input">
 			Input
@@ -204,25 +209,7 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 			/>
 		</div>
 	</div>
-	<div class="field">
-		<legend class="field-label">Checkbox Field label</legend>
-		<div class="field-body">
-			<label class="checkbox">
-				<input
-					type="checkbox"
-					name="checkbox-example"
-					required
-					id="sample-checkbox"
-					data-error-label="Checkbox Example"
-				/>
-				<span class="checkbox-check" role="presentation" aria-hidden="true"></span>
-				<span class="checkbox-text">
-					Checkbox
-					<span class="required-indicator"></span>
-				</span>
-			</label>
-		</div>
-	</div>
+
 	<div class="field">
 		<legend class="field-label">Radio Field label</legend>
 		<div class="field-body">
@@ -233,13 +220,19 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 					type="radio"
 					class="radio-dot"
 					value="Yes"
-					data-validation-label="Radio Input selection"
+					aria-label="Radio Field secondary label"
 					required
 				/>
 				<span class="radio-label-text">Yes</span>
 			</label>
 			<label class="radio" for="question-id-2">
-				<input name="question-1" id="question-id-2" type="radio" class="radio-dot" value="No" />
+				<input
+					name="question-1"
+					id="question-id-2"
+					type="radio"
+					class="radio-dot"
+					value="option-No"
+				/>
 				<span class="radio-label-text">No</span>
 			</label>
 			<label class="radio" for="question-id-3">
@@ -264,6 +257,27 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 			</label>
 		</div>
 	</div>
+
+	<div class="field">
+		<legend class="field-label">Checkbox Field label</legend>
+		<div class="field-body">
+			<label class="checkbox">
+				<input
+					type="checkbox"
+					name="checkbox-example"
+					required
+					id="sample-checkbox"
+					data-error-label="Checkbox Example"
+				/>
+				<span class="checkbox-check" role="presentation" aria-hidden="true"></span>
+				<span class="checkbox-text">
+					Checkbox
+					<span class="required-indicator"></span>
+				</span>
+			</label>
+		</div>
+	</div>
+
 	<div class="display-flex">
 		<button type="submit" class="button button-primary button-filled">Submit form</button>
 	</div>

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -210,7 +210,7 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 		</div>
 	</div>
 
-	<div class="field">
+	<fieldset class="field">
 		<legend class="field-label">Radio Example</legend>
 		<div class="field-body">
 			<label class="radio" for="question-id-1">
@@ -256,9 +256,9 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 				<span class="radio-label-text">Option 4</span>
 			</label>
 		</div>
-	</div>
+	</fieldset>
 
-	<div class="field">
+	<fieldset class="field">
 		<legend class="field-label">Checkbox Field label</legend>
 		<div class="field-body">
 			<label class="checkbox">
@@ -270,7 +270,54 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 				</span>
 			</label>
 		</div>
-	</div>
+	</fieldset>
+	<fieldset class="field">
+		<legend class="field-label">Multiple Checkbox Field label</legend>
+		<div class="field-body">
+			<label class="checkbox">
+				<input type="checkbox" name="multi-checkbox-example-1" id="sample-multi-checkbox-1" />
+				<span class="checkbox-check" role="presentation" aria-hidden="true"></span>
+				<span class="checkbox-text"> Checkbox 1 </span>
+			</label>
+		</div>
+		<div class="field-body">
+			<label class="checkbox">
+				<input
+					type="checkbox"
+					name="multi-checkbox-example-2"
+					id="sample-multi-checkbox-2"
+					aria-label="Checkbox 2 (required)"
+					required
+				/>
+				<span class="checkbox-check" role="presentation" aria-hidden="true"></span>
+				<span class="checkbox-text">
+					Checkbox 2 (required)
+					<span class="required-indicator"></span>
+				</span>
+			</label>
+		</div>
+		<div class="field-body">
+			<label class="checkbox">
+				<input type="checkbox" name="multi-checkbox-example-3" id="sample-multi-checkbox-3" />
+				<span class="checkbox-check" role="presentation" aria-hidden="true"></span>
+				<span class="checkbox-text"> Checkbox 3 </span>
+			</label>
+		</div>
+		<div class="field-body">
+			<label class="checkbox">
+				<input type="checkbox" name="multi-checkbox-example-4" id="sample-multi-checkbox-4" />
+				<span class="checkbox-check" role="presentation" aria-hidden="true"></span>
+				<span class="checkbox-text"> Checkbox 4 </span>
+			</label>
+		</div>
+		<div class="field-body">
+			<label class="checkbox">
+				<input type="checkbox" name="multi-checkbox-example-5" id="sample-multi-checkbox-5" />
+				<span class="checkbox-check" role="presentation" aria-hidden="true"></span>
+				<span class="checkbox-text"> Last Checkbox </span>
+			</label>
+		</div>
+	</fieldset>
 
 	<div class="display-flex">
 		<button type="submit" class="button button-primary button-filled">Submit form</button>

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -280,8 +280,6 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 				<span class="checkbox-check" role="presentation" aria-hidden="true"></span>
 				<span class="checkbox-text"> Checkbox 1 </span>
 			</label>
-		</div>
-		<div class="field-body">
 			<label class="checkbox">
 				<input
 					type="checkbox"
@@ -296,22 +294,16 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 					<span class="required-indicator"></span>
 				</span>
 			</label>
-		</div>
-		<div class="field-body">
 			<label class="checkbox">
 				<input type="checkbox" name="multi-checkbox-example-3" id="sample-multi-checkbox-3" />
 				<span class="checkbox-check" role="presentation" aria-hidden="true"></span>
 				<span class="checkbox-text"> Checkbox 3 </span>
 			</label>
-		</div>
-		<div class="field-body">
 			<label class="checkbox">
 				<input type="checkbox" name="multi-checkbox-example-4" id="sample-multi-checkbox-4" />
 				<span class="checkbox-check" role="presentation" aria-hidden="true"></span>
 				<span class="checkbox-text"> Checkbox 4 </span>
 			</label>
-		</div>
-		<div class="field-body">
 			<label class="checkbox">
 				<input type="checkbox" name="multi-checkbox-example-5" id="sample-multi-checkbox-5" />
 				<span class="checkbox-check" role="presentation" aria-hidden="true"></span>

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -233,7 +233,7 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 					type="radio"
 					class="radio-dot"
 					value="Yes"
-					data-error-label="Radio Input selection"
+					data-validation-label="Radio Input selection"
 					required
 				/>
 				<span class="radio-label-text">Yes</span>

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -211,7 +211,7 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 	</div>
 
 	<div class="field">
-		<legend class="field-label">Radio Field label</legend>
+		<legend class="field-label">Radio Example</legend>
 		<div class="field-body">
 			<label class="radio" for="question-id-1">
 				<input
@@ -220,7 +220,7 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 					type="radio"
 					class="radio-dot"
 					value="Yes"
-					aria-label="Radio Field secondary label"
+					aria-label="Radio Example"
 					required
 				/>
 				<span class="radio-label-text">Yes</span>

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -271,6 +271,7 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 			</label>
 		</div>
 	</fieldset>
+
 	<fieldset class="field">
 		<legend class="field-label">Multiple Checkbox Field label</legend>
 		<div class="field-body">

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -262,13 +262,7 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 		<legend class="field-label">Checkbox Field label</legend>
 		<div class="field-body">
 			<label class="checkbox">
-				<input
-					type="checkbox"
-					name="checkbox-example"
-					required
-					id="sample-checkbox"
-					data-error-label="Checkbox Example"
-				/>
+				<input type="checkbox" name="checkbox-example" required id="sample-checkbox" />
 				<span class="checkbox-check" role="presentation" aria-hidden="true"></span>
 				<span class="checkbox-text">
 					Checkbox

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -226,10 +226,10 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 	<div class="field">
 		<legend class="field-label">Radio Field label</legend>
 		<div class="field-body">
-			<label class="radio" for="question-1-1">
+			<label class="radio" for="question-id-1">
 				<input
 					name="question-1"
-					id="question-1-1"
+					id="question-id-1"
 					type="radio"
 					class="radio-dot"
 					value="Yes"

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -205,14 +205,62 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 		</div>
 	</div>
 	<div class="field">
+		<legend class="field-label">Checkbox Field label</legend>
 		<div class="field-body">
 			<label class="checkbox">
-				<input type="checkbox" name="checkbox-example" required id="sample-checkbox" />
+				<input
+					type="checkbox"
+					name="checkbox-example"
+					required
+					id="sample-checkbox"
+					data-error-label="Checkbox Example"
+				/>
 				<span class="checkbox-check" role="presentation" aria-hidden="true"></span>
 				<span class="checkbox-text">
 					Checkbox
 					<span class="required-indicator"></span>
 				</span>
+			</label>
+		</div>
+	</div>
+	<div class="field">
+		<legend class="field-label">Radio Field label</legend>
+		<div class="field-body">
+			<label class="radio" for="question-1-1">
+				<input
+					name="question-1"
+					id="question-1-1"
+					type="radio"
+					class="radio-dot"
+					value="Yes"
+					data-error-label="Challenge Collection selection"
+					required
+				/>
+				<span class="radio-label-text">Yes</span>
+			</label>
+			<label class="radio" for="question-id-2">
+				<input name="question-1" id="question-id-2" type="radio" class="radio-dot" value="No" />
+				<span class="radio-label-text">No</span>
+			</label>
+			<label class="radio" for="question-id-3">
+				<input
+					name="question-1"
+					id="question-id-3"
+					type="radio"
+					class="radio-dot"
+					value="Option 3"
+				/>
+				<span class="radio-label-text">Option 3</span>
+			</label>
+			<label class="radio" for="question-id-4">
+				<input
+					name="question-1"
+					id="question-id-4"
+					type="radio"
+					class="radio-dot"
+					value="Option 4"
+				/>
+				<span class="radio-label-text">Option 4</span>
 			</label>
 		</div>
 	</div>

--- a/site/src/components/form.md
+++ b/site/src/components/form.md
@@ -233,7 +233,7 @@ If you want to skip the basic validation on an input, apply a `data-skip-validat
 					type="radio"
 					class="radio-dot"
 					value="Yes"
-					data-error-label="Challenge Collection selection"
+					data-error-label="Radio Input selection"
 					required
 				/>
 				<span class="radio-label-text">Yes</span>


### PR DESCRIPTION
Task: task-[work-item-number]

Link: [preview](http://localhost:1111/)

[Explain the context of this pull request here]

## Testing

1. Pull and Run branch 
2. Open the Form Page
3. Without selecting a radio in the form behavior section, submit the form.
4. Expect the form errors to now represent aRadio input error label.  Expect that the error is representing the parent `.field .field-label` text OR to the first radios `aria-label` text.

## Additional information

[Optional]

## Contributor checklist

- [ ] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [x] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
