### PR TITLE
update body-background-medium to #FAFAFA

### DIFF
--- a/.changeset/tough-humans-jump.md
+++ b/.changeset/tough-humans-jump.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Updated body-background-medium theme color to use #FAFAFA palette token.

--- a/css/src/tokens/themes.scss
+++ b/css/src/tokens/themes.scss
@@ -18,7 +18,7 @@ $themes: (
 		'overlay-invert': palette.$palette-white,
 		'body-background': palette.$palette-white,
 		'body-background-accent': palette.$palette-yellow-sand,
-		'body-background-medium': palette.$palette-grey-20-deprecated,
+		'body-background-medium': palette.$palette-grey-10-deprecated,
 		'alternate-background': palette.$palette-grey-120-deprecated,
 		'alternate-background-medium': palette.$palette-grey-110-deprecated,
 		'card-background': palette.$palette-white,


### PR DESCRIPTION
Link: [preview](http://localhost:1111/atomics/colors.html)

Updates the body-background-medium theme token from palette-grey-20 to palette-grey-10 (#FAFAFA), aligning with the Docs Modernization spec which specifies #FAFAFA as the background color for the left rail.

 - body-background-medium: $palette-grey-20-deprecated → $palette-grey-10-deprecated

Testing

 1. Run locally.
 2. Confirm the updated background color is #FAFAFA.
 3. Verify no other background colors are unintentionally affected.

Additional information

This change is part of the Docs Modernization Phase 2 visual style updates, which specify #FAFAFA as the left rail background color.

Contributor checklist

 - [X]  Did you update the description of this pull request with a review link and test steps?
 - [X]  Did you submit a changeset? Changesets are required for all code changes.
 - [ ]  Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
 - [ ]  Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in 
/integration/tests/accessibility.
 - [ ]  Does your pull request change any transforms? Did you test they work on right to left?