### PR TITLE
fix watcher in development server

### DIFF
--- a/.changeset/fiery-badgers-sit.md
+++ b/.changeset/fiery-badgers-sit.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': patch
+---
+
+Fix the development server's file watcher, which stopped watching at the npm module boundary after a dependency upgrade.

--- a/site/src/scaffold/index.scss
+++ b/site/src/scaffold/index.scss
@@ -1,4 +1,4 @@
-@use '@microsoft/atlas-css/src/index.scss';
+@use '../../../css/src/index.scss';
 @use './styles/form.scss';
 @use './styles/height.scss';
 @use './styles/layout.scss';


### PR DESCRIPTION
Link: [preview](http://localhost:1111/)

After a recent dependency update, the parcel development server had stopped watching for changes in the /css folder, making development against the site difficult. This fixes that, but ceasing to reference the npm package name and instead just using a path.

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
