### PR TITLE
change the layout-body-flyout to have a default width of 320

### DIFF
--- a/.changeset/yellow-taxis-rhyme.md
+++ b/.changeset/yellow-taxis-rhyme.md
@@ -2,4 +2,4 @@
 '@microsoft/atlas-css': minor
 ---
 
-Updating the default width of the layout's flyout container to be 320px.
+Updating the default width of the layout's flyout container to be 320px on desktop screen sizes.

--- a/.changeset/yellow-taxis-rhyme.md
+++ b/.changeset/yellow-taxis-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Updating the default width of the layout's flyout container to be 320px.

--- a/css/src/components/layout.scss
+++ b/css/src/components/layout.scss
@@ -3,7 +3,7 @@
 $quarter-widescreen: math.div($breakpoint-widescreen, 4);
 $half-widescreen: math.div($breakpoint-widescreen, 2);
 $three-quarters-widescreen: math.div($breakpoint-widescreen, 4) * 3;
-$default-flyout-width-desktop: 360px;
+$default-flyout-width-desktop: 320px;
 $default-flyout-width-widescreen: 480px;
 
 :root {


### PR DESCRIPTION
Link: [preview](http://localhost:1111/)

Changes the default width of the flyout element to be 320px.

## Testing

1. `npm start`
2. Visit layouts page. 
3. Test flyout width on desktop +.

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
- [ ] Does your pull request change any transforms? Did you test they work on right to left?
