### PR TITLE
Add support for vertical gradient and red-purple gradient

### DIFF
--- a/.changeset/poor-lemons-cheer.md
+++ b/.changeset/poor-lemons-cheer.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-site': minor
+'@microsoft/atlas-css': minor
+---
+
+Add support for a three color gradient and a vertical gradient. Also adds a new red, yellow, and purple color for the new Ask Learn icon

--- a/.changeset/poor-lemons-cheer.md
+++ b/.changeset/poor-lemons-cheer.md
@@ -3,4 +3,4 @@
 '@microsoft/atlas-css': minor
 ---
 
-Add support for a three color gradient and a vertical gradient. Also adds a new red, yellow, and purple color for the new Ask Learn icon
+Add support for a vertical gradient. Also adds a new red and purple color to create a red-purple gradient for the new Ask Learn icon

--- a/.changeset/poor-lemons-cheer.md
+++ b/.changeset/poor-lemons-cheer.md
@@ -3,4 +3,4 @@
 '@microsoft/atlas-css': minor
 ---
 
-Add support for a vertical gradient. Also adds a new red and purple color to create a red-purple gradient for the new Ask Learn icon
+Add support for a vertical gradient and two new colors for a red-purple gradient

--- a/css/src/components/gradient.scss
+++ b/css/src/components/gradient.scss
@@ -78,17 +78,16 @@ $gradient-direction: (
 ) !default;
 
 @each $name, $gradient in $gradients {
-	$colorStart: nth($gradient, 1);
-	$colorMiddle: if(length($gradient) > 2, nth($gradient, 2), null);
-	$colorEnd: nth($gradient, length($gradient));
+	$colorStart: nth($gradient, $gradient-color-start-index);
+	$colorEnd: nth($gradient, $gradient-color-end-index);
 
 	.gradient-text-#{$name} {
-		@include gradient-text($colorStart, $colorMiddle, $colorEnd);
+		@include gradient-text($colorStart, $colorEnd);
 	}
 
 	@each $direction, $angle in $gradient-direction {
 		.gradient-text-#{$name}-#{$direction} {
-			@include gradient-text($colorStart, $colorMiddle, $colorEnd, $angle);
+			@include gradient-text($colorStart, $colorEnd, $angle);
 		}
 	}
 }

--- a/css/src/components/gradient.scss
+++ b/css/src/components/gradient.scss
@@ -74,10 +74,11 @@ $border-gradient-direction: (
 }
 
 @each $name, $gradient in $gradients {
-	$colorStart: nth($gradient, $gradient-color-start-index);
-	$colorEnd: nth($gradient, $gradient-color-end-index);
+	$colorStart: nth($gradient, 1);
+	$colorMiddle: if(length($gradient) > 2, nth($gradient, 2), null);
+	$colorEnd: nth($gradient, length($gradient));
 
 	.gradient-text-#{$name} {
-		@include gradient-text($colorStart, $colorEnd);
+		@include gradient-text($colorStart, $colorMiddle, $colorEnd);
 	}
 }

--- a/css/src/components/gradient.scss
+++ b/css/src/components/gradient.scss
@@ -73,6 +73,10 @@ $border-gradient-direction: (
 	}
 }
 
+$gradient-direction: (
+	'bottom': 180deg
+) !default;
+
 @each $name, $gradient in $gradients {
 	$colorStart: nth($gradient, 1);
 	$colorMiddle: if(length($gradient) > 2, nth($gradient, 2), null);
@@ -80,5 +84,11 @@ $border-gradient-direction: (
 
 	.gradient-text-#{$name} {
 		@include gradient-text($colorStart, $colorMiddle, $colorEnd);
+	}
+
+	@each $direction, $angle in $gradient-direction {
+		.gradient-text-#{$name}-#{$direction} {
+			@include gradient-text($colorStart, $colorMiddle, $colorEnd, $angle);
+		}
 	}
 }

