### PR TITLE
[site] Provide Figma embeds with an accessible name

### DIFF
--- a/.changeset/tidy-fireants-swim.md
+++ b/.changeset/tidy-fireants-swim.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': patch
+---
+
+Provide Figma embeds with an accessible name.

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -149,10 +149,11 @@
 						</div>
 						<iframe
 							id="figma-embed-iframe"
-							width="100%";
+							width="100%"
 							class="border"
 							height="450"
 							src="{{figmaEmbed}}"
+							title="Embedded Figma"
 							allowfullscreen="true"></iframe>
 					</div>
 				{{/figmaEmbed}}

--- a/site/src/scaffold/token.html
+++ b/site/src/scaffold/token.html
@@ -154,10 +154,11 @@
 									aria-label="Make Figma Embed Fullscreen">Fullscreen</button>
 							</div>
 							<iframe
-								width="100%";
+								width="100%"
 								class="border"
 								height="450"
 								src="{{figmaEmbed}}"
+								title="Embedded Figma"
 								allowfullscreen></iframe>
 					{{/figmaEmbed}}
 				</div>


### PR DESCRIPTION
Task: task-[work-item-number]

Link: [preview](http://localhost:1111/components/button.html)

Our Figma embeds are `<iframe>`s which are currently untitled. A best accessibility practice is to label your iframes so screenreader users have a sense of what they're getting themselves into by navigating into the iframe. The Accessibility Insights extension is currently flagging the lack of accessible names as an accessibility bug.

![Accessibility Insights dialog, reading 1 failed instance of a frame-title violation.](https://github.com/user-attachments/assets/df23d8c4-a06e-4da2-8847-3efadb900020)

This PR introduces a `title` attribute for Figma embeds, which will both improve the experience a little for screenreader users navigating our docs, as well as clean up the noise when we use Accessibility Insights or any other accessibility testing extensions to validate Atlas's styles.

## Testing

1. Run code locally. Navigate to http://localhost:1111/components/button.html.
2. Run the Accessibility Insights extension against the page.
    _Expected results:_ No `frame-title` warnings are flagged against the page.

![Accessibility Insights dialog, reporting no violations.](https://github.com/user-attachments/assets/3e1ae415-727d-4412-ab4e-b7c831b4a09c)

## Additional information

https://accessibilityinsights.io/info-examples/web/frame-title/

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
