### PR TITLE
The layout related TypeScript should use style.setProperty to avoid .cssText collisions

### DIFF
--- a/.changeset/modern-feet-worry.md
+++ b/.changeset/modern-feet-worry.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': patch
+---
+
+The layout related TypeScript should use style.setProperty to avoid downstream conflicts if sets document.documentElement.style.cssText directly.

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -1,21 +1,17 @@
 let frame: number;
 
+const root = document.documentElement;
+
 const setLayoutCssVariables = () => {
-	const footerHeight = document.querySelector('.layout-body-footer')?.clientHeight;
 	const headerHeight = document.querySelector('.layout-body-header')?.clientHeight;
+	const headerCssProp = headerHeight ? `${headerHeight}px` : '0px';
 
-	const headerCssProp = headerHeight
-		? `--atlas-header-height: ${headerHeight}px !important;`
-		: '--atlas-header-height: 0px !important;';
-	const footerCssProp = footerHeight
-		? `--atlas-footer-height: ${footerHeight}px !important;`
-		: '--atlas-footer-height: 0px !important;';
+	const footerHeight = document.querySelector('.layout-body-footer')?.clientHeight;
+	const footerCssProp = footerHeight ? `${footerHeight}px` : '0px';
 
-	document.documentElement.style.cssText = `
-			--window-inner-height: ${window.innerHeight}px !important;
-			${headerCssProp}
-			${footerCssProp}
-			`;
+	root.style.setProperty('--window-inner-height', `${window.innerHeight}px`, 'important');
+	root.style.setProperty('--atlas-header-height', headerCssProp, 'important');
+	root.style.setProperty('--atlas-footer-height', footerCssProp, 'important');
 };
 
 export function initLayout() {
@@ -31,7 +27,7 @@ export function initLayout() {
 		window.dispatchEvent(new CustomEvent('atlas-layout-change-event'))
 	);
 
-	document.documentElement.style.cssText = `--window-inner-height: ${window.innerHeight}px !important`;
+	root.style.setProperty('--window-inner-height', `${window.innerHeight}px`);
 
 	window.addEventListener('DOMContentLoaded', setLayoutCssVariables);
 }


### PR DESCRIPTION
Right now there is a problematic piece of the layout code that measures heights of containers. If someone else sets `document.documentElement.style.cssText` directly, it will either override the layout script, or on resize the layout script will override it. This can be a problem for certain scenarios, such as where a developer might assign css via cssText to prevent scrolling.

Luckily the solution is to use `document.documentElement.style.setProperty` instead.

Link: [preview](http://localhost:1111/)

## Testing

1. [Viisit layout page](http://localhost:1111/components/layout.html)
2. Ensure all permutations work as before.

https://caniuse.com/?search=setProperty

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
