### PR TITLE
Fixing default chevron icon appearance in accordion component

### DIFF
--- a/.changeset/late-otters-retire.md
+++ b/.changeset/late-otters-retire.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Fixing default chevron icon appearance in accordion component.

--- a/css/src/components/accordion.scss
+++ b/css/src/components/accordion.scss
@@ -37,9 +37,14 @@ $accordion-transition: transform 0.15s !default;
 	summary {
 		display: flex;
 		line-height: 1.5;
+		list-style: none;
 		cursor: pointer;
 		padding-block: $accordion-spacing;
 		gap: $accordion-gap;
+
+		&::-webkit-details-marker {
+			display: none;
+		}
 
 		&::before,
 		&::after {


### PR DESCRIPTION
Task: task-1017791
Link: [preview](http://localhost:1111/components/accordion.html)

There is an issue with the default chevron icon appearance in the accordion component (check the screenshot below). This PR fixes it

## Testing

1. `git checkout olga/accordion-fix-icon; npm run start`.
2. Visit accordion page
3. Inspect component, in dev tool disable "display: flex" rule for `.accordion summary`. You should not see the default chevron showing up

![image](https://github.com/user-attachments/assets/59370e34-7f2a-4d15-9776-c912035de9a9)

Here is the same but in `main` branch:

![image](https://github.com/user-attachments/assets/00c3025a-fa6b-41c4-a74c-0d6706cc8620)


## Additional information

![image](https://github.com/user-attachments/assets/2e06dcf8-1d66-4c4b-bd98-eb0126c33e0c)

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
- [ ] Does your pull request change any transforms? Did you test they work on right to left?
