### PR TITLE
Solution to allow layouts to constrain themselves to roughly viewport height

### DIFF
--- a/.changeset/quiet-pans-explode.md
+++ b/.changeset/quiet-pans-explode.md
@@ -1,0 +1,7 @@
+---
+'@microsoft/atlas-site': minor
+'@microsoft/atlas-css': minor
+'@microsoft/atlas-js': minor
+---
+
+Add the ability to constrain layouts to the height of the viewport certain screensizes. Desktop+ for holy-grail and tablet+ for other layouts. Excludes the single layout.

--- a/.changeset/slimy-berries-burn.md
+++ b/.changeset/slimy-berries-burn.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-integration': minor
+---
+
+Add tests for layout and constrained layouts.

--- a/css/src/components/layout.scss
+++ b/css/src/components/layout.scss
@@ -257,7 +257,7 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 	}
 }
 
-// Because the holy grail has two rows (containing menu main, menu aside) on tablet, we cannot apply height constrains at that size
+// Because the holy grail has two rows (containing menu main, menu aside) on tablet, we cannot apply height constraints at that size
 @include desktop {
 	.layout.layout-constrained.layout-holy-grail {
 		// 👇 minus two pixel at the end to account for percentage points and rounding, one px generally suffices though

--- a/css/src/components/layout.scss
+++ b/css/src/components/layout.scss
@@ -4,6 +4,12 @@ $quarter-widescreen: math.div($breakpoint-widescreen, 4);
 $half-widescreen: math.div($breakpoint-widescreen, 2);
 $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 
+::root {
+	--window-inner-height: 100vh; // to be overwritten by JS
+	--atlas-header-height: 0px; // to be overwritten by JS
+	--atlas-footer-height: 0px; // to be overwritten by JS
+}
+
 .layout {
 	display: flex;
 	flex-direction: column;
@@ -12,6 +18,9 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 	// --layout-gutter by default, see tokens/layout.scss
 	#{$layout-gap-custom-property-name}: $layout-gap;
 	#{$layout-gap-scalable-custom-property-name}: $layout-gap;
+
+	// todo convert to Sass var for validation
+	--atlas-contained-height: 1fr; // default value, does not contain the height
 
 	@include widescreen {
 		#{$layout-gap-scalable-custom-property-name}: $layout-widescreen-gap;
@@ -82,7 +91,10 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 		grid-template-areas: 'header' 'hero' 'menu' 'main' 'aside' 'footer';
 
 		@include tablet {
-			grid-template: auto auto 1fr auto auto / minmax(0, 1fr) minmax(0, 2fr);
+			grid-template: auto auto var(--atlas-contained-height) auto auto / minmax(0, 1fr) minmax(
+					0,
+					2fr
+				);
 			grid-template-areas:
 				'header header'
 				'hero hero'
@@ -92,7 +104,10 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 		}
 
 		@include desktop {
-			grid-template: auto auto 1fr auto / minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr);
+			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(0, 2fr) minmax(
+					0,
+					1fr
+				);
 			grid-template-areas:
 				'header header header'
 				'hero hero hero'
@@ -101,7 +116,7 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 		}
 
 		@include widescreen {
-			grid-template: auto auto 1fr auto / auto #{$quarter-widescreen} #{$half-widescreen} #{$quarter-widescreen} auto;
+			grid-template: auto auto var(--atlas-contained-height) auto / auto #{$quarter-widescreen} #{$half-widescreen} #{$quarter-widescreen} auto;
 			grid-template-areas:
 				'header header header header header'
 				'hero hero hero hero hero'
@@ -121,7 +136,7 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 		grid-template-areas: 'header' 'hero' 'menu' 'main' 'footer';
 
 		@include tablet {
-			grid-template: auto auto 1fr auto / minmax(0, 1fr) minmax(0, 2fr);
+			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(0, 2fr);
 			grid-template-areas:
 				'header header'
 				'hero hero'
@@ -130,7 +145,7 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 		}
 
 		@include desktop {
-			grid-template: auto auto 1fr auto / minmax(0, 1fr) minmax(0, 3fr);
+			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(0, 3fr);
 			grid-template-areas:
 				'header header'
 				'hero hero'
@@ -139,7 +154,7 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 		}
 
 		@include widescreen {
-			grid-template: auto auto 1fr auto / auto #{$quarter-widescreen} #{$three-quarters-widescreen} auto;
+			grid-template: auto auto var(--atlas-contained-height) auto / auto #{$quarter-widescreen} #{$three-quarters-widescreen} auto;
 			grid-template-areas:
 				'header header header header'
 				'hero hero hero hero'
@@ -159,7 +174,7 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 		grid-template-areas: 'header' 'hero' 'main' 'aside' 'footer';
 
 		@include tablet {
-			grid-template: auto auto 1fr auto / minmax(0, 2fr) minmax(0, 1fr);
+			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 2fr) minmax(0, 1fr);
 			grid-template-areas:
 				'header header'
 				'hero hero'
@@ -168,7 +183,7 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 		}
 
 		@include desktop {
-			grid-template: auto auto 1fr auto / minmax(0, 3fr) minmax(0, 1fr);
+			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 3fr) minmax(0, 1fr);
 			grid-template-areas:
 				'header header'
 				'hero hero'
@@ -177,7 +192,7 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 		}
 
 		@include widescreen {
-			grid-template: auto auto 1fr auto / auto #{$three-quarters-widescreen} #{$quarter-widescreen} auto;
+			grid-template: auto auto var(--atlas-contained-height) auto / auto #{$three-quarters-widescreen} #{$quarter-widescreen} auto;
 			grid-template-areas:
 				'header header header header'
 				'hero hero hero hero'
@@ -198,12 +213,33 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 
 		// note that to make some extra room this layout is not constrained by the widescreen breakpoint like others
 		@include tablet {
-			grid-template: auto auto 1fr auto / minmax(0, 1fr) minmax(0, 1fr);
+			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(0, 1fr);
 			grid-template-areas:
 				'header header'
 				'hero hero'
 				'main aside '
 				'footer footer';
+		}
+	}
+}
+
+.layout.layout-constrained {
+	&.layout-twin,
+	&.layout-sidecar-left,
+	&.layout-sidecar-right,
+	&.layout-holy-grail {
+		// 👇 minus two pixel at the end to account for percentage points and rounding, one px generally suffices though
+		--atlas-contained-height: calc(
+			var(--window-inner-height) - var(--atlas-header-height) - var(--atlas-footer-height) - 2px
+		);
+
+		.layout-body-main,
+		.layout-body-menu,
+		.layout-body-aside,
+		.layout-body-flyout {
+			@extend .scroll-vertical;
+			position: sticky;
+			inset-block-start: 0;
 		}
 	}
 }

--- a/css/src/components/layout.scss
+++ b/css/src/components/layout.scss
@@ -4,10 +4,11 @@ $quarter-widescreen: math.div($breakpoint-widescreen, 4);
 $half-widescreen: math.div($breakpoint-widescreen, 2);
 $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 
-::root {
+:root {
 	--window-inner-height: 100vh; // to be overwritten by JS
 	--atlas-header-height: 0px; // to be overwritten by JS
 	--atlas-footer-height: 0px; // to be overwritten by JS
+	--atlas-contained-height: 1fr; // default value, does not contain the height
 }
 
 .layout {
@@ -18,9 +19,6 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 	// --layout-gutter by default, see tokens/layout.scss
 	#{$layout-gap-custom-property-name}: $layout-gap;
 	#{$layout-gap-scalable-custom-property-name}: $layout-gap;
-
-	// todo convert to Sass var for validation
-	--atlas-contained-height: 1fr; // default value, does not contain the height
 
 	@include widescreen {
 		#{$layout-gap-scalable-custom-property-name}: $layout-widescreen-gap;
@@ -237,7 +235,8 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 		.layout-body-menu,
 		.layout-body-aside,
 		.layout-body-flyout {
-			@extend .scroll-vertical;
+			@extend %scroll-vertical;
+
 			position: sticky;
 			inset-block-start: 0;
 		}

--- a/css/src/components/layout.scss
+++ b/css/src/components/layout.scss
@@ -221,11 +221,45 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 	}
 }
 
-.layout.layout-constrained {
-	&.layout-twin,
-	&.layout-sidecar-left,
-	&.layout-sidecar-right,
-	&.layout-holy-grail {
+@mixin constrained-layout-child {
+	position: sticky;
+	inset-block-start: 0;
+	overflow-x: hidden;
+	overflow-y: auto;
+	-webkit-overflow-scrolling: touch;
+}
+
+@include tablet {
+	.layout.layout-constrained {
+		&.layout-twin,
+		&.layout-sidecar-left,
+		&.layout-sidecar-right {
+			// 👇 minus two pixel at the end to account for percentage points and rounding, one px generally suffices though
+			--atlas-contained-height: calc(
+				var(--window-inner-height) - var(--atlas-header-height) - var(--atlas-footer-height) - 2px
+			);
+		}
+
+		&.layout-twin,
+		&.layout-sidecar-right {
+			.layout-body-main,
+			.layout-body-aside {
+				@include constrained-layout-child;
+			}
+		}
+
+		&.layout-sidecar-left {
+			.layout-body-menu,
+			.layout-body-main {
+				@include constrained-layout-child;
+			}
+		}
+	}
+}
+
+// Because the holy grail has two rows (containing menu main, menu aside) on tablet, we cannot apply height constrains at that size
+@include desktop {
+	.layout.layout-constrained.layout-holy-grail {
 		// 👇 minus two pixel at the end to account for percentage points and rounding, one px generally suffices though
 		--atlas-contained-height: calc(
 			var(--window-inner-height) - var(--atlas-header-height) - var(--atlas-footer-height) - 2px
@@ -233,12 +267,8 @@ $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
 
 		.layout-body-main,
 		.layout-body-menu,
-		.layout-body-aside,
-		.layout-body-flyout {
-			@extend %scroll-vertical;
-
-			position: sticky;
-			inset-block-start: 0;
+		.layout-body-aside {
+			@include constrained-layout-child;
 		}
 	}
 }

--- a/css/src/components/scroll.scss
+++ b/css/src/components/scroll.scss
@@ -4,10 +4,14 @@
 	-webkit-overflow-scrolling: touch;
 }
 
-.scroll-vertical {
+%scroll-vertical {
 	overflow-x: hidden;
 	overflow-y: auto;
 	-webkit-overflow-scrolling: touch;
+}
+
+.scroll-vertical {
+	@extend %scroll-vertical;
 }
 
 .scroll-snap-container {

--- a/css/src/components/scroll.scss
+++ b/css/src/components/scroll.scss
@@ -4,14 +4,10 @@
 	-webkit-overflow-scrolling: touch;
 }
 
-%scroll-vertical {
+.scroll-vertical {
 	overflow-x: hidden;
 	overflow-y: auto;
 	-webkit-overflow-scrolling: touch;
-}
-
-.scroll-vertical {
-	@extend %scroll-vertical;
 }
 
 .scroll-snap-container {

--- a/integration/tests/layout.spec.ts
+++ b/integration/tests/layout.spec.ts
@@ -8,7 +8,7 @@ const setSidecarRightLayoutSelector = '[data-set-layout="layout-sidecar-right"]'
 const constrainLayoutSelector = '[data-toggle-layout-height-constraint]';
 const hideHeroSelector = '[data-toggle-hero-visibility]';
 
-test.only('any unconstrained layout does not have a constrained height (twin) @desktop', async ({
+test('any unconstrained layout does not have a constrained height (twin) @desktop', async ({
 	page
 }, testInfo) => {
 	test.skip(
@@ -55,9 +55,7 @@ test.only('any unconstrained layout does not have a constrained height (twin) @d
 	expect(result.layoutIsConstrained).toBe(false);
 });
 
-test.only('single layout is never constrained, even on desktop @desktop', async ({
-	page
-}, testInfo) => {
+test('single layout is never constrained, even on desktop @desktop', async ({ page }, testInfo) => {
 	test.skip(
 		testInfo.project.name !== 'Widescreen Chromium',
 		'Skip test if display screen is not widescreen'
@@ -100,7 +98,7 @@ test.only('single layout is never constrained, even on desktop @desktop', async 
 	expect(result.layoutIsConstrained).toBe(false);
 });
 
-test.only('any constrained layout is not actually constrained on mobile (twin) @desktop', async ({
+test('any constrained layout is not actually constrained on mobile (twin) @desktop', async ({
 	page
 }, testInfo) => {
 	test.skip(
@@ -147,7 +145,7 @@ test.only('any constrained layout is not actually constrained on mobile (twin) @
 	expect(result.layoutIsConstrained).toBe(false);
 });
 
-test.only('twin layout can have its height constrained to 100vh with hero hidden @desktop', async ({
+test('twin layout can have its height constrained to 100vh with hero hidden @desktop', async ({
 	page
 }, testInfo) => {
 	test.skip(
@@ -197,7 +195,7 @@ test.only('twin layout can have its height constrained to 100vh with hero hidden
 	expect(result.layoutIsConstrained).toBe(true);
 });
 
-test.only('holy grail layout can have its height constrained to 100vh with hero hidden @desktop', async ({
+test('holy grail layout can have its height constrained to 100vh with hero hidden @desktop', async ({
 	page
 }, testInfo) => {
 	test.skip(
@@ -247,7 +245,7 @@ test.only('holy grail layout can have its height constrained to 100vh with hero 
 	expect(result.layoutIsConstrained).toBe(true);
 });
 
-test.only('sidecar-right layout can have its height constrained to 100vh with hero hidden @desktop', async ({
+test('sidecar-right layout can have its height constrained to 100vh with hero hidden @desktop', async ({
 	page
 }, testInfo) => {
 	test.skip(
@@ -297,7 +295,7 @@ test.only('sidecar-right layout can have its height constrained to 100vh with he
 	expect(result.layoutIsConstrained).toBe(true);
 });
 
-test.only('sidecar-left layout can have its height constrained to 100vh with hero hidden @desktop', async ({
+test('sidecar-left layout can have its height constrained to 100vh with hero hidden @desktop', async ({
 	page
 }, testInfo) => {
 	test.skip(

--- a/integration/tests/layout.spec.ts
+++ b/integration/tests/layout.spec.ts
@@ -1,0 +1,348 @@
+import { test, expect } from '@playwright/test';
+
+const setSingleLayoutSelector = '[data-set-layout="layout-single"]';
+const setHolyGrailLayoutSelector = '[data-set-layout="layout-holy-grail"]';
+const setTwinLayoutSelector = '[data-set-layout="layout-twin"]';
+const setSidecarLeftLayoutSelector = '[data-set-layout="layout-sidecar-left"]';
+const setSidecarRightLayoutSelector = '[data-set-layout="layout-sidecar-right"]';
+const constrainLayoutSelector = '[data-toggle-layout-height-constraint]';
+const hideHeroSelector = '[data-toggle-hero-visibility]';
+
+test.only('any unconstrained layout does not have a constrained height (twin) @desktop', async ({
+	page
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'Widescreen Chromium',
+		'Skip test if display screen is not widescreen'
+	);
+
+	await page.goto('/components/layout.html');
+	await page.waitForLoadState('domcontentloaded');
+
+	const twinLayoutButton = await page.locator(setTwinLayoutSelector);
+	const constrainHeightButton = await page.locator(constrainLayoutSelector);
+	const hideHeroButton = await page.locator(hideHeroSelector);
+
+	expect(twinLayoutButton).toBeTruthy();
+	expect(constrainHeightButton).toBeTruthy();
+	expect(hideHeroButton).toBeTruthy();
+
+	await twinLayoutButton.click();
+
+	await page.waitForTimeout(300);
+
+	let result: { [key: string]: boolean | null | string | number } = {};
+
+	result = await page.evaluate(arg => {
+		const layoutHtml = document.querySelector('.layout.layout-twin');
+		if (!layoutHtml) {
+			throw new Error('Did not find expected layout element');
+		}
+		const mainElement = layoutHtml.querySelector('.layout-body-main');
+		if (!mainElement) {
+			throw new Error('Did not find expected layout main element');
+		}
+		const mainIsScrolled = mainElement.scrollHeight > mainElement.clientHeight;
+		const layoutIsConstrained =
+			layoutHtml.scrollHeight === window.innerHeight &&
+			window.innerHeight === layoutHtml.clientHeight;
+		arg.exceedsScreenHeight = mainIsScrolled;
+		arg.layoutIsConstrained = layoutIsConstrained;
+		return arg;
+	}, result);
+
+	expect(result.exceedsScreenHeight).toBe(false);
+	expect(result.layoutIsConstrained).toBe(false);
+});
+
+test.only('single layout is never constrained, even on desktop @desktop', async ({
+	page
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'Widescreen Chromium',
+		'Skip test if display screen is not widescreen'
+	);
+
+	await page.goto('/components/layout.html');
+	await page.waitForLoadState('domcontentloaded');
+
+	const singleLayoutButton = await page.locator(setSingleLayoutSelector);
+	const constrainHeightButton = await page.locator(constrainLayoutSelector);
+
+	expect(singleLayoutButton).toBeTruthy();
+	expect(constrainHeightButton).toBeTruthy();
+
+	await singleLayoutButton.click();
+
+	await page.waitForTimeout(300);
+
+	let result: { [key: string]: boolean | null | string | number } = {};
+
+	result = await page.evaluate(arg => {
+		const layoutHtml = document.querySelector('.layout.layout-single');
+		if (!layoutHtml) {
+			throw new Error('Did not find expected layout element');
+		}
+		const mainElement = layoutHtml.querySelector('.layout-body-main');
+		if (!mainElement) {
+			throw new Error('Did not find expected layout main element');
+		}
+		const mainIsScrolled = mainElement.scrollHeight > mainElement.clientHeight;
+		const layoutIsConstrained =
+			layoutHtml.scrollHeight === window.innerHeight &&
+			window.innerHeight === layoutHtml.clientHeight;
+		arg.exceedsScreenHeight = mainIsScrolled;
+		arg.layoutIsConstrained = layoutIsConstrained;
+		return arg;
+	}, result);
+
+	expect(result.exceedsScreenHeight).toBe(false);
+	expect(result.layoutIsConstrained).toBe(false);
+});
+
+test.only('any constrained layout is not actually constrained on mobile (twin) @desktop', async ({
+	page
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name === 'Widescreen Chromium',
+		'Skip test if display screen is not mobile'
+	);
+
+	await page.goto('/components/layout.html');
+	await page.waitForLoadState('domcontentloaded');
+
+	const twinLayoutButton = await page.locator(setTwinLayoutSelector);
+	const constrainHeightButton = await page.locator(constrainLayoutSelector);
+	const hideHeroButton = await page.locator(hideHeroSelector);
+
+	expect(twinLayoutButton).toBeTruthy();
+	expect(constrainHeightButton).toBeTruthy();
+	expect(hideHeroButton).toBeTruthy();
+
+	await twinLayoutButton.click();
+
+	await page.waitForTimeout(300);
+
+	let result: { [key: string]: boolean | null | string | number } = {};
+
+	result = await page.evaluate(arg => {
+		const layoutHtml = document.querySelector('.layout.layout-twin');
+		if (!layoutHtml) {
+			throw new Error('Did not find expected layout element');
+		}
+		const mainElement = layoutHtml.querySelector('.layout-body-main');
+		if (!mainElement) {
+			throw new Error('Did not find expected layout main element');
+		}
+		const mainIsScrolled = mainElement.scrollHeight > mainElement.clientHeight;
+		const layoutIsConstrained =
+			layoutHtml.scrollHeight === window.innerHeight &&
+			window.innerHeight === layoutHtml.clientHeight;
+		arg.exceedsScreenHeight = mainIsScrolled;
+		arg.layoutIsConstrained = layoutIsConstrained;
+		return arg;
+	}, result);
+
+	expect(result.exceedsScreenHeight).toBe(false);
+	expect(result.layoutIsConstrained).toBe(false);
+});
+
+test.only('twin layout can have its height constrained to 100vh with hero hidden @desktop', async ({
+	page
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'Widescreen Chromium',
+		'Skip test if display screen is not widescreen'
+	);
+
+	await page.goto('/components/layout.html');
+	await page.waitForLoadState('domcontentloaded');
+
+	const twinLayoutButton = await page.locator(setTwinLayoutSelector);
+	const constrainHeightButton = await page.locator(constrainLayoutSelector);
+	const hideHeroButton = await page.locator(hideHeroSelector);
+
+	expect(twinLayoutButton).toBeTruthy();
+	expect(constrainHeightButton).toBeTruthy();
+	expect(hideHeroButton).toBeTruthy();
+
+	await twinLayoutButton.click();
+
+	await page.waitForTimeout(300);
+
+	await hideHeroButton.click(); // remove hero
+	await constrainHeightButton.click(); // apply .layout-constrained
+
+	let result: { [key: string]: boolean | null | string | number } = {};
+
+	result = await page.evaluate(arg => {
+		const layoutHtml = document.querySelector('.layout.layout-twin');
+		if (!layoutHtml) {
+			throw new Error('Did not find expected layout element');
+		}
+		const mainElement = layoutHtml.querySelector('.layout-body-main');
+		if (!mainElement) {
+			throw new Error('Did not find expected layout main element');
+		}
+		const mainIsScrolled = mainElement.scrollHeight > mainElement.clientHeight;
+		const layoutIsConstrained =
+			layoutHtml.scrollHeight === window.innerHeight &&
+			window.innerHeight === layoutHtml.clientHeight;
+		arg.exceedsScreenHeight = mainIsScrolled;
+		arg.layoutIsConstrained = layoutIsConstrained;
+		return arg;
+	}, result);
+
+	expect(result.exceedsScreenHeight).toBe(true);
+	expect(result.layoutIsConstrained).toBe(true);
+});
+
+test.only('holy grail layout can have its height constrained to 100vh with hero hidden @desktop', async ({
+	page
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'Widescreen Chromium',
+		'Skip test if display screen is not widescreen'
+	);
+
+	await page.goto('/components/layout.html');
+	await page.waitForLoadState('domcontentloaded');
+
+	const holyGrailLayoutButton = await page.locator(setHolyGrailLayoutSelector);
+	const constrainHeightButton = await page.locator(constrainLayoutSelector);
+	const hideHeroButton = await page.locator(hideHeroSelector);
+
+	expect(holyGrailLayoutButton).toBeTruthy();
+	expect(constrainHeightButton).toBeTruthy();
+	expect(hideHeroButton).toBeTruthy();
+
+	await holyGrailLayoutButton.click();
+
+	await page.waitForTimeout(300);
+
+	await hideHeroButton.click(); // remove hero
+	await constrainHeightButton.click(); // apply .layout-constrained
+
+	let result: { [key: string]: boolean | null | string | number } = {};
+
+	result = await page.evaluate(arg => {
+		const layoutHtml = document.querySelector('.layout.layout-holy-grail');
+		if (!layoutHtml) {
+			throw new Error('Did not find expected layout element');
+		}
+		const mainElement = layoutHtml.querySelector('.layout-body-main');
+		if (!mainElement) {
+			throw new Error('Did not find expected layout main element');
+		}
+		const mainIsScrolled = mainElement.scrollHeight > mainElement.clientHeight;
+		const layoutIsConstrained =
+			layoutHtml.scrollHeight === window.innerHeight &&
+			window.innerHeight === layoutHtml.clientHeight;
+		arg.exceedsScreenHeight = mainIsScrolled;
+		arg.layoutIsConstrained = layoutIsConstrained;
+		return arg;
+	}, result);
+
+	expect(result.exceedsScreenHeight).toBe(true);
+	expect(result.layoutIsConstrained).toBe(true);
+});
+
+test.only('sidecar-right layout can have its height constrained to 100vh with hero hidden @desktop', async ({
+	page
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'Widescreen Chromium',
+		'Skip test if display screen is not widescreen'
+	);
+
+	await page.goto('/components/layout.html');
+	await page.waitForLoadState('domcontentloaded');
+
+	const sidecarRightButton = await page.locator(setSidecarRightLayoutSelector);
+	const constrainHeightButton = await page.locator(constrainLayoutSelector);
+	const hideHeroButton = await page.locator(hideHeroSelector);
+
+	expect(sidecarRightButton).toBeTruthy();
+	expect(constrainHeightButton).toBeTruthy();
+	expect(hideHeroButton).toBeTruthy();
+
+	await sidecarRightButton.click();
+
+	await page.waitForTimeout(300);
+
+	await hideHeroButton.click(); // remove hero
+	await constrainHeightButton.click(); // apply .layout-constrained
+
+	let result: { [key: string]: boolean | null | string | number } = {};
+
+	result = await page.evaluate(arg => {
+		const layoutHtml = document.querySelector('.layout.layout-sidecar-right');
+		if (!layoutHtml) {
+			throw new Error('Did not find expected layout element');
+		}
+		const mainElement = layoutHtml.querySelector('.layout-body-main');
+		if (!mainElement) {
+			throw new Error('Did not find expected layout main element');
+		}
+		const mainIsScrolled = mainElement.scrollHeight > mainElement.clientHeight;
+		const layoutIsConstrained =
+			layoutHtml.scrollHeight === window.innerHeight &&
+			window.innerHeight === layoutHtml.clientHeight;
+		arg.exceedsScreenHeight = mainIsScrolled;
+		arg.layoutIsConstrained = layoutIsConstrained;
+		return arg;
+	}, result);
+
+	expect(result.exceedsScreenHeight).toBe(true);
+	expect(result.layoutIsConstrained).toBe(true);
+});
+
+test.only('sidecar-left layout can have its height constrained to 100vh with hero hidden @desktop', async ({
+	page
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'Widescreen Chromium',
+		'Skip test if display screen is not widescreen'
+	);
+
+	await page.goto('/components/layout.html');
+	await page.waitForLoadState('domcontentloaded');
+
+	const sidecarLeftButton = await page.locator(setSidecarLeftLayoutSelector);
+	const constrainHeightButton = await page.locator(constrainLayoutSelector);
+	const hideHeroButton = await page.locator(hideHeroSelector);
+
+	expect(sidecarLeftButton).toBeTruthy();
+	expect(constrainHeightButton).toBeTruthy();
+	expect(hideHeroButton).toBeTruthy();
+
+	await sidecarLeftButton.click();
+
+	await page.waitForTimeout(300);
+
+	await hideHeroButton.click(); // remove hero
+	await constrainHeightButton.click(); // apply .layout-constrained
+
+	let result: { [key: string]: boolean | null | string | number } = {};
+
+	result = await page.evaluate(arg => {
+		const layoutHtml = document.querySelector('.layout.layout-sidecar-left');
+		if (!layoutHtml) {
+			throw new Error('Did not find expected layout element');
+		}
+		const mainElement = layoutHtml.querySelector('.layout-body-main');
+		if (!mainElement) {
+			throw new Error('Did not find expected layout main element');
+		}
+		const mainIsScrolled = mainElement.scrollHeight > mainElement.clientHeight;
+		const layoutIsConstrained =
+			layoutHtml.scrollHeight === window.innerHeight &&
+			window.innerHeight === layoutHtml.clientHeight;
+		arg.exceedsScreenHeight = mainIsScrolled;
+		arg.layoutIsConstrained = layoutIsConstrained;
+		return arg;
+	}, result);
+
+	expect(result.exceedsScreenHeight).toBe(true);
+	expect(result.layoutIsConstrained).toBe(true);
+});

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -1,0 +1,33 @@
+let frame: number;
+
+const setLayoutCssVariables = () => {
+	const footerHeight = document.querySelector('.layout-body-footer')?.clientHeight;
+	const headerHeight = document.querySelector('.layout-body-header')?.clientHeight;
+
+	const headerCssProp = headerHeight
+		? `--atlas-header-height: ${headerHeight}px !important;`
+		: '--atlas-header-height: 0px !important;';
+	const footerCssProp = footerHeight
+		? `--atlas-footer-height: ${footerHeight}px !important;`
+		: '--atlas-footer-height: 0px !important;';
+
+	document.documentElement.style.cssText = `
+			--window-inner-height: ${window.innerHeight}px !important;
+			${headerCssProp}
+			${footerCssProp}
+			`;
+};
+
+export function initLayoutHelpers() {
+	window.addEventListener('resize', () => {
+		if (frame) {
+			cancelAnimationFrame(frame);
+		}
+
+		frame = requestAnimationFrame(setLayoutCssVariables);
+	});
+
+	document.documentElement.style.cssText = `--window-inner-height: ${window.innerHeight}px !important`;
+
+	window.addEventListener('DOMContentLoaded', setLayoutCssVariables);
+}

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -18,14 +18,18 @@ const setLayoutCssVariables = () => {
 			`;
 };
 
-export function initLayoutHelpers() {
-	window.addEventListener('resize', () => {
+export function initLayout() {
+	window.addEventListener('atlas-layout-change-event', () => {
 		if (frame) {
 			cancelAnimationFrame(frame);
 		}
 
 		frame = requestAnimationFrame(setLayoutCssVariables);
 	});
+
+	window.addEventListener('resize', () =>
+		window.dispatchEvent(new CustomEvent('atlas-layout-change-event'))
+	);
 
 	document.documentElement.style.cssText = `--window-inner-height: ${window.innerHeight}px !important`;
 

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -4,3 +4,4 @@ export * from './behaviors/snap-scroll';
 export * from './elements/form-behavior';
 export * from './elements/tab-container/index';
 export * from './utilities/util';
+export * from './behaviors/layout';

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -23,7 +23,14 @@ This page is utilizing the holy grail layout, but you can use the buttons below 
   <button class="button" data-set-layout="layout-sidecar-left">Sidecar left</button>
   <button class="button" data-set-layout="layout-sidecar-right">Sidecar right</button>
 </div>
-<button class="button margin-top-sm" data-toggle-debug aria-pressed="false">Toggle container labels</button>
+<div class="buttons buttons-addons display-inline-flex">
+	<button class="button" data-toggle-debug aria-pressed="false">Toggle container labels</button>
+	<button class="button" data-toggle-layout-height-constraint aria-pressed="false">Constrain layout height</button>
+</div>
+<div class="buttons buttons-addons display-inline-flex">
+	<button class="button" data-toggle-hero-visibility aria-pressed="false">Toggle hero</button>
+	<button class="button" data-toggle-footer-visibility aria-pressed="false">Toggle footer</button>
+</div>
 
 ## Important concepts
 

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -206,7 +206,7 @@ Required elements: all except `layout-body-hero` and `layout-body-menu` (see all
 
 Allowed elements: all except `layout-body-menu`.
 
-Yes, on tablet screens and wider.
+Can have its height constrained? Yes, on tablet screens and wider.
 
 The following block is arranged from narrow widths on the left to wider widths on the right.
 

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -16,18 +16,18 @@ The layout component provides a flexible and efficient way to structure the majo
 
 This page is utilizing the holy grail layout, but you can use the buttons below to toggle layouts and test them out by resizing the screen. Try the "Toggle container labels" button below to see the css classes on each of the containers inside `.layout`.
 
-<div class="buttons buttons-addons margin-top-sm display-inline-flex">
+<div class="buttons buttons-addons margin-top-sm display-flex">
   <button class="button" data-set-layout="layout-holy-grail" aria-pressed="true">Holy grail</button>
   <button class="button" data-set-layout="layout-twin">Twin</button>
   <button class="button" data-set-layout="layout-single">Single</button>
   <button class="button" data-set-layout="layout-sidecar-left">Sidecar left</button>
   <button class="button" data-set-layout="layout-sidecar-right">Sidecar right</button>
 </div>
-<div class="buttons buttons-addons display-inline-flex">
+<div class="buttons buttons-addons display-flex">
 	<button class="button" data-toggle-debug aria-pressed="false">Toggle container labels</button>
 	<button class="button" data-toggle-layout-height-constraint aria-pressed="false">Constrain layout height</button>
 </div>
-<div class="buttons buttons-addons display-inline-flex">
+<div class="buttons buttons-addons display-flex">
 	<button class="button" data-toggle-hero-visibility aria-pressed="false">Toggle hero</button>
 	<button class="button" data-toggle-footer-visibility aria-pressed="false">Toggle footer</button>
 </div>
@@ -262,6 +262,25 @@ The specification for this layout is as follows.
 | ---------------- | ------------------------------------------------------------------ |
 | Narrow           | All elements are stacked.                                          |
 | Tablet and wider | Main and aside are side by side. Main and aside are the same width |
+
+## Layouts with individually scrolling content containers
+
+If you'd like central containers to scroll individually, instead of the page itself, you have to constrain the height of the layout to the viewport. In order to do that, you can add the `.layout-constrained` class to the `html.layout` element. This has no effect on narrow screens or on the `single` layout, but will work on all other layouts on tablet and larger. This requires the use of some very lightweight client JavaScript to updates a few values on the HTML element as the screen is resizes. This means you must install `@microsoft/atlas-js` and import and call the `initLayout` in your client scripts for this behavior to work. See [how this site does it on GitHub](https://github.com/microsoft/atlas-design/blob/main/site/src/scaffold/index.ts).
+
+### How constraint work?
+
+On tablet and wider, on layouts other than single, height of the page is calculated to be 100vh (i.e. the size of the viewport) _plus the size of the hero._ This means:
+
+1. Main (and any container horizontally adjacent to it) will have a height equal to the viewport height minus the footer's height and the header's height.
+1. Developers must still consider narrow views first. This behavior does not change scroll on narrow screens or mobile devices.
+1. Consider also whether to omit footer or move footer into a different container for a more perfect full-screen fit.
+
+### Why is hero excluded from height calculation?
+
+1. The hero is full width and never side by side with another container. It needn't be scrolled individually and what's more doing so would be quite an odd behavior.
+1. Including it will not harm the experience, but it isn't recommended when using height constraints.
+1. Users will have to scroll past hero to get to the content containers. If you do include it, ensure it isn't too tall.
+1. Remember, the hero is always optional.
 
 ## Accessibility Concerns
 

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -92,6 +92,8 @@ Required elements: all except `layout-body-hero`.
 
 Allowed elements: all.
 
+Can have its height constrained? No.
+
 ```Text
    Narrow
   ┌────────────┐
@@ -124,6 +126,8 @@ How do I apply it? `layout-holy-grail` to the `layout` element.
 Required elements: all except `layout-body-hero`.
 
 Allowed elements: all.
+
+Can have its height constrained? Yes, on desktop screens and wider. This differs from other constrainable layouts, because on tablet aside wraps under main, preventing us from constraining main's height effectively.
 
 The following block is arranged from narrow widths on the left to wider widths on the right.
 
@@ -163,6 +167,8 @@ Required elements: all except `layout-body-hero` and `layout-body-aside` (see al
 
 Allowed elements: all except `layout-body-aside`.
 
+Can have its height constrained? Yes, on tablet screens and wider.
+
 The following block is arranged from narrow widths on the left to wider widths on the right.
 
 ```txt
@@ -199,6 +205,8 @@ How do I apply it? `layout-sidecar-right` to the `layout` element.
 Required elements: all except `layout-body-hero` and `layout-body-menu` (see allowed elements).
 
 Allowed elements: all except `layout-body-menu`.
+
+Yes, on tablet screens and wider.
 
 The following block is arranged from narrow widths on the left to wider widths on the right.
 
@@ -237,6 +245,8 @@ Required elements: all except `layout-body-hero` and `layout-body-menu` (see all
 
 Allowed elements: all except `layout-body-menu`.
 
+Yes, on tablet screens and wider.
+
 The following block is arranged from narrow widths on the left to wider widths on the right.
 
 ```txt
@@ -265,11 +275,13 @@ The specification for this layout is as follows.
 
 ## Layouts with individually scrolling content containers
 
-If you'd like central containers to scroll individually, instead of the page itself, you have to constrain the height of the layout to the viewport. In order to do that, you can add the `.layout-constrained` class to the `html.layout` element. This has no effect on narrow screens or on the `single` layout, but will work on all other layouts on tablet and larger. This requires the use of some very lightweight client JavaScript to updates a few values on the HTML element as the screen resizes. This means you must install `@microsoft/atlas-js` and import and call the `initLayout` in your client scripts for this behavior to work. See [how this site does it on GitHub](https://github.com/microsoft/atlas-design/blob/main/site/src/scaffold/index.ts).
+If you'd like central containers to scroll individually, instead of the page itself, you have to constrain the height of the layout to the viewport. In order to do that, you can add the `.layout-constrained` class to the `html.layout` element. This has no effect on narrow screens or on the `single` layout, but will work on most other layouts on tablet and larger (the exception being holy grail, which kicks in on desktop widths). See each layout's individual section for behavior specific to it.
+
+This requires the use of some very lightweight client JavaScript to updates a few values on the HTML element as the screen resizes. This means you must install `@microsoft/atlas-js` and import and call the `initLayout` in your client scripts for this behavior to work. See [how this site does it on GitHub](https://github.com/microsoft/atlas-design/blob/main/site/src/scaffold/index.ts).
 
 ### How does constraint work?
 
-On tablet and wider, on layouts other than single, height of the page is calculated to be 100vh (i.e. the size of the viewport) _plus the size of the hero._ This means:
+When constraint is active the height of the page is calculated to be 100vh (i.e. the size of the viewport) _plus the size of the hero._ This means:
 
 1. Main (and any container horizontally adjacent to it) will have a height equal to the viewport height minus the footer's height and the header's height.
 1. Developers must still consider narrow views first. This behavior does not change scroll on narrow screens or mobile devices.

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -267,7 +267,7 @@ The specification for this layout is as follows.
 
 If you'd like central containers to scroll individually, instead of the page itself, you have to constrain the height of the layout to the viewport. In order to do that, you can add the `.layout-constrained` class to the `html.layout` element. This has no effect on narrow screens or on the `single` layout, but will work on all other layouts on tablet and larger. This requires the use of some very lightweight client JavaScript to updates a few values on the HTML element as the screen resizes. This means you must install `@microsoft/atlas-js` and import and call the `initLayout` in your client scripts for this behavior to work. See [how this site does it on GitHub](https://github.com/microsoft/atlas-design/blob/main/site/src/scaffold/index.ts).
 
-### How constraint work?
+### How does constraint work?
 
 On tablet and wider, on layouts other than single, height of the page is calculated to be 100vh (i.e. the size of the viewport) _plus the size of the hero._ This means:
 

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -245,7 +245,7 @@ Required elements: all except `layout-body-hero` and `layout-body-menu` (see all
 
 Allowed elements: all except `layout-body-menu`.
 
-Yes, on tablet screens and wider.
+Can have its height constrained? Yes, on tablet screens and wider.
 
 The following block is arranged from narrow widths on the left to wider widths on the right.
 

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -265,7 +265,7 @@ The specification for this layout is as follows.
 
 ## Layouts with individually scrolling content containers
 
-If you'd like central containers to scroll individually, instead of the page itself, you have to constrain the height of the layout to the viewport. In order to do that, you can add the `.layout-constrained` class to the `html.layout` element. This has no effect on narrow screens or on the `single` layout, but will work on all other layouts on tablet and larger. This requires the use of some very lightweight client JavaScript to updates a few values on the HTML element as the screen is resizes. This means you must install `@microsoft/atlas-js` and import and call the `initLayout` in your client scripts for this behavior to work. See [how this site does it on GitHub](https://github.com/microsoft/atlas-design/blob/main/site/src/scaffold/index.ts).
+If you'd like central containers to scroll individually, instead of the page itself, you have to constrain the height of the layout to the viewport. In order to do that, you can add the `.layout-constrained` class to the `html.layout` element. This has no effect on narrow screens or on the `single` layout, but will work on all other layouts on tablet and larger. This requires the use of some very lightweight client JavaScript to updates a few values on the HTML element as the screen resizes. This means you must install `@microsoft/atlas-js` and import and call the `initLayout` in your client scripts for this behavior to work. See [how this site does it on GitHub](https://github.com/microsoft/atlas-design/blob/main/site/src/scaffold/index.ts).
 
 ### How constraint work?
 

--- a/site/src/scaffold/index.ts
+++ b/site/src/scaffold/index.ts
@@ -6,7 +6,7 @@ import {
 	initDismiss,
 	initPopover,
 	initSnapScroll,
-	initLayoutHelpers
+	initLayout
 } from '@microsoft/atlas-js/src/index';
 import { handleFocusableIfScrollable } from './scripts/focusable-if-scrollable';
 import { initFullScreenToggle } from './scripts/full-screen-toggle';
@@ -24,4 +24,4 @@ initFullScreenToggle();
 handleFocusableIfScrollable();
 handleFullScreenNavButton();
 initLayoutPageControls();
-initLayoutHelpers();
+initLayout();

--- a/site/src/scaffold/index.ts
+++ b/site/src/scaffold/index.ts
@@ -2,7 +2,12 @@ import { handleCodeFilters } from './scripts/code-filter';
 import { handleFigmaFullScreenRequest } from './scripts/figma-embed';
 import { initTheme } from './scripts/theming';
 import { handleMockFormSubmit } from './scripts/form-submit';
-import { initDismiss, initPopover, initSnapScroll } from '@microsoft/atlas-js/src/index';
+import {
+	initDismiss,
+	initPopover,
+	initSnapScroll,
+	initLayoutHelpers
+} from '@microsoft/atlas-js/src/index';
 import { handleFocusableIfScrollable } from './scripts/focusable-if-scrollable';
 import { initFullScreenToggle } from './scripts/full-screen-toggle';
 import { initLayoutPageControls } from './scripts/layout-page';
@@ -19,3 +24,4 @@ initFullScreenToggle();
 handleFocusableIfScrollable();
 handleFullScreenNavButton();
 initLayoutPageControls();
+initLayoutHelpers();

--- a/site/src/scaffold/scripts/layout-page.ts
+++ b/site/src/scaffold/scripts/layout-page.ts
@@ -1,5 +1,6 @@
 const layoutsClasses = [
 	'layout-single',
+	'layout-twin',
 	'layout-holy-grail',
 	'layout-sidecar-left',
 	'layout-sidecar-right',
@@ -47,6 +48,55 @@ export function initLayoutPageControls() {
 		}
 		target.classList.toggle('button-filled');
 		document.documentElement.classList.toggle('debug');
+		target.setAttribute('aria-pressed', target.classList.contains('button-filled').toString());
+	});
+
+	window.addEventListener('click', (e: MouseEvent) => {
+		const target =
+			e.target instanceof Element &&
+			(e.target.closest('[data-toggle-layout-height-constraint]') as HTMLElement);
+		if (!target) {
+			return;
+		}
+
+		target.classList.toggle('button-filled');
+		document.documentElement.classList.toggle('layout-constrained');
+		target.setAttribute('aria-pressed', target.classList.contains('button-filled').toString());
+	});
+
+	//
+
+	window.addEventListener('click', (e: MouseEvent) => {
+		const target =
+			e.target instanceof Element &&
+			(e.target.closest('[data-toggle-hero-visibility]') as HTMLElement);
+		if (!target) {
+			return;
+		}
+
+		target.classList.toggle('button-filled');
+		const hero = document.querySelector('.layout-body-hero') as HTMLElement;
+		if (!hero) {
+			return;
+		}
+		hero.hidden = !hero.hidden;
+		target.setAttribute('aria-pressed', target.classList.contains('button-filled').toString());
+	});
+
+	window.addEventListener('click', (e: MouseEvent) => {
+		const target =
+			e.target instanceof Element &&
+			(e.target.closest('[data-toggle-footer-visibility]') as HTMLElement);
+		if (!target) {
+			return;
+		}
+
+		target.classList.toggle('button-filled');
+		const footer = document.querySelector('.layout-body-footer') as HTMLElement;
+		if (!footer) {
+			return;
+		}
+		footer.hidden = !footer.hidden;
 		target.setAttribute('aria-pressed', target.classList.contains('button-filled').toString());
 	});
 }

--- a/site/src/scaffold/scripts/layout-page.ts
+++ b/site/src/scaffold/scripts/layout-page.ts
@@ -62,6 +62,8 @@ export function initLayoutPageControls() {
 		target.classList.toggle('button-filled');
 		document.documentElement.classList.toggle('layout-constrained');
 		target.setAttribute('aria-pressed', target.classList.contains('button-filled').toString());
+
+		window.dispatchEvent(new CustomEvent('atlas-layout-change-event'));
 	});
 
 	//
@@ -81,6 +83,8 @@ export function initLayoutPageControls() {
 		}
 		hero.hidden = !hero.hidden;
 		target.setAttribute('aria-pressed', target.classList.contains('button-filled').toString());
+
+		window.dispatchEvent(new CustomEvent('atlas-layout-change-event'));
 	});
 
 	window.addEventListener('click', (e: MouseEvent) => {
@@ -98,6 +102,8 @@ export function initLayoutPageControls() {
 		}
 		footer.hidden = !footer.hidden;
 		target.setAttribute('aria-pressed', target.classList.contains('button-filled').toString());
+
+		window.dispatchEvent(new CustomEvent('atlas-layout-change-event'));
 	});
 }
 


### PR DESCRIPTION
Solution to allow layouts to constrain themselves to roughly viewport.

Visit: http://localhost:1111/components/layout.html

Click the constrain layout button, read through the updated documentation.

Resize screen to ensure various widths work well.

## Contributor checklist

- [x] Did you submit a changeset? Changesets are required for all code changes.
- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.

