### PR TITLE
Add a suggestion pill under tag

### DIFF
--- a/.changeset/giant-moles-confess.md
+++ b/.changeset/giant-moles-confess.md
@@ -3,4 +3,4 @@
 '@microsoft/atlas-css': minor
 ---
 
-Add a suggestion pill for the chat pattern
+Add a suggestion pill for the chat pattern and updated tag.md documentation

--- a/.changeset/giant-moles-confess.md
+++ b/.changeset/giant-moles-confess.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-site': minor
+'@microsoft/atlas-css': minor
+---
+
+Add a suggestion pill for the chat pattern

--- a/.changeset/giant-moles-confess.md
+++ b/.changeset/giant-moles-confess.md
@@ -3,4 +3,4 @@
 '@microsoft/atlas-css': minor
 ---
 
-Add a suggestion pill for the chat pattern and updated tag.md documentation
+Add a suggestion pill for the chat pattern and update tag.md documentation.

--- a/css/src/components/tag.scss
+++ b/css/src/components/tag.scss
@@ -38,6 +38,8 @@ $tag-border-color-primary: $primary-background-glow-high-contrast !default;
 $tag-interactive-divider-color-primary: $primary-box-shadow !default;
 $tag-interactive-color-primary-hover: $primary-dark-hover !default;
 
+$tag-suggestion-radius: 0.5rem !default;
+
 .tag {
 	display: inline-flex;
 	align-items: center;
@@ -212,7 +214,7 @@ $tag-interactive-color-primary-hover: $primary-dark-hover !default;
 }
 
 .tag.tag-suggestion {
-	border-radius: 0.5rem;
+	border-radius: $tag-suggestion-radius;
 
 	&:hover,
 	&.is-hovered {

--- a/css/src/components/tag.scss
+++ b/css/src/components/tag.scss
@@ -38,8 +38,7 @@ $tag-border-color-primary: $primary-background-glow-high-contrast !default;
 $tag-interactive-divider-color-primary: $primary-box-shadow !default;
 $tag-interactive-color-primary-hover: $primary-dark-hover !default;
 
-$tag-suggestion-radius: 0.5rem !default;
-$tag-suggestion-margin: 0.5rem !default;
+$tag-suggestion-radius: 8px !default;
 
 .tag {
 	display: inline-flex;
@@ -215,8 +214,6 @@ $tag-suggestion-margin: 0.5rem !default;
 }
 
 .tag.tag-suggestion {
-	margin-inline-end: calc($tag-suggestion-margin - $tag-gap-size);
-	margin-block-end: $tag-suggestion-margin;
 	border-radius: $tag-suggestion-radius;
 
 	&:hover,

--- a/css/src/components/tag.scss
+++ b/css/src/components/tag.scss
@@ -210,3 +210,13 @@ $tag-interactive-color-primary-hover: $primary-dark-hover !default;
 		}
 	}
 }
+
+.tag.tag-suggestion {
+	border-radius: 0.5rem;
+
+	&:hover,
+	&.is-hovered {
+		background-color: $primary-background;
+		color: $primary-dark;
+	}
+}

--- a/css/src/components/tag.scss
+++ b/css/src/components/tag.scss
@@ -39,6 +39,7 @@ $tag-interactive-divider-color-primary: $primary-box-shadow !default;
 $tag-interactive-color-primary-hover: $primary-dark-hover !default;
 
 $tag-suggestion-radius: 0.5rem !default;
