### PR TITLE
add nesting to list styling

### DIFF
--- a/.changeset/swift-dryers-grin.md
+++ b/.changeset/swift-dryers-grin.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+The changeset is to fix a style inheritence problem in the list element which ensures that the list style is applied to all the list items.

--- a/css/src/atomics/list.scss
+++ b/css/src/atomics/list.scss
@@ -1,6 +1,10 @@
 .list-style-none {
 	list-style: none !important;
 
+	> li {
+		list-style: none !important;
+	}
+
 	&::marker,
 	&::-webkit-details-marker {
 		display: none;


### PR DESCRIPTION
Task: task-1001343

Link: [preview](http://localhost:1111/)

In certain scenarios, the `.list-style-none` atomic does not take effect because `list-style` can be applied to either the list or the list items, and we have existing styles which targets the list items rather than the lists, so the list items aren't inheriting the list's "stylelessness". This PR ensures that the individual list items always inherit the list styling. Below is an example of the problem:

![image](https://github.com/user-attachments/assets/333778de-aaf7-40f6-a00d-601a6c6dfffe)
![image](https://github.com/user-attachments/assets/58f84b98-c58c-4639-a79c-4916345e4255)


## Testing

1. Step one
2. Step two
   Expected result:

## Additional information

[Optional]

## Contributor checklist

- [ ] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
