### PR TITLE
Add scrollbar-gutter atomics

### DIFF
--- a/.changeset/great-eyes-stare.md
+++ b/.changeset/great-eyes-stare.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': patch
+---
+
+Document scrollbar-gutter atomics

--- a/.changeset/great-eyes-stare.md
+++ b/.changeset/great-eyes-stare.md
@@ -1,5 +1,5 @@
 ---
-'@microsoft/atlas-site': patch
+'@microsoft/atlas-site': minor
 ---
 
 Document scrollbar-gutter atomics

--- a/.changeset/tricky-garlics-fry.md
+++ b/.changeset/tricky-garlics-fry.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Add scrollbar-gutter atomics

--- a/.changeset/tricky-garlics-fry.md
+++ b/.changeset/tricky-garlics-fry.md
@@ -1,5 +1,5 @@
 ---
-'@microsoft/atlas-css': patch
+'@microsoft/atlas-css': minor
 ---
 
 Add scrollbar-gutter atomics

--- a/css/src/atomics/overflow.scss
+++ b/css/src/atomics/overflow.scss
@@ -15,3 +15,11 @@
 		overflow-x: hidden !important;
 	}
 }
+
+.scrollbar-gutter-stable {
+	scrollbar-gutter: stable !important;
+}
+
+.scrollbar-gutter-stable-both-edges {
+	scrollbar-gutter: stable both-edges !important;
+}

--- a/css/src/atomics/overflow.scss
+++ b/css/src/atomics/overflow.scss
@@ -15,11 +15,3 @@
 		overflow-x: hidden !important;
 	}
 }
-
-.scrollbar-gutter-stable {
-	scrollbar-gutter: stable !important;
-}
-
-.scrollbar-gutter-stable-both-edges {
-	scrollbar-gutter: stable both-edges !important;
-}

--- a/css/src/components/scroll.scss
+++ b/css/src/components/scroll.scss
@@ -24,3 +24,11 @@
 	height: auto;
 	scroll-snap-align: center;
 }
+
+.scrollbar-gutter-stable {
+	scrollbar-gutter: stable !important;
+}
+
+.scrollbar-gutter-stable-both-edges {
+	scrollbar-gutter: stable both-edges !important;
+}

--- a/css/src/components/scroll.scss
+++ b/css/src/components/scroll.scss
@@ -24,11 +24,3 @@
 	height: auto;
 	scroll-snap-align: center;
 }
-
-.scrollbar-gutter-stable {
-	scrollbar-gutter: stable !important;
-}
-
-.scrollbar-gutter-stable-both-edges {
-	scrollbar-gutter: stable both-edges !important;
-}

--- a/site/src/atomics/overflow.md
+++ b/site/src/atomics/overflow.md
@@ -5,16 +5,18 @@ template: standard
 classType: Atomics
 classPrefixes:
   - overflow
+  - scrollbar-gutter
 ---
 
 # Overflow
 
 At times, you'll need to determine the overflow behavior of an element. Atlas provides several classes to do this.
 
-| cssproperty | value    | screensize |
-| ----------- | -------- | ---------- |
-| `overflow`  | `hidden` | `tablet`   |
-| `overflow-x`  | `hidden` | `tablet`   |
+| cssproperty        | value                         | screensize |
+| ------------------ | ----------------------------- | ---------- |
+| `overflow`         | `hidden`                      | `tablet`   |
+| `overflow-x`       | `hidden`                      | `tablet`   |
+| `scrollbar-gutter` | `stable`, `stable-both-edges` |            |
 
 ## Usage
 
@@ -36,12 +38,63 @@ You can use `.overflow-x-hidden` to set the clipping behavior for the left/right
 
 ```html
 <div class="border-radius-lg">
-    <div class="">
-        <div class="overflow-x-hidden" style="width: 100px">
-          <p class="font-size-xl" style="width: 150px">
-            This text is clipped on its right edge because we gave the parent container overflow-hidden.
-          </p>
-        </div>
-    </div>
+	<div class="">
+		<div class="overflow-x-hidden" style="width: 100px">
+			<p class="font-size-xl" style="width: 150px">
+				This text is clipped on its right edge because we gave the parent container overflow-hidden.
+			</p>
+		</div>
+	</div>
 </div>
 ```
