### PR TITLE
add a new reading-width component and adjust site layout to make use …

### DIFF
--- a/.changeset/common-beers-yell.md
+++ b/.changeset/common-beers-yell.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Add a new .reading-width class to help constrain content to a good recommended reading width.

--- a/.changeset/fiery-moles-clap.md
+++ b/.changeset/fiery-moles-clap.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': patch
+---
+
+Add the .reading-width component to the site's article-like content.

--- a/.changeset/metal-dryers-report.md
+++ b/.changeset/metal-dryers-report.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Adjust --layout-gap variable to use the correct mobile padding of 1rem (16px) to match header. Desktop and wider screens are unaffected.

--- a/css/src/components/index.scss
+++ b/css/src/components/index.scss
@@ -32,3 +32,4 @@
 @forward './segmented-control.scss';
 @forward './timeline.scss';
 @forward './layout.scss';
+@forward './reading-width.scss';

--- a/css/src/components/layout.scss
+++ b/css/src/components/layout.scss
@@ -25,8 +25,9 @@ $layout-menu-collapsed-width: 96px !default;
 	max-inline-size: 100vw;
 
 	// --layout-gutter by default, see tokens/layout.scss
-	#{tokens.$layout-gap-custom-property-name}: tokens.$layout-gap;
-	#{tokens.$layout-gap-scalable-custom-property-name}: tokens.$layout-gap;
+	#{tokens.$layout-gap-custom-property-name}: tokens.$layout-gap-narrow;
+	#{tokens.$layout-gap-scalable-custom-property-name}: tokens.$layout-gap-narrow;
+
 	#{tokens.$layout-flyout-width-desktop-custom-property-name}: $default-flyout-width-desktop;
 	#{tokens.$layout-flyout-width-widescreen-custom-property-name}: $default-flyout-width-widescreen;
 	#{tokens.$layout-flyout-width-name}: var(
@@ -36,6 +37,11 @@ $layout-menu-collapsed-width: 96px !default;
 	#{tokens.$layout-menu-collapsed-width-widescreen-spacer-width-name}: calc(
 		$quarter-widescreen - var(#{tokens.$layout-menu-collapsed-width-name})
 	);
