### PR TITLE
account for hidden footers, no layout rounding, header track to use minmax

### DIFF
--- a/.changeset/chilly-cobras-tease.md
+++ b/.changeset/chilly-cobras-tease.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+For the layout component, the height of the header's grid track should be minmax(auto, max-content) to ensure proper height constraint happens.

--- a/.changeset/famous-chefs-repeat.md
+++ b/.changeset/famous-chefs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': patch
+---
+
+Fix bug where a hidden footer element would still register a height. Layout now always expects a header, but not necessarily a footer, since footers can be rendered within containers too.

--- a/.changeset/pink-lizards-check.md
+++ b/.changeset/pink-lizards-check.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Stop accounting for rounding in calculations and remove -1px in the --atlas-contained-height property.

--- a/.changeset/shaggy-numbers-notice.md
+++ b/.changeset/shaggy-numbers-notice.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': minor
+---
+
+Export a `dispatchAtlasLayoutUpdateEvent` function for easier use downstream.

--- a/.changeset/strong-owls-attack.md
+++ b/.changeset/strong-owls-attack.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': patch
+---
+
+Move footer border to child element of layout.

--- a/css/src/components/layout.scss
+++ b/css/src/components/layout.scss
@@ -363,9 +363,8 @@ $default-flyout-width-widescreen: 480px;
 		&.layout-twin,
 		&.layout-sidecar-left,
 		&.layout-sidecar-right {
-			// 👇 minus a pixel at the end to account for percentage points and rounding
 			--atlas-contained-height: calc(
-				var(--window-inner-height) - var(--atlas-header-height) - var(--atlas-footer-height) - 1px
+				var(--window-inner-height) - var(--atlas-header-height) - var(--atlas-footer-height)
 			);
 		}
 
