### PR TITLE
Remove person avatar background

### DIFF
--- a/.changeset/shiny-dryers-perform.md
+++ b/.changeset/shiny-dryers-perform.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Remove person avatar background color.

--- a/css/src/components/persona.scss
+++ b/css/src/components/persona.scss
@@ -2,7 +2,6 @@ $persona-font-size-sm: $font-size-9 !default;
 $persona-font-size-md: $font-size-8 !default;
 $persona-font-size-lg: $font-size-7 !default;
 
-$persona-avatar-background-color: $alternate-background-medium !default;
 $persona-avatar-font-color: $text-invert !default;
 $persona-avatar-border-radius: $border-radius-rounded;
 
@@ -25,7 +24,6 @@ $persona-gap-size: $layout-1 !default;
 		width: 2.6666em;
 		height: 2.6666em;
 		border-radius: $persona-avatar-border-radius;
-		background-color: $persona-avatar-background-color;
 		color: $persona-avatar-font-color;
 
 		img,


### PR DESCRIPTION
Link: [preview](http://localhost:1111/)

This PR removes the default persona avatar background. The default background color may cause a black ring around the avatar image. Background color atomics can be added to set the background color when needed. 

![image](https://github.com/user-attachments/assets/2de58981-a08c-46d9-8d60-8684d6650116)


## Testing

1. Visit http://localhost:1111/components/persona.html

## Additional information

[Optional]

## Contributor checklist

- [ ] Did you update the description of this pull request with a review link and test steps?
- [ ] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
- [ ] Does your pull request change any transforms? Did you test they work on right to left?