+
+	@include mixins.desktop {
+		#{tokens.$layout-gap-custom-property-name}: tokens.$layout-gap;
+		#{tokens.$layout-gap-scalable-custom-property-name}: tokens.$layout-gap;
+	}
 
 	@include mixins.widescreen {
 		#{tokens.$layout-gap-scalable-custom-property-name}: tokens.$layout-widescreen-gap;

--- a/css/src/components/reading-width.scss
+++ b/css/src/components/reading-width.scss
@@ -1,0 +1,5 @@
+@use '../tokens/index.scss' as tokens;
+
+.reading-width {
+	max-inline-size: min(100%, #{tokens.$reading-width-padded});
+}

--- a/css/src/tokens/layout.scss
+++ b/css/src/tokens/layout.scss
@@ -8,6 +8,7 @@ $column-gap: 0.75rem !default;
 $large-column-gap: 1.5rem !default;
 $reading-max-width: 50rem !default;
 
+$layout-gap-narrow: 16px !default;
 $layout-gap: 24px !default;
 $layout-widescreen-width: breakpoints.$breakpoint-widescreen - $layout-gap * 2 !default;
 $layout-widescreen-gap: max(

--- a/css/src/tokens/typography.scss
+++ b/css/src/tokens/typography.scss
@@ -1,4 +1,5 @@
 @use './layout.scss' as layout;
+
 /**
  * @sass-export-section="typography"
  */

--- a/css/src/tokens/typography.scss
+++ b/css/src/tokens/typography.scss
@@ -1,3 +1,4 @@
+@use './layout.scss' as layout;
 /**
  * @sass-export-section="typography"
  */
@@ -29,5 +30,12 @@ $letter-spacing-wide: 0.225rem;
 
 // Line height
 $line-height-normal: 1.3;
+
+// Reading width
+$optimal-reading-width: 688px !default;
+$reading-width-padding: 24px !default;
+$reading-width-padded: calc(
+	#{$optimal-reading-width} + (var(#{layout.$layout-gap-custom-property-name}) * 2)
+) !default;
 
 //@end-sass-export-section

--- a/integration/config/page.ts
+++ b/integration/config/page.ts
@@ -44,6 +44,7 @@ export const pages: LocalPageConfig[] = [
 	{ pathname: '/components/overview.html', name: 'Components/overview', routes },
 	{ pathname: '/components/popover.html', name: 'Components/popover', routes },
 	{ pathname: '/components/radio.html', name: 'Components/radio', routes },
+	{ pathname: '/components/reading-width.html', name: 'Components/reading-width', routes },
 	{ pathname: '/components/scroll.html', name: 'Components/scroll', routes },
 	{ pathname: '/components/select.html', name: 'Components/select', routes },
 	{ pathname: '/components/table.html', name: 'Components/table', routes },

--- a/site/src/components/reading-width.md
+++ b/site/src/components/reading-width.md
@@ -1,0 +1,31 @@
+---
+title: Reading Width
+description: The reading width component in the Atlas Design System
+template: standard
+classType: Component
+classPrefixes:
+  - reading-width
+---
+
+# Reading width
+
+The reading width component constrains an element's maximum width to an optimal reading measure. This improves readability for long-form text content by preventing lines from becoming too wide, which can make it difficult for readers to track from the end of one line to the beginning of the next.
+
+## Usage
+
+Apply the `.reading-width` class to any container whose content should be constrained to a comfortable reading width. This page's text uses this very class!
+
+```html-no-example
+<div class="reading-width">
+	<p>
+		This paragraph is constrained to an optimal reading width. Long lines of text are harder to
+		read because the eye has to travel further from the end of one line to the beginning of the
+		next, making it easy to lose your place. By limiting the maximum width, we ensure a
+		comfortable reading experience.
+	</p>
+</div>
+```
+
+## Recommended implementation
+
+It's a good idea to use `.reading-width` in combination with a container that is centered either within the viewport or a parent element. Try using it in combination with `margin-inline-auto` to automatically center the content horizontally. If used in a grid, you may need to ensure the grid-column that container the reading-width container uses the `minmax` function to ensure it `margin-inline-auto` does not break outside the layout.

--- a/site/src/components/reading-width.md
+++ b/site/src/components/reading-width.md
@@ -28,4 +28,4 @@ Apply the `.reading-width` class to any container whose content should be constr
 
 ## Recommended implementation
 
-It's a good idea to use `.reading-width` in combination with a container that is centered either within the viewport or a parent element. Try using it in combination with `margin-inline-auto` to automatically center the content horizontally. If used in a grid, you may need to ensure the grid-column that container the reading-width container uses the `minmax` function to ensure it `margin-inline-auto` does not break outside the layout.
+Use `.reading-width` within a container that is centered in the viewport or a parent element. Pair it with `.margin-inline-auto` to automatically center the content horizontally. If used in a grid, ensure the grid column containing the `.reading-width` container uses the `minmax` function so that margin-inline-auto does not cause content to break outside the layout.

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -108,6 +108,7 @@
 		</nav>
 
 		<main id="main" class="layout-body-main">
+			<div id="main-column" class="reading-width margin-inline-auto">
 			{{{breadcrumbs}}}
 
 			<div id="actions-holder" class="layout-padding padding-right-none">
@@ -180,6 +181,7 @@
 							allowfullscreen="true"></iframe>
 					</div>
 				{{/figmaEmbed}}
+			</div>
 			</div>
 		</main>
 

--- a/site/src/scaffold/styles/layout.scss
+++ b/site/src/scaffold/styles/layout.scss
@@ -12,19 +12,21 @@ html {
 }
 
 #main {
+	background-color: tokens.$body-background;
+}
+
+#main-column {
 	display: grid;
-	grid-area: main;
 	padding-block: tokens.$layout-3;
 	padding: tokens.$layout-gap;
-	background-color: tokens.$body-background;
 	gap: tokens.$layout-3;
-	grid-template: auto 1fr / 9fr 1fr;
+	grid-template: auto 1fr / minmax(0, 9fr) minmax(0, 1fr);
 	grid-template-areas:
 		'breadcrumbs actions'
 		'article article';
 
 	@include mixins.desktop {
-		grid-template: auto 1fr / 7fr 3fr;
+		grid-template: auto 1fr / minmax(0, 7fr) minmax(0, 3fr);
 		grid-template-areas:
 			'breadcrumbs actions'
 			'article article';

--- a/site/src/scaffold/token.html
+++ b/site/src/scaffold/token.html
@@ -101,6 +101,7 @@
 		</nav>
 
 		<main id="main" class="layout-body-main">
+			<div id="main-column" class="reading-width margin-inline-auto">
 			{{{breadcrumbs}}}
 
 			<div id="actions-holder" class="layout-padding padding-right-none">
@@ -178,6 +179,7 @@
 								allowfullscreen></iframe>
 					{{/figmaEmbed}}
 				</div>
+			</div>
 			</div>
 		</main>
 


### PR DESCRIPTION
The first of several PRs allowing for a nicer reading experience for users. This one:
1. Adds a new `.reading-width` class component, which is 688 plus padding on both sides.
1. Adjusts the `--layout-gap` variable to be smaller 16px on mobile and 24px on desktop (desktop is unchanged).
1. Adjusts the site's css a little bit, to add one level of nesting to allow for the application of `.reading-width`.

Link: [preview](http://localhost:1111/components/reading-width.html)

## Testing

1. Run locally.
2. Visit page above.
3. Resize screen, you ought to see a constrained container and it should never overlfow the boundaries of the page.

## Additional information

<img width="758" height="469" alt="image" src="https://github.com/user-attachments/assets/28c97fd1-6344-44bc-9eba-0628974a8f64" />

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [x] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
