### PR TITLE
Remove Firefox-only button focus outline normalization styles

### DIFF
--- a/.changeset/three-poets-watch.md
+++ b/.changeset/three-poets-watch.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Remove buttons' Firefox-only tiny focus rings, which would sometimes beat out Atlas's default focus outlines

--- a/css/src/core/normalize.scss
+++ b/css/src/core/normalize.scss
@@ -203,29 +203,6 @@ button,
 }
 
 /**
-   * Remove the inner border and padding in Firefox.
-   */
-
-button::-moz-focus-inner,
-[type='button']::-moz-focus-inner,
-[type='reset']::-moz-focus-inner,
-[type='submit']::-moz-focus-inner {
-	border-style: none;
-	padding: 0;
-}
-
-/**
-   * Restore the focus styles unset by the previous rule.
-   */
-
-button:-moz-focusring,
-[type='button']:-moz-focusring,
-[type='reset']:-moz-focusring,
-[type='submit']:-moz-focusring {
-	outline: 1px dotted ButtonText;
-}
-
-/**
    * Correct the padding in Firefox.
    */
 


### PR DESCRIPTION
Task: task-[978192](https://ceapex.visualstudio.com/Engineering/_workitems/edit/978192)

Link: [preview](http://localhost:1111/)

Our `normalize.scss` styles include some Firefox-only focus outline normalizations which, when shown, creates tiny outlines that have been reported as too small to see on some displays (to the point of basically not having focus outlines at all). In some cases, these styles are more specific than Atlas's standard, globally applied focus outlines.

![Search button in L1 navigation, with a tiny dotted focus outline](https://github.com/user-attachments/assets/5f5f505b-b762-4df5-9d73-7441944c904c)

This PR removes those styles altogether. **We could alternatively stick them in a `:where` selector if we wanted to keep them, but I'm not sure I can find a good reason to keep them - happy to have this discussion, however!**

## Testing

### Verify old behavior

1. In Firefox, navigate to https://design.learn.microsoft.com/components/form.html#form-with-edits-required
2. Tab to the example's Submit button.
   Expected result: The Submit button's focus outline is tiny and dotted, rather than our more pronounced focus outlines.


### Verify changes

1. Run Atlas site locally.
2. In Firefox, navigate to http://localhost:1111/components/form.html#form-with-edits-required
3. Tab to the example's Submit button.
   Expected result: The Submit button displays our prominent dashed focus outline.

**Another good page to check is segmented controls.**

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
