### PR TITLE
Update filled tag and progress bar colors

### DIFF
--- a/.changeset/quiet-months-change.md
+++ b/.changeset/quiet-months-change.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Update filled tag and progress bar background color.

--- a/css/src/components/tag.scss
+++ b/css/src/components/tag.scss
@@ -204,6 +204,7 @@ $tag-interactive-color-primary-hover: $primary-dark-hover !default;
 
 			&:hover,
 			&.is-hovered {
+				border-inline-start-color: $tag-border-color;
 				color: $tag-interactive-color-filled-close-hover;
 			}
 		}

--- a/css/src/tokens/themes.scss
+++ b/css/src/tokens/themes.scss
@@ -56,7 +56,7 @@ $themes: (
 		'secondary-base': $palette-grey-30,
 		'secondary-background': $palette-grey-10,
 		'secondary-background-hover': $palette-grey-30,
-		'secondary-background-glow-high-contrast': $palette-grey-10,
+		'secondary-background-glow-high-contrast': $palette-grey-20,
 		'secondary-dark': $palette-grey-210,
 		'secondary-dark-hover': $palette-grey-60,
 		'secondary-hover': $palette-grey-80,


### PR DESCRIPTION
Link: [preview](http://localhost:1111/)

This PR updates the `secondary-background-glow-high-contrast` theme variable to a slightly darker grey as the previous color is deemed too light by users. It also fixes interactive filled tag close hover divider color.

Figma: https://www.figma.com/design/uVA2amRR71yJZ0GS6RI6zL/%F0%9F%8C%9E-Atlas-Design-Library?node-id=73202-812&p=f&t=Fdfh5RYdQKonWpEA-0

## Testing

1. Visit http://localhost:1111/components/tag.html , review filled tag background color. Compare with https://design.learn.microsoft.com/components/tag.html . 
2. Visit http://localhost:1111/components/progress-bar.html , review progress bar background color. Compare with https://design.learn.microsoft.com/components/progress-bar.html
   
Expected result: Filled tag and progress bar background color is slightly darker than before.

## Additional information

[Optional]

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
- [ ] Does your pull request change any transforms? Did you test they work on right to left?