+
+## Scrollbar gutter
+
+When using automatic overflow, as with the [scrolling components](../components/scroll.md), the sudden appearance or disappearance of a container's scrollbar can cause the container's content to jump around. While this might be fine if the scrollbar appears or disappears as a result of the user zooming or resizing their browser, it can look clunky otherwise — such as when messages are appended to a constrained-width or constrained-height chat container, resulting in a scrollbar where there wasn't one previously.
+
+To see this default behavior, resize the below example until its scrollbar appears.
+
+<div class="scroll-vertical max-height-30vh background-color-primary inner-focus margin-top-xs" data-focusable-if-scrollable style="resize: vertical">
+	<p class="color-success-invert font-size-xl margin-bottom">
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+		<pre class="color-success-invert">
+		|
+		|
+		|
+		|
+    	▼
+    	</pre>
+    </p>
+</div>
+
+The scrollbar gutter atomics can be used to reserve space for the scrollbar when it's not visible. That way, when the scrollbar appears, it uses that reserved space, and no content jumps around.
+
+`.scrollbar-gutter-stable` reserves only the space for the scrollbar. In this example, notice the padding-like space on the right side of the container. When you resize the container, the scrollbar appears in that space, and none of the text shifts.
+
+<div class="scroll-vertical scrollbar-gutter-stable max-height-30vh background-color-primary inner-focus margin-top-xs" data-focusable-if-scrollable style="resize: vertical">
+	<p class="color-success-invert font-size-xl margin-bottom">
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+		<pre class="color-success-invert">
+		|
+		|
+		|
+		|
+    	▼
+    	</pre>
+    </p>
+</div>
+
+`.scrollbar-gutter-stable-both-edges` reserves space for the scrollbar and an equal amount of space on the opposite side, so that the content appears more centered within its container. In this example, padding-like space is added to both the left and right sides of the container, centering the text a little. When the scrollbar appears, it appears on the right side of the container, with no change to that extra spacing on the left.
+
+<div class="scroll-vertical scrollbar-gutter-stable-both-edges max-height-30vh background-color-primary inner-focus margin-top-xs" data-focusable-if-scrollable style="resize: vertical">
+	<p class="color-success-invert font-size-xl margin-bottom">
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+		<pre class="color-success-invert">
+		|
+		|
+		|
+		|
+    	▼
+    	</pre>
+    </p>
+</div>

--- a/site/src/components/scroll.md
+++ b/site/src/components/scroll.md
@@ -24,7 +24,7 @@ Force an elements overflow to be horizontally scrollable by using `.scroll-horiz
 
 ## Vertical scrolling
 
-Force an elements overflow to be horizontally scrollable by using `.scroll-vertical`. Note that this will only occur if the elements height is constrained.
+Force an elements overflow to be vertically scrollable by using `.scroll-vertical`. Note that this will only occur if the elements height is constrained.
 
 <div class="scroll-vertical max-height-30vh background-color-success margin-top-md padding-xl inner-focus" data-focusable-if-scrollable>
 	<p class="color-success-invert font-size-xl margin-bottom">
@@ -140,3 +140,7 @@ _Note: `data-focusable-if-scrollable`, the attribute we use to programmatically 
 	</nav>
 </section>
 ```
+
+## Avoiding jumping text with scrollbar gutters
+
+In some cases, the appearance or disappearance of a scrollbar can cause that container's contents to jump around. This might be fine if the scrollbar is appearing as a result of the user opting to zoom or resize their browser, but when that's not the case, the jumping can be extra noticeable. If you're noticing this in your scrolling component, consider applying a [scrollbar gutter atomic](../atomics/overflow.md#scrollbar-gutter).


### PR DESCRIPTION
Task: task-[work-item-number]

Link: [preview](http://localhost:1111/atomics/overflow.html)

Introduces the `.scrollbar-gutter-stable` and `.scrollbar-gutter-stable-both-edges` atomics, to be used with overflowing/scrolling containers. These atomics can be used to prevent text from jumping around when a scrollbar appears or disappears.

## Testing

1. Navigate to http://localhost:1111/atomics/overflow.html, and scroll down to the two bottommost examples.
2. Use the examples' resize handles to resize the containers until scrollbars appear and disappear.
   Expected result: Text inside the containers should not jump around as scrollbars (dis)appear.

## Additional information

https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter

## Contributor checklist

- [X] Did you update the description of this pull request with a review link and test steps?
- [X] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
