### PR TITLE
[Feature] add width class for fit content

### DIFF
--- a/.changeset/six-eels-deny.md
+++ b/.changeset/six-eels-deny.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-site': minor
+'@microsoft/atlas-css': minor
+---
+
+Add .width-fit as addtional width class

--- a/.changeset/six-eels-deny.md
+++ b/.changeset/six-eels-deny.md
@@ -3,4 +3,4 @@
 '@microsoft/atlas-css': minor
 ---
 
-Add .width-fit as addtional width class
+Add .width-fit-content as additional width class

--- a/css/src/atomics/width.scss
+++ b/css/src/atomics/width.scss
@@ -1,6 +1,6 @@
 @use 'sass:list';
 
-$universal-widths: auto, 100, 150, 200, 250, 300, 350 !default;
+$universal-widths: auto, fit-content, 100, 150, 200, 250, 300, 350 !default;
 $mobile-incompatible-widths: 400, 450, 500, unset !default;
 $all-widths: list.join($universal-widths, $mobile-incompatible-widths);
 
@@ -10,12 +10,8 @@ $all-widths: list.join($universal-widths, $mobile-incompatible-widths);
 	width: 100% !important;
 }
 
-.width-fit-content {
-	width: fit-content;
-}
-
 @each $width in $universal-widths {
-	$unit: if($width != auto, 'px', '');
+	$unit: if($width != auto and $width != fit-content, 'px', '');
 	.width-#{$width} {
 		width: #{$width}#{$unit} !important;
 	}
@@ -26,12 +22,8 @@ $all-widths: list.join($universal-widths, $mobile-incompatible-widths);
 		width: 100% !important;
 	}
 
-	.width-fit-content-tablet {
-		width: fit-content;
-	}
-
 	@each $width in $all-widths {
-		$unit: if($width != auto and $width != unset, 'px', '');
+		$unit: if($width != auto and $width != unset and $width != fit-content, 'px', '');
 		.width-#{$width}-tablet {
 			width: #{$width}#{$unit} !important;
 		}
@@ -43,12 +35,8 @@ $all-widths: list.join($universal-widths, $mobile-incompatible-widths);
 		width: 100% !important;
 	}
 
-	.width-fit-content-desktop {
-		width: fit-content;
-	}
-
 	@each $width in $all-widths {
-		$unit: if($width != auto and $width != unset, 'px', '');
+		$unit: if($width != auto and $width != unset and $width != fit-content, 'px', '');
 		.width-#{$width}-desktop {
 			width: #{$width}#{$unit} !important;
 		}

--- a/css/src/atomics/width.scss
+++ b/css/src/atomics/width.scss
@@ -10,7 +10,7 @@ $all-widths: list.join($universal-widths, $mobile-incompatible-widths);
 	width: 100% !important;
 }
 
-.width-fit {
+.width-fit-content {
 	width: fit-content;
 }
 
@@ -26,7 +26,7 @@ $all-widths: list.join($universal-widths, $mobile-incompatible-widths);
 		width: 100% !important;
 	}
 
-	.width-fit {
+	.width-fit-content-tablet {
 		width: fit-content;
 	}
 
@@ -43,7 +43,7 @@ $all-widths: list.join($universal-widths, $mobile-incompatible-widths);
 		width: 100% !important;
 	}
 
-	.width-fit {
+	.width-fit-content-desktop {
 		width: fit-content;
 	}
 

--- a/css/src/atomics/width.scss
+++ b/css/src/atomics/width.scss
@@ -10,6 +10,10 @@ $all-widths: list.join($universal-widths, $mobile-incompatible-widths);
 	width: 100% !important;
 }
 