+$tag-suggestion-margin: 0.5rem !default;
 
 .tag {
 	display: inline-flex;
@@ -214,6 +215,8 @@ $tag-suggestion-radius: 0.5rem !default;
 }
 
 .tag.tag-suggestion {
+	margin-inline-end: calc($tag-suggestion-margin - $tag-gap-size);
+	margin-block-end: $tag-suggestion-margin;
 	border-radius: $tag-suggestion-radius;
 
 	&:hover,

--- a/site/src/components/tag.md
+++ b/site/src/components/tag.md
@@ -168,3 +168,13 @@ To make an interactive tag, nest the [popover component](./popover.md) inside a 
 		</tr>
 	</tbody>
 </table>
+
+### Suggestion pill
+
+A suggestion pill looks roughly like a tag but functions like a button. The user can click on a suggestion to trigger an action. See more use cases in the [chat pattern](./../patterns/chat.md).
+
+```html
+<button type="button" class="tag tag-sm tag-suggestion">
+	<span>Suggestion pill<span>
+</button>
+```

--- a/site/src/patterns/chat.md
+++ b/site/src/patterns/chat.md
@@ -275,22 +275,24 @@ The following markup utilizes various components and atomics to create a chat ex
 To display suggestions to the user, use the tag-based suggestion pill. The pills should be left-aligned and will sit side-by-side unless one pill is too long and forces the next pill onto the next line.
 
 ```html
-<button type="button" class="tag tag-sm tag-suggestion">
-	<span>Suggestion pill<span>
-</button>
-<button type="button" class="tag tag-sm tag-suggestion">
-	<span>Suggestion pill<span>
-</button>
-<button type="button" class="tag tag-sm tag-suggestion">
-	<span>Suggestion pill<span>
-</button>
-<button type="button" class="tag tag-sm tag-suggestion">
-	<span>Suggestion pill<span>
-</button>
-<button type="button" class="tag tag-sm tag-suggestion">
-	<span>Suggestion pill<span>
-</button>
-<button type="button" class="tag tag-sm tag-suggestion">
-	<span>Suggestion pill<span>
-</button>
+<div class="display-flex flex-wrap-wrap gap-xxs">
+	<button type="button" class="tag tag-sm tag-suggestion">
+		<span>Suggestion pill 1<span>
+	</button>
+	<button type="button" class="tag tag-sm tag-suggestion">
+		<span>Suggestion pill 2<span>
+	</button>
+	<button type="button" class="tag tag-sm tag-suggestion">
+		<span>Suggestion pill 3<span>
+	</button>
+	<button type="button" class="tag tag-sm tag-suggestion">
+		<span>Suggestion pill 4<span>
+	</button>
+	<button type="button" class="tag tag-sm tag-suggestion">
+		<span>Suggestion pill 5<span>
+	</button>
+	<button type="button" class="tag tag-sm tag-suggestion">
+		<span>Suggestion pill 6<span>
+	</button>
+</div>
 ```

--- a/site/src/patterns/chat.md
+++ b/site/src/patterns/chat.md
@@ -275,13 +275,22 @@ The following markup utilizes various components and atomics to create a chat ex
 To display suggestions to the user, use the tag-based suggestion pill. The pills should be left-aligned and will sit side-by-side unless one pill is too long and forces the next pill onto the next line.
 
 ```html
-<button type="button" class="tag tag-sm tag-suggestion margin-bottom-xxs">
-	<span>Catch me up on the meeting I missed this morning<span>
+<button type="button" class="tag tag-sm tag-suggestion">
+	<span>Suggestion pill<span>
 </button>
 <button type="button" class="tag tag-sm tag-suggestion">
-	<span>Summarize this page<span>
+	<span>Suggestion pill<span>
 </button>
 <button type="button" class="tag tag-sm tag-suggestion">
-	<span>Tell me about other capabilities<span>
+	<span>Suggestion pill<span>
+</button>
+<button type="button" class="tag tag-sm tag-suggestion">
+	<span>Suggestion pill<span>
+</button>
+<button type="button" class="tag tag-sm tag-suggestion">
+	<span>Suggestion pill<span>
+</button>
+<button type="button" class="tag tag-sm tag-suggestion">
+	<span>Suggestion pill<span>
 </button>
 ```

--- a/site/src/patterns/chat.md
+++ b/site/src/patterns/chat.md
@@ -269,3 +269,16 @@ The following markup utilizes various components and atomics to create a chat ex
 	</article>
 </section>
 ```
+
+### Suggestion Pill
+
+To display suggestions to the user, use the tag-based suggestion pill.
+
+```html
+<button type="button" class="tag tag-sm tag-suggestion">
+	<span>Catch me up on the meeting I missed this morning<span>
+</button>
+<button type="button" class="tag tag-sm tag-suggestion">
+	<span>Summarize this page<span>
+</button>
+```

--- a/site/src/patterns/chat.md
+++ b/site/src/patterns/chat.md
@@ -272,13 +272,16 @@ The following markup utilizes various components and atomics to create a chat ex
 
 ### Suggestion Pill
 
-To display suggestions to the user, use the tag-based suggestion pill.
+To display suggestions to the user, use the tag-based suggestion pill. The pills should be left-aligned and will sit side-by-side unless one pill is too long and forces the next pill onto the next line.
 
 ```html
-<button type="button" class="tag tag-sm tag-suggestion">
+<button type="button" class="tag tag-sm tag-suggestion margin-bottom-xxs">
 	<span>Catch me up on the meeting I missed this morning<span>
 </button>
 <button type="button" class="tag tag-sm tag-suggestion">
 	<span>Summarize this page<span>
+</button>
+<button type="button" class="tag tag-sm tag-suggestion">
+	<span>Tell me about other capabilities<span>
 </button>
 ```


### PR DESCRIPTION
Link: [preview](http://localhost:1111/patterns/chat.html)

This PR adds a suggestion pill under tag to allow users to click on a prompt. Compare to fluent AI's suggestion: https://ai.fluentui.dev/?path=/docs/components-suggestions--docs

## Testing

1. http://localhost:1111/patterns/chat.html Scroll down to the bottom of the page for the example. 
 
## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
- [ ] Does your pull request change any transforms? Did you test they work on right to left?