--- a/css/src/mixins/gradient.scss
+++ b/css/src/mixins/gradient.scss
@@ -1,16 +1,10 @@
-@mixin gradient-text($startColor, $middleColor: null, $endColor, $direction: 90deg) {
+@mixin gradient-text($startColor, $endColor, $direction: 90deg) {
 	/* stylelint-disable */
 	-webkit-background-clip: text;
 	/* stylelint-enable */
 	background-clip: text;
 	background-color: $startColor;
-
-	@if $middleColor {
-		background-image: linear-gradient($direction, $startColor, $middleColor, $endColor);
-	} @else {
-		background-image: linear-gradient($direction, $startColor, $endColor);
-	}
-
+	background-image: linear-gradient($direction, $startColor, $endColor);
 	color: transparent;
 	-webkit-text-fill-color: transparent;
 	line-height: 1.4; // required because of background clip, avoid "g" and "y" getting cut off

--- a/css/src/mixins/gradient.scss
+++ b/css/src/mixins/gradient.scss
@@ -1,4 +1,4 @@
-@mixin gradient-text($startColor, $middleColor: null, $endColor) {
+@mixin gradient-text($startColor, $middleColor: null, $endColor, $direction: 90deg) {
 	/* stylelint-disable */
 	-webkit-background-clip: text;
 	/* stylelint-enable */
@@ -6,9 +6,9 @@
 	background-color: $startColor;
 
 	@if $middleColor {
-		background-image: linear-gradient(90deg, $startColor, $middleColor, $endColor);
+		background-image: linear-gradient($direction, $startColor, $middleColor, $endColor);
 	} @else {
-		background-image: linear-gradient(90deg, $startColor, $endColor);
+		background-image: linear-gradient($direction, $startColor, $endColor);
 	}
 
 	color: transparent;

--- a/css/src/mixins/gradient.scss
+++ b/css/src/mixins/gradient.scss
@@ -1,10 +1,16 @@
-@mixin gradient-text($startColor, $endColor) {
+@mixin gradient-text($startColor, $middleColor: null, $endColor) {
 	/* stylelint-disable */
 	-webkit-background-clip: text;
 	/* stylelint-enable */
 	background-clip: text;
 	background-color: $startColor;
-	background-image: linear-gradient(90deg, $startColor, $endColor);
+
+	@if $middleColor {
+		background-image: linear-gradient(90deg, $startColor, $middleColor, $endColor);
+	} @else {
+		background-image: linear-gradient(90deg, $startColor, $endColor);
+	}
+
 	color: transparent;
 	-webkit-text-fill-color: transparent;
 	line-height: 1.4; // required because of background clip, avoid "g" and "y" getting cut off

--- a/css/src/mixins/gradient.scss
+++ b/css/src/mixins/gradient.scss
@@ -1,10 +1,10 @@
-@mixin gradient-text($startColor, $endColor, $direction: 90deg) {
+@mixin gradient-text($startColor, $endColor, $angle: 90deg) {
 	/* stylelint-disable */
 	-webkit-background-clip: text;
 	/* stylelint-enable */
 	background-clip: text;
 	background-color: $startColor;
-	background-image: linear-gradient($direction, $startColor, $endColor);
+	background-image: linear-gradient($angle, $startColor, $endColor);
 	color: transparent;
 	-webkit-text-fill-color: transparent;
 	line-height: 1.4; // required because of background clip, avoid "g" and "y" getting cut off

--- a/css/src/tokens/colors.scss
+++ b/css/src/tokens/colors.scss
@@ -50,6 +50,9 @@ $gradient-text-purple: var(--theme-gradient-text-purple);
 $gradient-text-blue: var(--theme-gradient-text-blue);
 $gradient-vivid-start: var(--theme-gradient-vivid-start);
 $gradient-vivid-end: var(--theme-gradient-vivid-end);
+$gradient-ask-learn-yellow: var(--theme-gradient-ask-learn-yellow);
+$gradient-ask-learn-red: var(--theme-gradient-ask-learn-red);
+$gradient-ask-learn-purple: var(--theme-gradient-ask-learn-purple);
 
 $default-hover: var(--theme-hover-base);
 $default-hover-invert: var(--theme-hover-invert);
@@ -264,8 +267,10 @@ $gradients: (
 	'purple-blue': (
 		$gradient-text-purple,
 		$gradient-text-blue
+	),
+	'ask-learn': (
+		$gradient-ask-learn-yellow,
+		$gradient-ask-learn-red,
+		$gradient-ask-learn-purple
 	)
 );
-
-$gradient-color-start-index: 1;
-$gradient-color-end-index: 2;

--- a/css/src/tokens/colors.scss
+++ b/css/src/tokens/colors.scss
@@ -50,9 +50,8 @@ $gradient-text-purple: var(--theme-gradient-text-purple);
 $gradient-text-blue: var(--theme-gradient-text-blue);
 $gradient-vivid-start: var(--theme-gradient-vivid-start);
 $gradient-vivid-end: var(--theme-gradient-vivid-end);
-$gradient-ask-learn-yellow: var(--theme-gradient-ask-learn-yellow);
-$gradient-ask-learn-red: var(--theme-gradient-ask-learn-red);
-$gradient-ask-learn-purple: var(--theme-gradient-ask-learn-purple);
+$gradient-bright-red: var(--theme-gradient-bright-red);
+$gradient-bright-purple: var(--theme-gradient-bright-purple);
 
 $default-hover: var(--theme-hover-base);
 $default-hover-invert: var(--theme-hover-invert);
@@ -268,9 +267,11 @@ $gradients: (
 		$gradient-text-purple,
 		$gradient-text-blue
 	),
-	'ask-learn': (
-		$gradient-ask-learn-yellow,
-		$gradient-ask-learn-red,
-		$gradient-ask-learn-purple
+	'red-purple': (
+		$gradient-bright-red,
+		$gradient-bright-purple
 	)
 );
+
+$gradient-color-start-index: 1;
+$gradient-color-end-index: 2;

--- a/css/src/tokens/palette.scss
+++ b/css/src/tokens/palette.scss
@@ -348,4 +348,9 @@ $palette-yellow-high-contrast: #ff0 !default;
 $palette-yellow-high-contrast-hover: #ff3 !default;
 $palette-visited-high-contrast: #3cff00 !default;
 
+// Ask Learn
+$palette-ask-learn-yellow: #ffb152 !default;
+$palette-ask-learn-red: #f2598a !default;
+$palette-ask-learn-purple: #8c48ff !default;
+
 //@end-sass-export-section

--- a/css/src/tokens/palette.scss
+++ b/css/src/tokens/palette.scss
@@ -233,6 +233,7 @@ $palette-purple-100: #03002c !default;
 $palette-purple-a: #cd9bcf !default;
 $palette-purple-b: #702573 !default; // light
 $palette-purple-c: #b84dc6 !default;
+$palette-purple-d: #c73ecc !default;
 
 $palette-purple-opacity-30: hsl(251deg 47% 18% / 30%) !default;
 $palette-purple-opacity-70: hsl(251deg 47% 18% / 70%) !default;
@@ -342,15 +343,12 @@ $palette-red-210: #3f1011 !default;
 $palette-red-opacity-30: hsl(0deg 100% 33% / 30%) !default;
 $palette-red-opacity-70: hsl(0deg 100% 33% / 70%) !default;
 
+$palette-red-a: #ff5c39 !default;
+
 // High Contrast
 
 $palette-yellow-high-contrast: #ff0 !default;
 $palette-yellow-high-contrast-hover: #ff3 !default;
 $palette-visited-high-contrast: #3cff00 !default;
-
-// Ask Learn
-$palette-ask-learn-yellow: #ffb152 !default;
-$palette-ask-learn-red: #f2598a !default;
-$palette-ask-learn-purple: #8c48ff !default;
 
 //@end-sass-export-section

--- a/css/src/tokens/themes.scss
+++ b/css/src/tokens/themes.scss
@@ -119,7 +119,10 @@ $themes: (
 		'gradient-text-purple': $palette-purple-b,
 		'gradient-text-blue': $palette-blue-130,
 		'gradient-vivid-start': $palette-purple-c,
-		'gradient-vivid-end': $palette-blue-100
+		'gradient-vivid-end': $palette-blue-100,
+		'gradient-ask-learn-yellow': $palette-ask-learn-yellow,
+		'gradient-ask-learn-red': $palette-ask-learn-red,
+		'gradient-ask-learn-purple': $palette-ask-learn-purple
 	),
 	'dark': (
 		'text': $palette-grey-30-deprecated,
@@ -238,7 +241,10 @@ $themes: (
 		'gradient-text-purple': $palette-purple-a,
 		'gradient-text-blue': $palette-blue-a,
 		'gradient-vivid-start': $palette-purple-c,
-		'gradient-vivid-end': $palette-blue-30-deprecated
+		'gradient-vivid-end': $palette-blue-30-deprecated,
+		'gradient-ask-learn-yellow': $palette-ask-learn-yellow,
+		'gradient-ask-learn-red': $palette-ask-learn-red,
+		'gradient-ask-learn-purple': $palette-ask-learn-purple
 	),
 	'high-contrast': (
 		'text': $palette-white,
@@ -357,7 +363,10 @@ $themes: (
 		'gradient-text-purple': $white-static,
 		'gradient-text-blue': $white-static,
 		'gradient-vivid-start': $white-static,
-		'gradient-vivid-end': $white-static
+		'gradient-vivid-end': $white-static,
+		'gradient-ask-learn-yellow': $white-static,
+		'gradient-ask-learn-red': $white-static,
+		'gradient-ask-learn-purple': $white-static
 	)
 ) !default;
 //@end-sass-export-section

--- a/css/src/tokens/themes.scss
+++ b/css/src/tokens/themes.scss
@@ -120,9 +120,8 @@ $themes: (
 		'gradient-text-blue': $palette-blue-130,
 		'gradient-vivid-start': $palette-purple-c,
 		'gradient-vivid-end': $palette-blue-100,
-		'gradient-ask-learn-yellow': $palette-ask-learn-yellow,
-		'gradient-ask-learn-red': $palette-ask-learn-red,
-		'gradient-ask-learn-purple': $palette-ask-learn-purple
+		'gradient-bright-red': $palette-red-a,
+		'gradient-bright-purple': $palette-purple-d
 	),
 	'dark': (
 		'text': $palette-grey-30-deprecated,
@@ -242,9 +241,8 @@ $themes: (
 		'gradient-text-blue': $palette-blue-a,
 		'gradient-vivid-start': $palette-purple-c,
 		'gradient-vivid-end': $palette-blue-30-deprecated,
-		'gradient-ask-learn-yellow': $palette-ask-learn-yellow,
-		'gradient-ask-learn-red': $palette-ask-learn-red,
-		'gradient-ask-learn-purple': $palette-ask-learn-purple
+		'gradient-bright-red': $palette-red-a,
+		'gradient-bright-purple': $palette-purple-d
 	),
 	'high-contrast': (
 		'text': $palette-white,
@@ -364,9 +362,8 @@ $themes: (
 		'gradient-text-blue': $white-static,
 		'gradient-vivid-start': $white-static,
 		'gradient-vivid-end': $white-static,
-		'gradient-ask-learn-yellow': $white-static,
-		'gradient-ask-learn-red': $white-static,
-		'gradient-ask-learn-purple': $white-static
+		'gradient-bright-red': $white-static,
+		'gradient-bright-purple': $white-static
 	)
 ) !default;
 //@end-sass-export-section

--- a/site/src/components/gradients.md
+++ b/site/src/components/gradients.md
@@ -30,6 +30,10 @@ Because gradient transitions take up the entire width of a particular element, i
 <h3 class="font-size-h3 font-weight-bold">
 	A vivid gradient from <span class="gradient-text-vivid">purple to blue</span>
 </h3>
+<h3 class="font-size-h3 font-weight-bold">
+	A three-color gradient from
+	<span class="gradient-text-ask-learn">yellow to red to purple</span>
+</h3>
 ```
 
 ## Gradient borders usage

--- a/site/src/components/gradients.md
+++ b/site/src/components/gradients.md
@@ -19,9 +19,9 @@ There are two main types of gradients.
 
 Because gradient transitions take up the entire width of a particular element, it's recommended to highlight inline elements, icons, or a portion of a heading, and not the entire heading itself.
 
-| base class name             | interpolated value     |
-| --------------------------- | ---------------------- |
-| `gradient-text-<colorname>` | `purple-blue`, `vivid` |
+| base class name             | interpolated value                   |
+| --------------------------- | ------------------------------------ |
+| `gradient-text-<colorname>` | `purple-blue`, `vivid`, `red-purple` |
 
 ```html
 <h3 class="font-size-h3 font-weight-bold">
@@ -31,8 +31,7 @@ Because gradient transitions take up the entire width of a particular element, i
 	A vivid gradient from <span class="gradient-text-vivid">purple to blue</span>
 </h3>
 <h3 class="font-size-h3 font-weight-bold">
-	A three-color gradient from
-	<span class="gradient-text-ask-learn">yellow to red to purple</span>
+	A bright gradient from <span class="gradient-text-red-purple">red to purple</span>
 </h3>
 ```
 
@@ -42,12 +41,10 @@ You can specify for the gradient to transition vertically instead of horizontall
 
 ```html
 <h3 class="font-size-h3 font-weight-bold">
-	This gradient transitions from
-	<span class="gradient-text-ask-learn-bottom">top to bottom</span>
+	This gradient transitions from <span class="gradient-text-red-purple-bottom">top to bottom</span>
 </h3>
 <h3 class="font-size-h3 font-weight-bold">
-	This gradient transitions from
-	<span class="gradient-text-ask-learn">left to right</span>
+	This gradient transitions from <span class="gradient-text-red-purple">left to right</span>
 </h3>
 ```
 

--- a/site/src/components/gradients.md
+++ b/site/src/components/gradients.md
@@ -37,7 +37,7 @@ Because gradient transitions take up the entire width of a particular element, i
 
 ## Direction of gradient
 
-You can specify for the gradient to transition vertically instead of horizontally by appending `-bottom` to the end of the gradient class. By default, the gradient moves from left to right, so you do not need to specify `-right`.
+By default, the gradient moves from left to right. To transition gradient vertically instead, append `-bottom` to the end of the gradient atomic - `gradient-text-<colorname>-bottom`.
 
 ```html
 <h3 class="font-size-h3 font-weight-bold">

--- a/site/src/components/gradients.md
+++ b/site/src/components/gradients.md
@@ -36,6 +36,21 @@ Because gradient transitions take up the entire width of a particular element, i
 </h3>
 ```
 
+## Direction of gradient
+
+You can specify for the gradient to transition vertically instead of horizontally by appending `-bottom` to the end of the gradient class. By default, the gradient moves from left to right, so you do not need to specify `-right`.
+
+```html
+<h3 class="font-size-h3 font-weight-bold">
+	This gradient transitions from
+	<span class="gradient-text-ask-learn-bottom">top to bottom</span>
+</h3>
+<h3 class="font-size-h3 font-weight-bold">
+	This gradient transitions from
+	<span class="gradient-text-ask-learn">left to right</span>
+</h3>
+```
+
 ## Gradient borders usage
 
 The `.gradient-border` component is a moderately pluggable component used to blend the boundaries between colors. Because of the near-infinite number of steps, color variations, and gradient types involved in creating a gradient, we've scoped these to be linear gradients that transition between `transparent` and a given color represented by the `--border-gradient-end-color` custom property. Each gradient combination requires a minimum of two class, one specifying the color and one specifying the direction.


### PR DESCRIPTION
Link: [preview](http://localhost:1111/components/gradients.html)

This PR adds support for a vertical gradient (previously only supported a horizontal gradient moving from left to right) and adds a red and a purple color for the new Ask Learn icon. 

The gradient getting added:

![image](https://github.com/user-attachments/assets/3ef62edd-608b-4dd7-8b08-f6f26dd09207)


## Testing

1. See http://localhost:1111/components/gradients.html for the new three color gradient 


## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [ ] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
- [ ] Does your pull request change any transforms? Did you test they work on right to left?
