### PR TITLE
invert states for element toggles on site layout page

### DIFF
--- a/.changeset/witty-gifts-turn.md
+++ b/.changeset/witty-gifts-turn.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': patch
+---
+
+Invert button states for hero and footer toggles.

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -28,8 +28,8 @@ This page is utilizing the holy grail layout, but you can use the buttons below 
 	<button class="button" data-toggle-layout-height-constraint aria-pressed="false">Constrain layout height</button>
 </div>
 <div class="buttons buttons-addons display-flex">
-	<button class="button" data-toggle-hero-visibility aria-pressed="false">Toggle hero</button>
-	<button class="button" data-toggle-footer-visibility aria-pressed="false">Toggle footer</button>
+	<button class="button button-filled" data-toggle-hero-visibility aria-pressed="true">Toggle hero</button>
+	<button class="button button-filled" data-toggle-footer-visibility aria-pressed="true">Toggle footer</button>
 	<button class="button" data-toggle-flyout-visibility aria-pressed="false">Toggle flyout</button>
 </div>
 


### PR DESCRIPTION
The states on the site are inverted for hero and footer toggles, when compared to flyout. This updates to show a filled button for elements that are currently shown.

http://localhost:1111/components/layout.html

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
