### PR TITLE
Reduce h2/h6 token sizes and align markdown h6 sizing

### DIFF
--- a/.changeset/heavy-games-wink.md
+++ b/.changeset/heavy-games-wink.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Reduce h2 and h6 typography token sizes by 2px and align markdown h6 to token sizing.

--- a/css/src/components/markdown.scss
+++ b/css/src/components/markdown.scss
@@ -133,8 +133,7 @@ $list-top-spacing: 1rem !default;
 	}
 
 	h6 {
-		@include mixins.responsive-font-size(tokens.$font-size-6, false, 1.05rem);
-
+		font-size: tokens.$font-size-6;
 		margin-block-start: 2.25rem;
 		margin-block-end: 0.375rem;
 		letter-spacing: 1px;

--- a/css/src/tokens/typography.scss
+++ b/css/src/tokens/typography.scss
@@ -8,11 +8,11 @@ $document-font-size: 16px;
 $font-size-9: 0.75rem !default; // 12px
 $font-size-8: 0.875rem !default; // 14px
 $font-size-7: 1rem !default; // 16px
-$font-size-6: 1.125rem !default; // 18px
+$font-size-6: 1rem !default; // 16px
 $font-size-5: 1.25rem !default; // 20px
 $font-size-4: 1.5rem !default; // 24px
 $font-size-3: 1.75rem !default; // 28px
-$font-size-2: 2.125rem !default; // 34px
+$font-size-2: 2rem !default; // 32px
 $font-size-1: 2.5rem !default; // 40px
 $font-size-0: 3.375rem !default; // 54px
 


### PR DESCRIPTION
 Reduces h2 and h6 typography token sizes by 2px each to better align with Fluent 2 targets:

 - $font-size-2: 2.125rem (34px) → 2rem (32px)
 - $font-size-6: 1.125rem (18px) → 1rem (16px)

Link: [preview](http://localhost:1111/)

## Testing

1. Run locally.
2. Visit any page with h2 and h6 headings (for example, the markdown documentation page).
3. Confirm h2 uses responsive sizing from 24px (1.5rem) up to 32px (2rem) depending on viewport width.
4. Verify h6 no longer scales responsively and remains fixed at 16px (1rem) at all viewport sizes.

## Additional information

<img width="867" height="873" alt="image" src="https://github.com/user-attachments/assets/f85efa87-5e24-4d11-aabd-748a979d1beb" />

## Contributor checklist

 - [X]  Did you update the description of this pull request with a review link and test steps?
 - [X]  Did you submit a changeset? Changesets are required for all code changes.
 - [ ]  Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
 - [ ]  Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in 
/integration/tests/accessibility.
 - [ ]  Does your pull request change any transforms? Did you test they work on right to left?
