### PR TITLE
update site header panel zindex

### DIFF
--- a/.changeset/tender-starfishes-deliver.md
+++ b/.changeset/tender-starfishes-deliver.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+The z-index of the site-header's panels should not be dropdown, which is "in content." It should be popover, which is "on content"

--- a/css/src/components/site-header.scss
+++ b/css/src/components/site-header.scss
@@ -177,7 +177,7 @@ $site-header-panel-featured-section-border: 1px solid $table-border-dark !defaul
 		background-color: $site-header-panel-background-color;
 		text-wrap: wrap;
 		box-shadow: $site-header-panel-shadow;
-		z-index: $zindex-dropdown;
+		z-index: $zindex-popover;
 		inset-inline-start: 0;
 		inset-block-start: calc($site-header-height - 1px);
 		border-block-start: $site-header-panel-border;


### PR DESCRIPTION
The z-index of the site-header's panels should not be dropdown, which is "in content." It should be popover, which is "on content". Without this change, it's possible for "sticky" and "dropdowns" to be on top of the site header's panels.

## Additional information

[Optional]

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
