### PR TITLE
Adds radiant option to Gradient component [Pending final color approval from design]

### DIFF
--- a/.changeset/pretty-countries-punch.md
+++ b/.changeset/pretty-countries-punch.md
@@ -3,4 +3,4 @@
 '@microsoft/atlas-css': minor
 ---
 
-Adding color theme to gradient component and updating documentation
+Adding radiant option to gradient component and updating documentation

--- a/.changeset/pretty-countries-punch.md
+++ b/.changeset/pretty-countries-punch.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-site': minor
+'@microsoft/atlas-css': minor
+---
+
+Adding color theme to gradient component and updating documentation

--- a/css/src/tokens/colors.scss
+++ b/css/src/tokens/colors.scss
@@ -49,6 +49,8 @@ $gradient-text-purple: var(--theme-gradient-text-purple);
 $gradient-text-blue: var(--theme-gradient-text-blue);
 $gradient-vivid-start: var(--theme-gradient-vivid-start);
 $gradient-vivid-end: var(--theme-gradient-vivid-end);
+$gradient-radiant-start: var(--theme-gradient-radiant-start);
+$gradient-radiant-end: var(--theme-gradient-radiant-end);
 
 $default-hover: var(--theme-hover-base);
 $default-hover-invert: $body-background-medium;
@@ -226,6 +228,9 @@ $color-index-background-glow-high-contrast: 8;
 //}
 
 $gradients: (
+	'radiant': (
+		$gradient-radiant-start $gradient-radiant-end
+	),
 	'vivid': (
 		$gradient-vivid-start,
 		$gradient-vivid-end

--- a/css/src/tokens/colors.scss
+++ b/css/src/tokens/colors.scss
@@ -229,7 +229,8 @@ $color-index-background-glow-high-contrast: 8;
 
 $gradients: (
 	'radiant': (
-		$gradient-radiant-start $gradient-radiant-end
+		$gradient-radiant-start,
+		$gradient-radiant-end
 	),
 	'vivid': (
 		$gradient-vivid-start,

--- a/css/src/tokens/palette.scss
+++ b/css/src/tokens/palette.scss
@@ -191,6 +191,10 @@ $palette-red-100: #290001 !default;
 $palette-red-opacity-30: hsl(0deg 100% 33% / 30%) !default;
 $palette-red-opacity-70: hsl(0deg 100% 33% / 70%) !default;
 
+// Orange
+$palette-orange-30: #f4cbc2 !default;
+$palette-orange-50: #ff5c39 !default;
+
 // High Contrast
 
 $palette-yellow-high-contrast: #ff0 !default;

--- a/css/src/tokens/themes.scss
+++ b/css/src/tokens/themes.scss
@@ -105,7 +105,9 @@ $themes: (
 		'gradient-text-purple': $palette-purple-b,
 		'gradient-text-blue': $palette-blue-70,
 		'gradient-vivid-start': $palette-purple-c,
-		'gradient-vivid-end': $palette-blue-50
+		'gradient-vivid-end': $palette-blue-50,
+		'gradient-radiant-start': $palette-purple-c,
+		'gradient-radiant-end': $palette-orange-50
 	),
 	'dark': (
 		'text': $palette-grey-30,
@@ -210,7 +212,9 @@ $themes: (
 		'gradient-text-purple': $palette-purple-a,
 		'gradient-text-blue': $palette-blue-a,
 		'gradient-vivid-start': $palette-purple-c,
-		'gradient-vivid-end': $palette-blue-30
+		'gradient-vivid-end': $palette-blue-30,
+		'gradient-radiant-start': $palette-purple-c,
+		'gradient-radiant-end': $palette-orange-30
 	),
 	'high-contrast': (
 		'text': $palette-white,
@@ -315,7 +319,9 @@ $themes: (
 		'gradient-text-purple': $white-static,
 		'gradient-text-blue': $white-static,
 		'gradient-vivid-start': $white-static,
-		'gradient-vivid-end': $white-static
+		'gradient-vivid-end': $white-static,
+		'gradient-radiant-start': $white-static,
+		'gradient-radiant-end': $white-static
 	)
 ) !default;
 //@end-sass-export-section

--- a/site/src/components/gradients.md
+++ b/site/src/components/gradients.md
@@ -19,9 +19,9 @@ There are two main types of gradients.
 
 Because gradient transitions take up the entire width of a particular element, it's recommended to highlight inline elements, icons, or a portion of a heading, and not the entire heading itself.
 
-| base class name             | interpolated value     |
-| --------------------------- | ---------------------- |
-| `gradient-text-<colorname>` | `purple-blue`, `vivid` |
+| base class name             | interpolated value                |
+| --------------------------- | --------------------------------- |
+| `gradient-text-<colorname>` | `purple-blue`, `vivid`, `radiant` |
 
 ```html
 <h3 class="font-size-h3 font-weight-bold">
@@ -29,6 +29,9 @@ Because gradient transitions take up the entire width of a particular element, i
 </h3>
 <h3 class="font-size-h3 font-weight-bold">
 	A vivid gradient from <span class="gradient-text-vivid">purple to blue</span>
+</h3>
+<h3 class="font-size-h3 font-weight-bold">
+	A radiant gradient from <span class="gradient-text-radiant">purple to orange</span>
 </h3>
 ```
 


### PR DESCRIPTION
Task: task-991473
Link: [preview](http://localhost:1111/components/gradients.html)

The [figma ](https://www.figma.com/design/a5gqz0qtUMAKF36lNS6b61?node-id=2581-105428&m=dev#912103500)for Form-based advisor introduces a new text gradient. Adding new color theme and updating documentation.

**Note**
Dark theme color was calculated using the same HSL relationship as primary blue:
Hue stays the same, Saturation - 30%, Light + 26%

Here are the blue and orange HSL values
```css
palette-blue-50: hsl(206, 100%, 42%); // light theme
palette-blue-30: hsl(206, 70%, 68%); //dark theme
palette-orange-50: hsl(11, 100%, 61%);  // light theme
palette-orange-30: hsl(11, 70%, 85%); //dark theme
```

## Testing

1. Run Atlas locally 
2. Visit Preview link
   Expected result:
   Light Theme
   
![image](https://github.com/user-attachments/assets/75e8c27f-5a65-4aae-844a-6591182d710b)

   Dark theme
![image](https://github.com/user-attachments/assets/3718df10-f6c4-469f-8b67-76218c9892af)

   High contrast
   
![image](https://github.com/user-attachments/assets/093dcf29-6cb0-41c6-8e17-7d8f8bc78670)


## Additional information

[Optional]

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
