### PR TITLE
Add `-tablet` suffixed version of `.layout-padding` and `.layout-gap`.

### DIFF
--- a/.changeset/young-jobs-smell.md
+++ b/.changeset/young-jobs-smell.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-site': minor
+'@microsoft/atlas-css': minor
+---
+
+Add `-tablet` suffixed version of `.layout-padding` and `.layout-gap`.

--- a/css/src/components/layout.scss
+++ b/css/src/components/layout.scss
@@ -40,6 +40,16 @@ $default-flyout-width-widescreen: 480px;
 	margin-inline: var(#{$layout-gap-scalable-custom-property-name}) !important;
 }
 
+@include tablet {
+	.layout-padding-tablet {
+		padding-inline: var(#{$layout-gap-custom-property-name}) !important;
+	}
+
+	.layout-margin-tablet {
+		margin-inline: var(#{$layout-gap-scalable-custom-property-name}) !important;
+	}
+}
+
 .layout-body {
 	display: grid;
 	width: 100%;

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -62,10 +62,12 @@ The basic boilerplate for a layout is as follows:
 
 The `$layout-gap` token is used to generate two separate classes that can be used to apply spacing to containers _within_ each of the major layout areas. Spacing should _not_ be applied to the `layout-body-*` containers themselves, but rather to elements within them - most often a single container that is a direct child of the `layout-body-*` element.
 
-| Class name        | Use case                             | Examples of use case                                                                  |
-| ----------------- | ------------------------------------ | ------------------------------------------------------------------------------------- |
-| `.layout-padding` | Layout areas that are not full width | The menu and aside areas. The main area when not in a single layout                   |
-| `.layout-margin`  | Full width layout areas              | The header, footer, and hero. The main area when it is full width in a single layout. |
+| Class name               | Use case                                                                   | Examples of use case                                                                  |
+| ------------------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `.layout-padding`        | Layout areas that are not full width                                       | The menu and aside areas. The main area when not in a single layout                   |
+| `.layout-margin`         | Full width layout areas                                                    | The header, footer, and hero. The main area when it is full width in a single layout. |
+| `.layout-padding-tablet` | Same as `.layout-padding` but only applied on tablet breakpoint and above. |                                                                                       |
+| `.layout-margin-tablet`  | Same as `.layout-margin` but only applied on tablet breakpoint and above.  |                                                                                       |
 
 Why not use gap? You certainly can apply any [gap atomics](../atomics/gap.md) to the `layout-body` to change spacing as you see fit. However, to provide adequate space to display focus rectangles and to ensure enough space to render dynamic inline elements (like heading anchors), spacing applied to an inner container is still the best choice.
 


### PR DESCRIPTION
Add -tablet suffixed version of .layout-padding and .layout-gap. #699

Finding cases where it is useful to not apply the layout padding or margin on small screens.

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
