### PR TITLE
Blocking site header buttons's underline on hover

### DIFF
--- a/.changeset/fair-starfishes-brake.md
+++ b/.changeset/fair-starfishes-brake.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Blocking underlines on hover for site header buttons

--- a/css/src/components/site-header.scss
+++ b/css/src/components/site-header.scss
@@ -113,6 +113,8 @@ $site-header-panel-featured-section-border: 1px solid $table-border-dark !defaul
 		&:hover,
 		&.is-hovered,
 		&:focus-visible {
+			text-decoration: none;
+
 			&:not([aria-expanded='true']) {
 				@extend %site-header-hover-underline;
 			}
@@ -153,6 +155,8 @@ $site-header-panel-featured-section-border: 1px solid $table-border-dark !defaul
 		&.is-hovered,
 		&:focus-visible {
 			@extend %site-header-hover-underline;
+
+			text-decoration: none;
 		}
 
 		@include tablet {


### PR DESCRIPTION
Task: task-1010346

Link: [preview](http://localhost:1111/)

Adding rules to disable underline in hover state.

## Testing

1. Visit any page.
2. Make sure brand link on hover state doesn't have double underline
3. Review code

## Contributor checklist

- [ ] Did you update the description of this pull request with a review link and test steps?
- [ ] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