+.width-fit {
+	width: fit-content;
+}
+
 @each $width in $universal-widths {
 	$unit: if($width != auto, 'px', '');
 	.width-#{$width} {
@@ -20,6 +24,10 @@ $all-widths: list.join($universal-widths, $mobile-incompatible-widths);
 @include tablet {
 	.width-full-tablet {
 		width: 100% !important;
+	}
+
+	.width-fit {
+		width: fit-content;
 	}
 
 	@each $width in $all-widths {
@@ -33,6 +41,10 @@ $all-widths: list.join($universal-widths, $mobile-incompatible-widths);
 @include desktop {
 	.width-full-desktop {
 		width: 100% !important;
+	}
+
+	.width-fit {
+		width: fit-content;
 	}
 
 	@each $width in $all-widths {

--- a/site/src/atomics/width.md
+++ b/site/src/atomics/width.md
@@ -13,10 +13,10 @@ Need to specify a specific width for an element? You've come to the right place!
 
 Values are in pixels. Keep in mind that the `min-width` and `max-width` properties override the standard `width` property. If you aren't using the Atlas core folder as a base for your styles, these classes work best when [you're setting `box-sizing` to be `border-box` in some way](https://css-tricks.com/box-sizing/#aa-present-day-box-sizing). Values represent pixel unless they are a string or otherwise specified.
 
-| cssproperty                                      | value                                                                  | screensize                           |
-| ------------------------------------------------ | ---------------------------------------------------------------------- | ------------------------------------ |
-| `width`                                          | `auto`, `100`, `150`, `200`, `250`, `300`, `350`, `full` (100%), `fit` | all screensizes, `tablet`, `desktop` |
-| `width` (available on tablet screens and larger) | `400`, `450`, `500`, `unset`                                           | `tablet`, `desktop`                  |
+| cssproperty                                      | value                                                                          | screensize                           |
+| ------------------------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------ |
+| `width`                                          | `auto`, `100`, `150`, `200`, `250`, `300`, `350`, `full` (100%), `fit-content` | all screensizes, `tablet`, `desktop` |
+| `width` (available on tablet screens and larger) | `400`, `450`, `500`, `unset`                                                   | `tablet`, `desktop`                  |
 
 ## Usage
 
@@ -86,7 +86,7 @@ List of all available classes:
 
 ```atomics-filter
 .width-full
-.width-fit
+.width-fit-content
 .width-auto
 .width-100
 .width-150

--- a/site/src/atomics/width.md
+++ b/site/src/atomics/width.md
@@ -13,10 +13,10 @@ Need to specify a specific width for an element? You've come to the right place!
 
 Values are in pixels. Keep in mind that the `min-width` and `max-width` properties override the standard `width` property. If you aren't using the Atlas core folder as a base for your styles, these classes work best when [you're setting `box-sizing` to be `border-box` in some way](https://css-tricks.com/box-sizing/#aa-present-day-box-sizing). Values represent pixel unless they are a string or otherwise specified.
 
-| cssproperty                                      | value                                                           | screensize                           |
-| ------------------------------------------------ | --------------------------------------------------------------- | ------------------------------------ |
-| `width`                                          | `auto`, `100`, `150`, `200`, `250`, `300`, `350`, `full` (100%) | all screensizes, `tablet`, `desktop` |
-| `width` (available on tablet screens and larger) | `400`, `450`, `500`, `unset`                                    | `tablet`, `desktop`                  |
+| cssproperty                                      | value                                                                  | screensize                           |
+| ------------------------------------------------ | ---------------------------------------------------------------------- | ------------------------------------ |
+| `width`                                          | `auto`, `100`, `150`, `200`, `250`, `300`, `350`, `full` (100%), `fit` | all screensizes, `tablet`, `desktop` |
+| `width` (available on tablet screens and larger) | `400`, `450`, `500`, `unset`                                           | `tablet`, `desktop`                  |
 
 ## Usage
 
@@ -86,6 +86,7 @@ List of all available classes:
 
 ```atomics-filter
 .width-full
+.width-fit
 .width-auto
 .width-100
 .width-150


### PR DESCRIPTION
Task: [Story](https://ceapex.visualstudio.com/Engineering/_workitems/edit/1001591)

Link: [preview](http://localhost:1111/atomics/width.html)

This PR was sparked from the need to have the width of child components be at max the size of their content instead of the deriving from parent (or left to decide for itself). For example, we noticed that the iframe for arkose captcha takes less space than the modal that holds it leading to extra space in the container: 

<img width="576" alt="image (3) (1)" src="https://github.com/user-attachments/assets/62f7bf37-b9d7-412c-a6fc-ab6f809f4fec">

Adding `fit-content` to the modal fixes this:
![image](https://github.com/user-attachments/assets/16bc431d-ff4d-4844-bda8-45ffa023637c)
![image (4)](https://github.com/user-attachments/assets/602256e5-7e72-4b3f-8734-769c500ff0ab)

## Testing

To test this new class, you can locally add this (below) snippet to `/site/src/atomics/width.md` and run `npm start`

``` html
<div class="width-500-tablet border padding-sm font-weight-semibold">
	<div class="width-fit-content" style="background: red; height: 20px">
		This div is only as wide the content
	</div>
</div>
```

The inner div (red) should only be as wide as the text it contains (not as wide as the parent)

<img width="289" alt="image" src="https://github.com/user-attachments/assets/79c4da87-f4f8-4ab4-a470-3b9a716e34b5">


## Additional information
[PR](https://ceapex.visualstudio.com/Engineering/_git/docs-ui/pullrequest/915565) where we intend to use it if curious 🙂

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
