### PR TITLE
Add max width Atomic classes

### DIFF
--- a/.changeset/wicked-points-admire.md
+++ b/.changeset/wicked-points-admire.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-site': minor
+'@microsoft/atlas-css': minor
+---
+
+Add max width Atomic classes, max-width-full and max-width-100vw along with relevant documentation.

--- a/css/src/atomics/width.scss
+++ b/css/src/atomics/width.scss
@@ -42,3 +42,13 @@ $all-widths: list.join($universal-widths, $mobile-incompatible-widths);
 		}
 	}
 }
+
+// max-widths
+
+.max-width-full {
+	max-width: 100% !important;
+}
+
+.max-width-100vw {
+	max-width: 100vw !important;
+}

--- a/site/src/atomics/width.md
+++ b/site/src/atomics/width.md
@@ -17,6 +17,7 @@ Values are in pixels. Keep in mind that the `min-width` and `max-width` properti
 | ------------------------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------ |
 | `width`                                          | `auto`, `100`, `150`, `200`, `250`, `300`, `350`, `full` (100%), `fit-content` | all screensizes, `tablet`, `desktop` |
 | `width` (available on tablet screens and larger) | `400`, `450`, `500`, `unset`                                                   | `tablet`, `desktop`                  |
+| `max-width`                                      | `full` (100%), `100vw`                                                         | all screensizes                      |
 
 ## Usage
 
@@ -60,6 +61,17 @@ Set the `width` of an element.
 </div>
 ```
 
+Set the `max-width` of an element.
+
+```html
+<div class="max-width-full border padding-sm font-weight-semibold">
+	<p>Max Width Full</p>
+</div>
+<div class="max-width-100vw border padding-sm font-weight-semibold">
+	<p>Max Width 100vw</p>
+</div>
+```
+
 ### Responsive rules
 
 Certain widths are too large for many mobile screens, so they are only available on larger screensizes. See the table above for information on which helpers can be applied universally.
@@ -85,6 +97,8 @@ Another possible pattern may be that a container needs to be constrained on smal
 List of all available classes:
 
 ```atomics-filter
+.max-width-full
+.max-width-100vw
 .width-full
 .width-fit-content
 .width-auto


### PR DESCRIPTION
## Overview
This PR introduces new atomic classes to constrain the max-width property on elements. These additions complement the existing width utilities and provide more flexibility in setting maximum widths for various elements.

## Changes
Max-Width Utilities: Added new atomic classes for setting the `max-width` property.
`.max-width-full`: Sets max-width to `100%`.
`.max-width-100vw`: Sets max-width to `100vw`.

Link: run `npm start` and navigate to [width documentation page](http://localhost:1111/atomics/width.html)

## Testing

View documentation page.

## Additional information

screenshot of updated width documentation
![image](https://github.com/user-attachments/assets/2b71784b-96e2-438a-9741-da6cfe1dbedf)