### PR TITLE
bugfix: scroll listeners with passive required

### DIFF
--- a/.changeset/chilled-lemons-greet.md
+++ b/.changeset/chilled-lemons-greet.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': patch
+---
+
+Layout to use passive scroll listeners to measure visible header height

--- a/.changeset/rare-zoos-exercise.md
+++ b/.changeset/rare-zoos-exercise.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': patch
+---
+
+Measurement for atlas-footer-visible-height was not correct.

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -42,4 +42,13 @@ export function initLayout() {
 	root.style.setProperty('--window-inner-height', `${window.innerHeight}px`);
 
 	window.addEventListener('DOMContentLoaded', setLayoutCssVariables, { passive: true });
+
+	// determine if header/footer are visible below the top of the viewport
+	window.addEventListener(
+		'scroll',
+		() => window.dispatchEvent(new CustomEvent('atlas-layout-change-event')),
+		{
+			passive: true
+		}
+	);
 }

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -14,7 +14,10 @@ const setLayoutCssVariables = () => {
 	const footerHeight = footer?.clientHeight || 0;
 	const footerCssProp = footerHeight ? `${footerHeight}px` : '0px';
 	const footerY = footer?.getBoundingClientRect().y || 0; // determine if header and footer are visible, assign visible heights as well
-	const visibleFooterHeight = Math.round(Math.max(0, footerY + footerHeight));
+
+	const visibleFooterHeight = Math.round(
+		footerY < window.innerHeight ? Math.min(window.innerHeight - footerY, footerHeight) : 0
+	);
 	const visibleFooterCssProp = `${visibleFooterHeight}px`;
 
 	root.style.setProperty('--window-inner-height', `${window.innerHeight}px`, 'important');
@@ -44,6 +47,7 @@ export function initLayout() {
 	window.addEventListener('DOMContentLoaded', setLayoutCssVariables, { passive: true });
 
 	// determine if header/footer are visible below the top of the viewport
+
 	window.addEventListener(
 		'scroll',
 		() => window.dispatchEvent(new CustomEvent('atlas-layout-change-event')),


### PR DESCRIPTION
#705 should have added this as part of the work.

1. If we're measuring the header/footers height, we need to listen for scrolling and ensure those values are updated.
2. There were incorrect calculations in the measuring the footers height.

Testing
1. Visit page. http://localhost:1111/components/layout.html
1. Scroll around, values of atlas-header-visible-height and atlas-footer-visible-height variables should update. When the respective elements go out of view.

## Additional information

[Optional]

## Contributor checklist

- [ ] Did you update the description of this pull request with a review link and test steps?
- [ ] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