@@ -389,9 +388,8 @@ $default-flyout-width-widescreen: 480px;
 // Because the holy grail has two rows (containing menu main, menu aside) on tablet, we cannot apply height constraints at that size
 @include desktop {
 	.layout.layout-constrained.layout-holy-grail {
-		// 👇 minus a pixel at the end to account for percentage points and rounding
 		--atlas-contained-height: calc(
-			var(--window-inner-height) - var(--atlas-header-height) - var(--atlas-footer-height) - 1px
+			var(--window-inner-height) - var(--atlas-header-height) - var(--atlas-footer-height)
 		);
 
 		.layout-body-main,

--- a/css/src/components/layout.scss
+++ b/css/src/components/layout.scss
@@ -104,13 +104,15 @@ $default-flyout-width-widescreen: 480px;
 .layout,
 .layout.layout-single {
 	.layout-body {
-		grid-template: auto auto auto 1fr auto auto / minmax(0, 1fr);
+		grid-template: minmax(auto, max-content) auto auto 1fr auto auto / minmax(0, 1fr);
 		grid-template-areas: 'header' 'hero' 'menu' 'main' 'aside' 'footer';
 	}
 
 	&.layout-flyout-active .layout-body {
 		@include desktop {
-			grid-template: auto auto auto 1fr auto auto / minmax(0, 1fr) var(#{$layout-flyout-width-name});
+			grid-template: minmax(auto, max-content) auto auto 1fr auto auto / minmax(0, 1fr) var(
+					#{$layout-flyout-width-name}
+				);
 			grid-template-areas: 'header header' 'hero flyout' 'menu flyout' 'main flyout' 'aside flyout' 'footer footer';
 		}
 	}
@@ -118,14 +120,13 @@ $default-flyout-width-widescreen: 480px;
 
 .layout.layout-holy-grail {
 	.layout-body {
-		grid-template: auto auto auto 1fr auto auto / minmax(0, 1fr);
+		grid-template: minmax(auto, max-content) auto auto 1fr auto auto / minmax(0, 1fr);
 		grid-template-areas: 'header' 'hero' 'menu' 'main' 'aside' 'footer';
 
 		@include tablet {
-			grid-template: auto auto var(--atlas-contained-height) auto auto / minmax(0, 1fr) minmax(
-					0,
-					2fr
-				);
+			grid-template:
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto auto / minmax(0, 1fr)
+				minmax(0, 2fr);
 			grid-template-areas:
 				'header header'
 				'hero hero'
@@ -135,10 +136,12 @@ $default-flyout-width-widescreen: 480px;
 		}
 
 		@include desktop {
-			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(0, 2fr) minmax(
+			grid-template:
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(
 					0,
-					1fr
-				);
+					2fr
+				)
+				minmax(0, 1fr);
 			grid-template-areas:
 				'header header header'
 				'hero hero hero'
@@ -147,7 +150,7 @@ $default-flyout-width-widescreen: 480px;
 		}
 
 		@include widescreen {
-			grid-template: auto auto var(--atlas-contained-height) auto / auto #{$quarter-widescreen} #{$half-widescreen} #{$quarter-widescreen} auto;
+			grid-template: minmax(auto, max-content) auto var(--atlas-contained-height) auto / auto #{$quarter-widescreen} #{$half-widescreen} #{$quarter-widescreen} auto;
 			grid-template-areas:
 				'header header header header header'
 				'hero hero hero hero hero'
@@ -187,11 +190,13 @@ $default-flyout-width-widescreen: 480px;
 	}
 
 	.layout-body {
-		grid-template: auto auto auto 1fr auto / minmax(0, 1fr);
+		grid-template: minmax(auto, max-content) auto auto 1fr auto / minmax(0, 1fr);
 		grid-template-areas: 'header' 'hero' 'menu' 'main' 'footer';
 
 		@include tablet {
-			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(0, 2fr);
+			grid-template:
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 1fr)
+				minmax(0, 2fr);
 			grid-template-areas:
 				'header header'
 				'hero hero'
@@ -200,7 +205,9 @@ $default-flyout-width-widescreen: 480px;
 		}
 
 		@include desktop {
-			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(0, 3fr);
+			grid-template:
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 1fr)
+				minmax(0, 3fr);
 			grid-template-areas:
 				'header header'
 				'hero hero'
@@ -209,7 +216,7 @@ $default-flyout-width-widescreen: 480px;
 		}
 
 		@include widescreen {
-			grid-template: auto auto var(--atlas-contained-height) auto / auto #{$quarter-widescreen} #{$three-quarters-widescreen} auto;
+			grid-template: minmax(auto, max-content) auto var(--atlas-contained-height) auto / auto #{$quarter-widescreen} #{$three-quarters-widescreen} auto;
 			grid-template-areas:
 				'header header header header'
 				'hero hero hero hero'
@@ -220,9 +227,12 @@ $default-flyout-width-widescreen: 480px;
 
 	&.layout-flyout-active .layout-body {
 		@include desktop {
-			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(0, 3fr) var(
-					#{$layout-flyout-width-name}
-				);
+			grid-template:
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(
+					0,
+					3fr
+				)
+				var(#{$layout-flyout-width-name});
 			grid-template-areas:
 				'header header header'
 				'hero hero flyout'
@@ -230,9 +240,12 @@ $default-flyout-width-widescreen: 480px;
 				'footer footer footer';
 		}
 		@include widescreen {
-			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(0, 3fr) var(
-					#{$layout-flyout-width-name}
-				);
+			grid-template:
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(
+					0,
+					3fr
+				)
+				var(#{$layout-flyout-width-name});
 			grid-template-areas:
 				'header header header'
 				'hero hero flyout'
@@ -248,11 +261,13 @@ $default-flyout-width-widescreen: 480px;
 	}
 
 	.layout-body {
-		grid-template: auto auto auto 1fr auto / minmax(0, 1fr);
+		grid-template: minmax(auto, max-content) auto auto 1fr auto / minmax(0, 1fr);
 		grid-template-areas: 'header' 'hero' 'main' 'aside' 'footer';
 
 		@include tablet {
-			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 2fr) minmax(0, 1fr);
+			grid-template:
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 2fr)
+				minmax(0, 1fr);
 			grid-template-areas:
 				'header header'
 				'hero hero'
@@ -261,7 +276,9 @@ $default-flyout-width-widescreen: 480px;
 		}
 
 		@include desktop {
-			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 3fr) minmax(0, 1fr);
+			grid-template:
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 3fr)
+				minmax(0, 1fr);
 			grid-template-areas:
 				'header header'
 				'hero hero'
@@ -270,7 +287,7 @@ $default-flyout-width-widescreen: 480px;
 		}
 
 		@include widescreen {
-			grid-template: auto auto var(--atlas-contained-height) auto / auto #{$three-quarters-widescreen} #{$quarter-widescreen} auto;
+			grid-template: minmax(auto, max-content) auto var(--atlas-contained-height) auto / auto #{$three-quarters-widescreen} #{$quarter-widescreen} auto;
 			grid-template-areas:
 				'header header header header'
 				'hero hero hero hero'
@@ -281,9 +298,12 @@ $default-flyout-width-widescreen: 480px;
 
 	&.layout-flyout-active .layout-body {
 		@include desktop {
-			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 3fr) minmax(0, 1fr) var(
-					#{$layout-flyout-width-name}
-				);
+			grid-template:
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 3fr) minmax(
+					0,
+					1fr
+				)
+				var(#{$layout-flyout-width-name});
 			grid-template-areas:
 				'header header header'
 				'hero hero flyout'
@@ -292,9 +312,12 @@ $default-flyout-width-widescreen: 480px;
 		}
 
 		@include widescreen {
-			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 3fr) minmax(0, 1fr) var(
-					#{$layout-flyout-width-name}
-				);
+			grid-template:
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 3fr) minmax(
+					0,
+					1fr
+				)
+				var(#{$layout-flyout-width-name});
 			grid-template-areas:
 				'header header header'
 				'hero hero flyout'
@@ -310,12 +333,14 @@ $default-flyout-width-widescreen: 480px;
 	}
 
 	.layout-body {
-		grid-template: auto auto auto 1fr auto / minmax(0, 1fr);
+		grid-template: minmax(auto, max-content) auto auto 1fr auto / minmax(0, 1fr);
 		grid-template-areas: 'header' 'hero' 'main' 'aside' 'footer';
 
 		// note that to make some extra room this layout is not constrained by the widescreen breakpoint like others
 		@include tablet {
-			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(0, 1fr);
+			grid-template:
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 1fr)
+				minmax(0, 1fr);
 			grid-template-areas:
 				'header header'
 				'hero hero'
@@ -326,9 +351,12 @@ $default-flyout-width-widescreen: 480px;
 
 	&.layout-flyout-active .layout-body {
 		@include desktop {
-			grid-template: auto auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(0, 1fr) var(
-					#{$layout-flyout-width-name}
-				);
+			grid-template:
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(
+					0,
+					1fr
+				)
+				var(#{$layout-flyout-width-name});
 			grid-template-areas:
 				'header header header'
 				'hero hero flyout'
@@ -364,7 +392,7 @@ $default-flyout-width-widescreen: 480px;
 		&.layout-sidecar-left,
 		&.layout-sidecar-right {
 			--atlas-contained-height: calc(
-				var(--window-inner-height) - var(--atlas-header-height) - var(--atlas-footer-height)
+				var(--window-inner-height) - var(--atlas-header-height) - var(--atlas-footer-height) - 1px
 			);
 		}
 
@@ -389,7 +417,7 @@ $default-flyout-width-widescreen: 480px;
 @include desktop {
 	.layout.layout-constrained.layout-holy-grail {
 		--atlas-contained-height: calc(
-			var(--window-inner-height) - var(--atlas-header-height) - var(--atlas-footer-height)
+			var(--window-inner-height) - var(--atlas-header-height) - var(--atlas-footer-height) - 1px
 		);
 
 		.layout-body-main,

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -1,5 +1,3 @@
-let frame: number;
-
 const root = document.documentElement;
 
 const setLayoutCssVariables = () => {
@@ -7,25 +5,16 @@ const setLayoutCssVariables = () => {
 	const headerHeight = header?.clientHeight || 0;
 	const headerCssProp = headerHeight ? `${headerHeight}px` : '0px';
 	const headerY = header?.getBoundingClientRect().y || 0; // determine if header is visible, assign visible heights as well
-	const visibleHeaderHeight = Math.round(Math.max(0, headerY + headerHeight));
+	const visibleHeaderHeight = Math.max(0, headerY + headerHeight);
 	const visibleHeaderCssProp = `${visibleHeaderHeight}px`;
 
 	const footer = document.querySelector('.layout-body-footer');
-	// get computed style of the footer to ensure it is not hidden
-	const footerHidden = footer && window.getComputedStyle(footer).display === 'none';
-	let footerHeight = 0;
-	let footerCssProp = '0px';
-	let footerY = 0;
-	let visibleFooterHeight = 0;
-	if (!footerHidden) {
-		footerHeight = footer?.clientHeight || 0;
-		footerCssProp = footerHeight ? `${footerHeight}px` : '0px';
-		footerY = footer?.getBoundingClientRect().y || 0; // determine if header and footer are visible, assign visible heights as well
+	const footerHeight = footer?.clientHeight || 0;
+	const footerCssProp = footerHeight ? `${footerHeight}px` : '0px';
+	const footerY = footer?.getBoundingClientRect().y || 0; // determine if header and footer are visible, assign visible heights as well
 
-		visibleFooterHeight = Math.round(
-			footerY < window.innerHeight ? Math.min(window.innerHeight - footerY, footerHeight) : 0
-		);
-	}
+	const visibleFooterHeight =
+		footerY < window.innerHeight ? Math.min(window.innerHeight - footerY, footerHeight) : 0;
 	const visibleFooterCssProp = `${visibleFooterHeight}px`;
 
 	root.style.setProperty('--window-inner-height', `${window.innerHeight}px`, 'important');
@@ -35,32 +24,30 @@ const setLayoutCssVariables = () => {
 	root.style.setProperty('--atlas-footer-visible-height', visibleFooterCssProp, 'important');
 };
 
+let animationFrame = 0;
+
+function scheduleUpdate(update: typeof setLayoutCssVariables) {
+	cancelAnimationFrame(animationFrame);
+	animationFrame = requestAnimationFrame(update);
+}
+
+export const dispatchAtlasLayoutUpdateEvent = () => {
+	window.dispatchEvent(new CustomEvent('atlas-layout-change-event'));
+};
+
 export function initLayout() {
 	window.addEventListener('atlas-layout-change-event', () => {
-		if (frame) {
-			cancelAnimationFrame(frame);
-		}
-
-		frame = requestAnimationFrame(setLayoutCssVariables);
+		scheduleUpdate(setLayoutCssVariables);
 	});
 
-	window.addEventListener(
-		'resize',
-		() => window.dispatchEvent(new CustomEvent('atlas-layout-change-event')),
-		{ passive: true }
-	);
+	window.addEventListener('resize', dispatchAtlasLayoutUpdateEvent, { passive: true });
 
 	root.style.setProperty('--window-inner-height', `${window.innerHeight}px`);
 
-	window.addEventListener('DOMContentLoaded', setLayoutCssVariables, { passive: true });
+	window.addEventListener('DOMContentLoaded', dispatchAtlasLayoutUpdateEvent);
 
-	// determine if header/footer are visible below the top of the viewport
-
-	window.addEventListener(
-		'scroll',
-		() => window.dispatchEvent(new CustomEvent('atlas-layout-change-event')),
-		{
-			passive: true
-		}
-	);
+	// determine if header/footer are visible below the top of the viewport - remove with atlas-js 1.13.1
+	window.addEventListener('scroll', dispatchAtlasLayoutUpdateEvent, {
+		passive: true
+	});
 }

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -11,13 +11,21 @@ const setLayoutCssVariables = () => {
 	const visibleHeaderCssProp = `${visibleHeaderHeight}px`;
 
 	const footer = document.querySelector('.layout-body-footer');
-	const footerHeight = footer?.clientHeight || 0;
-	const footerCssProp = footerHeight ? `${footerHeight}px` : '0px';
-	const footerY = footer?.getBoundingClientRect().y || 0; // determine if header and footer are visible, assign visible heights as well
+	// get computed style of the footer to ensure it is not hidden
+	const footerHidden = footer && window.getComputedStyle(footer).display !== 'none';
+	let footerHeight = 0;
+	let footerCssProp = '0px';
+	let footerY = 0;
+	let visibleFooterHeight = window.innerHeight;
+	if (!footerHidden) {
+		footerHeight = footer?.clientHeight || 0;
+		footerCssProp = footerHeight ? `${footerHeight}px` : '0px';
+		footerY = footer?.getBoundingClientRect().y || 0; // determine if header and footer are visible, assign visible heights as well
 
-	const visibleFooterHeight = Math.round(
-		footerY < window.innerHeight ? Math.min(window.innerHeight - footerY, footerHeight) : 0
-	);
+		visibleFooterHeight = Math.round(
+			footerY < window.innerHeight ? Math.min(window.innerHeight - footerY, footerHeight) : 0
+		);
+	}
 	const visibleFooterCssProp = `${visibleFooterHeight}px`;
 
 	root.style.setProperty('--window-inner-height', `${window.innerHeight}px`, 'important');

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -12,11 +12,11 @@ const setLayoutCssVariables = () => {
 
 	const footer = document.querySelector('.layout-body-footer');
 	// get computed style of the footer to ensure it is not hidden
-	const footerHidden = footer && window.getComputedStyle(footer).display !== 'none';
+	const footerHidden = footer && window.getComputedStyle(footer).display === 'none';
 	let footerHeight = 0;
 	let footerCssProp = '0px';
 	let footerY = 0;
-	let visibleFooterHeight = window.innerHeight;
+	let visibleFooterHeight = 0;
 	if (!footerHidden) {
 		footerHeight = footer?.clientHeight || 0;
 		footerCssProp = footerHeight ? `${footerHeight}px` : '0px';

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -168,9 +168,11 @@
 			<p>Flying flyout</p>
 		</section>
 
-		<footer id="footer" class="layout-body-footer border-top padding-md">
-			<div class="layout-margin">
-				<p>© Microsoft 2024</p>
+		<footer id="footer" class="layout-body-footer">
+			<div class="border-top padding-md">
+				<div class="layout-margin">
+					<p>© Microsoft 2024</p>
+				</div>
 			</div>
 		</footer>
 	</body>

--- a/site/src/scaffold/token.html
+++ b/site/src/scaffold/token.html
@@ -169,9 +169,11 @@
 			<!-- empty for now -->
 		</aside>
 
-		<footer id="footer" class="layout-body-footer border-top padding-md">
-			<div class="layout-margin">
-				<p>© Microsoft 2024</p>
+		<footer id="footer" class="layout-body-footer">
+			<div class="border-top padding-md">
+				<div class="layout-margin">
+					<p>© Microsoft 2024</p>
+				</div>
 			</div>
 		</footer>
 	</body>


### PR DESCRIPTION
Fix bug where a hidden footer element would still register a height. Account for a few more small bugfixes too.
- Layout now always expects a header, but not necessarily a footer, since footers can be rendered within containers too. 
- Stop accounting for rounding in calculations and remove -1px in the --atlas-contained-height property.
- Stop rounding in the measurements in JS.
- The header now has a track value of minmax(auto, max-content), which helps when switching between different layouts.

## Testing

1. Visit page. http://localhost:1111/components/layout.html
2. There should be not up/down scroll on contained layouts on tablet +.
3.  Scroll around, values of atlas-header-visible-height and atlas-footer-visible-height variables should update. When the respective elements go out of view. 
4. If you put "display-none" on the footer and scroll or resize the header height vars should be zero.

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
