### PR TITLE
Refactor all layouts to use minmax(0 Xfr), where prior they were Xfr.

### DIFF
--- a/.changeset/famous-falcons-scream.md
+++ b/.changeset/famous-falcons-scream.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': minor
+---
+
+Update doc site to use a view transition when changing between layout examples.

--- a/.changeset/lazy-peaches-bathe.md
+++ b/.changeset/lazy-peaches-bathe.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Refactor all layouts to use minmax(0 Xfr), where prior they were Xfr.

--- a/css/src/components/layout.scss
+++ b/css/src/components/layout.scss
@@ -72,7 +72,7 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 .layout,
 .layout.layout-single {
 	.layout-body {
-		grid-template: auto auto auto 1fr auto auto / 1fr;
+		grid-template: auto auto auto 1fr auto auto / minmax(0, 1fr);
 		grid-template-areas: 'header' 'hero' 'menu' 'main' 'aside' 'footer';
 	}
 }
@@ -83,7 +83,7 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 		grid-template-areas: 'header' 'hero' 'menu' 'main' 'aside' 'footer';
 
 		@include tablet {
-			grid-template: auto auto 1fr auto auto / 1fr 2fr;
+			grid-template: auto auto 1fr auto auto / minmax(0, 1fr) minmax(0, 2fr);
 			grid-template-areas:
 				'header header'
 				'hero hero'
@@ -93,7 +93,7 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 		}
 
 		@include desktop {
-			grid-template: auto auto 1fr auto / 1fr 2fr 1fr;
+			grid-template: auto auto 1fr auto / minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr);
 			grid-template-areas:
 				'header header header'
 				'hero hero hero'
@@ -118,11 +118,11 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 	}
 
 	.layout-body {
-		grid-template: auto auto auto 1fr auto / 1fr;
+		grid-template: auto auto auto 1fr auto / minmax(0, 1fr);
 		grid-template-areas: 'header' 'hero' 'menu' 'main' 'footer';
 
 		@include tablet {
-			grid-template: auto auto 1fr auto / 1fr 2fr;
+			grid-template: auto auto 1fr auto / minmax(0, 1fr) minmax(0, 2fr);
 			grid-template-areas:
 				'header header'
 				'hero hero'
@@ -131,7 +131,7 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 		}
 
 		@include desktop {
-			grid-template: auto auto 1fr auto / 1fr 3fr;
+			grid-template: auto auto 1fr auto / minmax(0, 1fr) minmax(0, 3fr);
 			grid-template-areas:
 				'header header'
 				'hero hero'
@@ -156,11 +156,11 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 	}
 
 	.layout-body {
-		grid-template: auto auto auto 1fr auto / 1fr;
+		grid-template: auto auto auto 1fr auto / minmax(0, 1fr);
 		grid-template-areas: 'header' 'hero' 'main' 'aside' 'footer';
 
 		@include tablet {
-			grid-template: auto auto 1fr auto / 2fr 1fr;
+			grid-template: auto auto 1fr auto / minmax(0, 2fr) minmax(0, 1fr);
 			grid-template-areas:
 				'header header'
 				'hero hero'
@@ -169,7 +169,7 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 		}
 
 		@include desktop {
-			grid-template: auto auto 1fr auto / 3fr 1fr;
+			grid-template: auto auto 1fr auto / minmax(0, 3fr) minmax(0, 1fr);
 			grid-template-areas:
 				'header header'
 				'hero hero'

--- a/site/src/scaffold/scripts/layout-page.ts
+++ b/site/src/scaffold/scripts/layout-page.ts
@@ -26,14 +26,16 @@ export function initLayoutPageControls() {
 				'Attempting to set a layout class that does not match current list of available layouts'
 			);
 		}
-		setLayoutClass(layoutToSet);
-		scrollTo({ behavior: 'smooth', top: target.getBoundingClientRect().top - 200 });
 
-		const setThemeButtons = Array.from(document.querySelectorAll('[data-set-layout]'));
-		for (const button of setThemeButtons) {
-			button.setAttribute('aria-pressed', 'false');
-		}
-		target.setAttribute('aria-pressed', 'true');
+		safeViewTransition(() => {
+			setLayoutClass(layoutToSet);
+			scrollTo({ behavior: 'instant', top: target.getBoundingClientRect().top - 200 });
+			const setThemeButtons = Array.from(document.querySelectorAll('[data-set-layout]'));
+			for (const button of setThemeButtons) {
+				button.setAttribute('aria-pressed', 'false');
+			}
+			target.setAttribute('aria-pressed', 'true');
+		});
 	});
 
 	window.addEventListener('click', (e: MouseEvent) => {
@@ -46,4 +48,18 @@ export function initLayoutPageControls() {
 		document.documentElement.classList.toggle('debug');
 		target.setAttribute('aria-pressed', target.classList.contains('button-filled').toString());
 	});
+}
+
+declare global {
+	interface Document {
+		startViewTransition(callback: () => void): void;
+	}
+}
+
+function safeViewTransition(cb: () => void) {
+	if (!document.startViewTransition) {
+		cb();
+	} else {
+		document.startViewTransition(() => cb());
+	}
 }


### PR DESCRIPTION
This pull request refactors grids to help prevent grid blowouts. It uses `minmax` in order to prevent grid blowouts. Prior to this, we were using the `overflow-x: hidden` hack, but that has some definite negative effects.

## Testing

1. Visit layout page. 
2. Select various layouts. No grid blowouts. Test in Firefox and safari too if possible.

## Additional information

[Optional]

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
