### PR TITLE
Remove max layout width, update layout sidebar width, allow collapsible

### DIFF
--- a/.changeset/busy-files-sneeze.md
+++ b/.changeset/busy-files-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': major
+---
+
+Site header no longer applies extra padding on wide screens. This change matches the changes to layouts.

--- a/.changeset/cute-rabbits-sleep.md
+++ b/.changeset/cute-rabbits-sleep.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': major
+---
+
+Both the `.layout-body-menu` and `.layout-body-aside` have a narrower maximum width applied, circa 275px wide. These containers still scale down as required on narrower widths.

--- a/.changeset/fancy-candies-stay.md
+++ b/.changeset/fancy-candies-stay.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': major
+---
+
+Layouts no longer apply a maximum site width, instead elements are anchored to the sides of the screen regardless of scaling.

--- a/.changeset/good-canyons-sneeze.md
+++ b/.changeset/good-canyons-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': major
+---
+
+The `.banner`, `.hero`, and `.site-header` components no longer have a maximum width applied on wide screen sizes. Pairs with changes made to the .layout class.

--- a/.changeset/mighty-flies-sink.md
+++ b/.changeset/mighty-flies-sink.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Narrow the `.layout-body-menu`'s collapsed width significantly.

--- a/.changeset/olive-bobcats-stare.md
+++ b/.changeset/olive-bobcats-stare.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': patch
+---
+
+Update the full screen button behavior to remove reading width from the main column element. This allows for the continued testing of full width elements like hero and site header.

--- a/.changeset/sour-canyons-dress.md
+++ b/.changeset/sour-canyons-dress.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': major
+---
+
+To match layout changes that remove the site's max width, `.layout-margin` and `.layout-padding` classes have been updated, removing their larger, `calc`ed values that applied to widescreen.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,6 @@
 	},
 	"typescript.tsc.autoDetect": "off",
 	"github.copilot.enable": {
-		"*": false
+		"*": true
 	}
 }

--- a/css/src/components/banner.scss
+++ b/css/src/components/banner.scss
@@ -43,10 +43,6 @@ $banner-dismiss-margin: tokens.$spacer-2 !default;
 			inset-block-start: $banner-padding;
 			inset-inline-start: tokens.$layout-gap;
 			border-color: transparent transparent $banner-color $banner-color;
-
-			@include mixins.widescreen {
-				inset-inline-start: tokens.$layout-widescreen-gap;
-			}
 		}
 	}
 

--- a/css/src/components/hero.scss
+++ b/css/src/components/hero.scss
@@ -17,7 +17,6 @@ $hero-details-content-fluid-width: 35% !default;
 $hero-content-width: tokens.$reading-max-width !default;
 
 $hero-image-width: calc((100% - 2 * tokens.$layout-gap) * 0.55) !default;
-$hero-image-width-widescreen: calc((100% - 2 * tokens.$layout-widescreen-gap) * 0.55) !default;
 
 .hero {
 	@extend %layout-gap;
@@ -157,11 +156,6 @@ $hero-image-width-widescreen: calc((100% - 2 * tokens.$layout-widescreen-gap) * 
 
 		@include mixins.desktop {
 			display: block;
-		}
-
-		@include mixins.widescreen {
-			width: $hero-image-width-widescreen;
-			inset-inline-end: tokens.$layout-widescreen-gap;
 		}
 
 		@media (forced-colors: active) {

--- a/css/src/components/layout.scss
+++ b/css/src/components/layout.scss
@@ -2,6 +2,7 @@
 @use '../mixins/index.scss' as mixins;
 
 $default-flyout-width-desktop: 320px;
+$default-flyout-width-widescreen: 480px;
 $layout-menu-collapsed-width: 68px !default;
 $layout-menu-expanded-target-width: 275px !default;
 $layout-aside-collapsed-width: 68px !default;
@@ -40,6 +41,10 @@ $layout-aside-expanded-target-width: 275px !default;
 	@include mixins.desktop {
 		#{tokens.$layout-gap-custom-property-name}: tokens.$layout-gap;
 		#{tokens.$layout-gap-scalable-custom-property-name}: tokens.$layout-gap;
+	}
+
+	@include mixins.widescreen {
+		#{tokens.$layout-flyout-width-desktop-custom-property-name}: $default-flyout-width-widescreen;
 	}
 }
 

--- a/css/src/components/layout.scss
+++ b/css/src/components/layout.scss
@@ -1,16 +1,11 @@
-@use 'sass:math';
 @use '../tokens/index.scss' as tokens;
 @use '../mixins/index.scss' as mixins;
 
-$quarter-widescreen: math.div(tokens.$breakpoint-widescreen, 4);
-$half-widescreen: math.div(tokens.$breakpoint-widescreen, 2);
-$three-quarters-widescreen: math.div(tokens.$breakpoint-widescreen, 4) * 3;
 $default-flyout-width-desktop: 320px;
-$default-flyout-width-widescreen: 480px;
-$default-aside-min-width: 300px;
-$eighth-widescreen: math.div(tokens.$breakpoint-widescreen, 8); // 225px
-$five-eighths-widescreen: math.div(tokens.$breakpoint-widescreen, 8) * 5; // 1125px
-$layout-menu-collapsed-width: 96px !default;
+$layout-menu-collapsed-width: 68px !default;
+$layout-menu-expanded-target-width: 275px !default;
+$layout-aside-collapsed-width: 68px !default;
+$layout-aside-expanded-target-width: 275px !default;
 
 :root {
 	--window-inner-height: 100vh; // to be overwritten by JS
@@ -29,26 +24,22 @@ $layout-menu-collapsed-width: 96px !default;
 	#{tokens.$layout-gap-scalable-custom-property-name}: tokens.$layout-gap-narrow;
 
 	#{tokens.$layout-flyout-width-desktop-custom-property-name}: $default-flyout-width-desktop;
-	#{tokens.$layout-flyout-width-widescreen-custom-property-name}: $default-flyout-width-widescreen;
 	#{tokens.$layout-flyout-width-name}: var(
 		#{tokens.$layout-flyout-width-desktop-custom-property-name}
 	);
 	#{tokens.$layout-menu-collapsed-width-name}: $layout-menu-collapsed-width;
-	#{tokens.$layout-menu-collapsed-width-widescreen-spacer-width-name}: calc(
-		$quarter-widescreen - var(#{tokens.$layout-menu-collapsed-width-name})
-	);
+	#{tokens.$layout-menu-expanded-target-width-name}: $layout-menu-expanded-target-width;
+	#{tokens.$layout-aside-collapsed-width-name}: $layout-aside-collapsed-width;
+	#{tokens.$layout-aside-expanded-target-width-name}: $layout-aside-expanded-target-width;
+
+	#{tokens.$layout-menu-width-name}: var(#{tokens.$layout-menu-expanded-target-width-name});
+	#{tokens.$layout-aside-width-name}: var(#{tokens.$layout-aside-expanded-target-width-name});
+	#{tokens.$layout-menu-spacer-width-name}: 0px;
+	#{tokens.$layout-aside-spacer-width-name}: 0px;
 
 	@include mixins.desktop {
 		#{tokens.$layout-gap-custom-property-name}: tokens.$layout-gap;
 		#{tokens.$layout-gap-scalable-custom-property-name}: tokens.$layout-gap;
-	}
-
-	@include mixins.widescreen {
-		#{tokens.$layout-gap-scalable-custom-property-name}: tokens.$layout-widescreen-gap;
-		// sets widescreen custom prop
-		#{tokens.$layout-flyout-width-name}: var(
-			#{tokens.$layout-flyout-width-widescreen-custom-property-name}
-		);
 	}
 }
 
@@ -145,7 +136,9 @@ $layout-menu-collapsed-width: 96px !default;
 
 		@include mixins.tablet {
 			grid-template:
-				minmax(auto, max-content) auto var(--atlas-contained-height) auto auto / minmax(0, 1fr)
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto auto / var(
+					#{tokens.$layout-menu-width-name}
+				)
 				minmax(0, 2fr);
 			grid-template-areas:
 				'header header'
@@ -157,117 +150,26 @@ $layout-menu-collapsed-width: 96px !default;
 
 		@include mixins.desktop {
 			grid-template:
-				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(
-					0,
-					2fr
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto / var(
+					#{tokens.$layout-menu-width-name}
 				)
-				minmax(0, 1fr);
-			grid-template-areas:
-				'header header header'
-				'hero hero hero'
-				'menu main aside'
-				'footer footer footer';
-		}
-
-		@include mixins.widescreen {
-			grid-template: minmax(auto, max-content) auto var(--atlas-contained-height) auto / auto #{$quarter-widescreen} #{$half-widescreen} #{$quarter-widescreen} auto;
+				var(#{tokens.$layout-menu-spacer-width-name})
+				minmax(0, 1fr)
+				var(#{tokens.$layout-aside-spacer-width-name})
+				minmax(0, var(#{tokens.$layout-aside-width-name}));
 			grid-template-areas:
 				'header header header header header'
 				'hero hero hero hero hero'
-				'. menu main aside .'
+				'menu . main . aside'
 				'footer footer footer footer footer';
-		}
-	}
-
-	&.layout-menu-collapsed .layout-body {
-		@include mixins.tablet {
-			grid-template:
-				minmax(auto, max-content) auto var(--atlas-contained-height) auto auto / var(
-					#{tokens.$layout-menu-collapsed-width-name}
-				)
-				minmax(0, 1fr);
-			grid-template-areas:
-				'header header'
-				'hero hero'
-				'menu main'
-				'menu aside'
-				'footer footer';
-		}
-
-		@include mixins.desktop {
-			grid-template:
-				minmax(auto, max-content) auto var(--atlas-contained-height) auto / var(
-					#{tokens.$layout-menu-collapsed-width-name}
-				)
-				minmax(0, 4fr)
-				minmax(0, 23fr) minmax(0, 10fr);
-			grid-template-areas:
-				'header header header header'
-				'hero hero hero hero'
-				'menu . main aside'
-				'footer footer footer footer';
-		}
-
-		@include mixins.widescreen {
-			grid-template:
-				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, auto) var(
-					#{tokens.$layout-menu-collapsed-width-name}
-				)
-				minmax(0, var(#{tokens.$layout-menu-collapsed-width-widescreen-spacer-width-name}))
-				$half-widescreen minmax(0, #{$quarter-widescreen}) minmax(0, auto);
-			grid-template-areas:
-				'header header header header header header'
-				'hero hero hero hero hero hero'
-				'. menu . main aside .'
-				'footer footer footer footer footer footer';
 		}
 	}
 
 	&.layout-flyout-active .layout-body {
 		@include mixins.desktop {
 			grid-template:
-				auto auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr)
-				var(#{tokens.$layout-flyout-width-name});
-			grid-template-areas:
-				'header header header header'
-				'hero hero hero flyout'
-				'menu main aside flyout'
-				'footer footer footer footer';
-		}
-
-		@include mixins.widescreen {
-			grid-template:
-				auto auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr)
-				var(#{tokens.$layout-flyout-width-name});
-			grid-template-areas:
-				'header header header header'
-				'hero hero hero flyout'
-				'menu main aside flyout'
-				'footer footer footer footer';
-		}
-	}
-
-	&.layout-flyout-active.layout-menu-collapsed .layout-body {
-		@include mixins.desktop {
-			grid-template:
-				auto auto var(--atlas-contained-height) auto / var(
-					#{tokens.$layout-menu-collapsed-width-name}
-				)
-				minmax(0, 2fr) minmax(0, 1fr)
-				var(#{tokens.$layout-flyout-width-name});
-			grid-template-areas:
-				'header header header header'
-				'hero hero hero flyout'
-				'menu main aside flyout'
-				'footer footer footer footer';
-		}
-
-		@include mixins.widescreen {
-			grid-template:
-				auto auto var(--atlas-contained-height) auto / var(
-					#{tokens.$layout-menu-collapsed-width-name}
-				)
-				minmax(0, 2fr) minmax(0, 1fr)
+				auto auto var(--atlas-contained-height) auto / var(#{tokens.$layout-menu-width-name})
+				minmax(0, 1fr) minmax(0, var(#{tokens.$layout-aside-width-name}))
 				var(#{tokens.$layout-flyout-width-name});
 			grid-template-areas:
 				'header header header header'
@@ -289,41 +191,8 @@ $layout-menu-collapsed-width: 96px !default;
 
 		@include mixins.tablet {
 			grid-template:
-				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 1fr)
-				minmax(0, 2fr);
-			grid-template-areas:
-				'header header'
-				'hero hero'
-				'menu main'
-				'footer footer';
-		}
-
-		@include mixins.desktop {
-			grid-template:
-				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 1fr)
-				minmax(0, 3fr);
-			grid-template-areas:
-				'header header'
-				'hero hero'
-				'menu main'
-				'footer footer';
-		}
-
-		@include mixins.widescreen {
-			grid-template: minmax(auto, max-content) auto var(--atlas-contained-height) auto / auto #{$quarter-widescreen} #{$three-quarters-widescreen} auto;
-			grid-template-areas:
-				'header header header header'
-				'hero hero hero hero'
-				'. menu main .'
-				'footer footer footer footer';
-		}
-	}
-
-	&.layout-menu-collapsed .layout-body {
-		@include mixins.tablet {
-			grid-template:
 				minmax(auto, max-content) auto var(--atlas-contained-height) auto / var(
-					#{tokens.$layout-menu-collapsed-width-name}
+					#{tokens.$layout-menu-width-name}
 				)
 				minmax(0, 1fr);
 			grid-template-areas:
@@ -332,71 +201,13 @@ $layout-menu-collapsed-width: 96px !default;
 				'menu main'
 				'footer footer';
 		}
-
-		@include mixins.desktop {
-			grid-template:
-				minmax(auto, max-content) auto var(--atlas-contained-height) auto / var(
-					#{tokens.$layout-menu-collapsed-width-name}
-				)
-				minmax(0, 4fr)
-				minmax(0, 23fr) minmax(0, 10fr);
-			grid-template-areas:
-				'header header header header'
-				'hero hero hero hero'
-				'menu . main main'
-				'footer footer footer footer';
-		}
-
-		@include mixins.widescreen {
-			grid-template:
-				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, auto) var(
-					#{tokens.$layout-menu-collapsed-width-name}
-				)
-				minmax(0, var(#{tokens.$layout-menu-collapsed-width-widescreen-spacer-width-name}))
-				#{$three-quarters-widescreen} minmax(0, auto);
-			grid-template-areas:
-				'header header header header header'
-				'hero hero hero hero hero'
-				'. menu . main .'
-				'footer footer footer footer footer';
-		}
 	}
 
 	&.layout-flyout-active .layout-body {
 		@include mixins.desktop {
 			grid-template:
-				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(
-					0,
-					3fr
-				)
-				var(#{tokens.$layout-flyout-width-name});
-			grid-template-areas:
-				'header header header'
-				'hero hero flyout'
-				'menu main flyout'
-				'footer footer footer';
-		}
-
-		@include mixins.widescreen {
-			grid-template:
-				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(
-					0,
-					3fr
-				)
-				var(#{tokens.$layout-flyout-width-name});
-			grid-template-areas:
-				'header header header'
-				'hero hero flyout'
-				'menu main flyout'
-				'footer footer footer';
-		}
-	}
-
-	&.layout-flyout-active.layout-menu-collapsed .layout-body {
-		@include mixins.desktop {
-			grid-template:
-				auto auto var(--atlas-contained-height) auto / var(
-					#{tokens.$layout-menu-collapsed-width-name}
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto / var(
+					#{tokens.$layout-menu-width-name}
 				)
 				minmax(0, 1fr)
 				var(#{tokens.$layout-flyout-width-name});
@@ -405,21 +216,6 @@ $layout-menu-collapsed-width: 96px !default;
 				'hero hero flyout'
 				'menu main flyout'
 				'footer footer footer';
-		}
-
-		@include mixins.widescreen {
-			grid-template:
-				auto auto var(--atlas-contained-height) auto / var(
-					#{tokens.$layout-menu-collapsed-width-name}
-				)
-				minmax(0, var(#{tokens.$layout-menu-collapsed-width-widescreen-spacer-width-name}))
-				minmax(0, 1fr)
-				var(#{tokens.$layout-flyout-width-name});
-			grid-template-areas:
-				'header header header header'
-				'hero hero hero flyout'
-				'menu . main flyout'
-				'footer footer footer footer';
 		}
 	}
 }
@@ -435,56 +231,22 @@ $layout-menu-collapsed-width: 96px !default;
 
 		@include mixins.tablet {
 			grid-template:
-				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 2fr)
-				minmax(0, 1fr);
-			grid-template-areas:
-				'header header'
-				'hero hero'
-				'main aside '
-				'footer footer';
-		}
-
-		@include mixins.desktop {
-			grid-template:
-				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 3fr)
-				minmax(0, 1fr);
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 1fr)
+				minmax(0, var(#{tokens.$layout-aside-width-name}));
 			grid-template-areas:
 				'header header'
 				'hero hero'
 				'main aside'
 				'footer footer';
 		}
-
-		@include mixins.widescreen {
-			grid-template: minmax(auto, max-content) auto var(--atlas-contained-height) auto / auto #{$three-quarters-widescreen} #{$quarter-widescreen} auto;
-			grid-template-areas:
-				'header header header header'
-				'hero hero hero hero'
-				'. main aside .'
-				'footer footer footer footer';
-		}
 	}
 
 	&.layout-flyout-active .layout-body {
 		@include mixins.desktop {
 			grid-template:
-				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 3fr) minmax(
+				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 1fr) minmax(
 					0,
-					1fr
-				)
-				var(#{tokens.$layout-flyout-width-name});
-			grid-template-areas:
-				'header header header'
-				'hero hero flyout'
-				'main aside flyout'
-				'footer footer footer';
-		}
-
-		@include mixins.widescreen {
-			grid-template:
-				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 3fr) minmax(
-					0,
-					1fr
+					var(#{tokens.$layout-aside-width-name})
 				)
 				var(#{tokens.$layout-flyout-width-name});
 			grid-template-areas:
@@ -505,7 +267,6 @@ $layout-menu-collapsed-width: 96px !default;
 		grid-template: minmax(auto, max-content) auto auto 1fr auto / minmax(0, 1fr);
 		grid-template-areas: 'header' 'hero' 'main' 'aside' 'footer';
 
-		// note that to make some extra room this layout is not constrained by the widescreen breakpoint like others
 		@include mixins.tablet {
 			grid-template:
 				minmax(auto, max-content) auto var(--atlas-contained-height) auto / minmax(0, 1fr)
@@ -533,6 +294,22 @@ $layout-menu-collapsed-width: 96px !default;
 				'footer footer footer';
 		}
 	}
+}
+
+.layout.layout-aside-collapsed {
+	#{tokens.$layout-aside-width-name}: var(#{tokens.$layout-aside-collapsed-width-name});
+	#{tokens.$layout-aside-spacer-width-name}: calc(
+		var(#{tokens.$layout-aside-expanded-target-width-name}) -
+			var(#{tokens.$layout-aside-collapsed-width-name})
+	);
+}
+
+.layout.layout-menu-collapsed {
+	#{tokens.$layout-menu-width-name}: var(#{tokens.$layout-menu-collapsed-width-name});
+	#{tokens.$layout-menu-spacer-width-name}: calc(
+		var(#{tokens.$layout-menu-expanded-target-width-name}) -
+			var(#{tokens.$layout-menu-collapsed-width-name})
+	);
 }
 
 @mixin constrained-layout-child {
@@ -599,5 +376,4 @@ $layout-menu-collapsed-width: 96px !default;
 		}
 	}
 }
-
 /* stylelint-enable */

--- a/css/src/components/site-header.scss
+++ b/css/src/components/site-header.scss
@@ -72,10 +72,6 @@ $site-header-panel-featured-section-border: 1px solid tokens.$table-border-dark 
 	gap: $site-header-inline-gap;
 	padding-inline: tokens.$layout-gap;
 
-	@include mixins.widescreen {
-		padding-inline: tokens.$layout-widescreen-gap;
-	}
-
 	.site-header-button {
 		@include mixins.control;
 		@include mixins.unselectable;
@@ -201,10 +197,6 @@ $site-header-panel-featured-section-border: 1px solid tokens.$table-border-dark 
 
 		@include mixins.desktop {
 			grid-template-columns: auto 25%;
-		}
-
-		@include mixins.widescreen {
-			padding-inline: tokens.$layout-widescreen-gap;
 		}
 
 		.site-header-panel-featured-content {

--- a/css/src/mixins/layout-gap.scss
+++ b/css/src/mixins/layout-gap.scss
@@ -3,8 +3,4 @@
 
 %layout-gap {
 	padding-inline: tokens.$layout-gap;
-
-	@include media-queries.widescreen {
-		padding-inline: tokens.$layout-widescreen-gap;
-	}
 }

--- a/css/src/mixins/layout-gap.scss
+++ b/css/src/mixins/layout-gap.scss
@@ -1,6 +1,7 @@
 @use '../tokens/index.scss' as tokens;
+@use '../tokens/layout.scss' as layout;
 @use './media-queries.scss' as media-queries;
 
 %layout-gap {
-	padding-inline: tokens.$layout-gap;
+	padding-inline: var(#{layout.$layout-gap-custom-property-name});
 }

--- a/css/src/tokens/layout.scss
+++ b/css/src/tokens/layout.scss
@@ -22,6 +22,12 @@ $layout-gap-scalable-custom-property-name: '--layout-gap-scalable' !default;
 $layout-flyout-width-name: '--layout-flyout-width' !default;
 $layout-flyout-width-desktop-custom-property-name: '--layout-flyout-width-desktop' !default;
 $layout-flyout-width-widescreen-custom-property-name: '--layout-flyout-width-widescreen' !default;
+$layout-menu-width-name: '--layout-menu-width' !default;
 $layout-menu-collapsed-width-name: '--layout-menu-collapsed-width' !default;
-$layout-menu-collapsed-width-widescreen-spacer-width-name: '--layout-menu-collapsed-width-widescreen' !default;
+$layout-menu-expanded-target-width-name: '--layout-menu-expanded-target-width' !default;
+$layout-aside-width-name: '--layout-aside-width' !default;
+$layout-aside-collapsed-width-name: '--layout-aside-collapsed-width' !default;
+$layout-aside-expanded-target-width-name: '--layout-aside-expanded-target-width' !default;
+$layout-menu-spacer-width-name: '--layout-menu-spacer-width' !default;
+$layout-aside-spacer-width-name: '--layout-aside-spacer-width' !default;
 //@end-sass-export-section

--- a/integration/tests/layout.spec.ts
+++ b/integration/tests/layout.spec.ts
@@ -539,7 +539,9 @@ test('aside-collapsed modifier collapses aside on holy-grail layout at widescree
 	await expect(aside).toBeVisible();
 
 	// Get aside width before collapse
-	const widthBefore = await aside.evaluate(el => el.getBoundingClientRect().width);
+	const boxBefore = await aside.boundingBox();
+	expect(boxBefore).not.toBeNull();
+	const widthBefore = boxBefore!.width;
 
 	// Toggle aside-collapsed modifier
 	await page.locator(toggleAsideCollapsedSelector).click();
@@ -549,8 +551,9 @@ test('aside-collapsed modifier collapses aside on holy-grail layout at widescree
 
 	// Aside should still be visible but narrower
 	await expect(aside).toBeVisible();
-	const widthAfter = await aside.evaluate(el => el.getBoundingClientRect().width);
-	expect(widthAfter).toBeLessThan(widthBefore);
+	const boxAfter = await aside.boundingBox();
+	expect(boxAfter).not.toBeNull();
+	expect(boxAfter!.width).toBeLessThan(widthBefore);
 
 	// Main should still be visible
 	const main = layoutWithModifier.locator('.layout-body-main');
@@ -558,8 +561,13 @@ test('aside-collapsed modifier collapses aside on holy-grail layout at widescree
 
 	// Toggle again to expand aside
 	await page.locator(toggleAsideCollapsedSelector).click();
-	const widthRestored = await aside.evaluate(el => el.getBoundingClientRect().width);
-	expect(widthRestored).toBeGreaterThan(widthAfter);
+	await expect(layoutWithModifier).toBeHidden();
+	// Wait for view transition to complete and aside to reach expanded width
+	await expect(async () => {
+		const boxRestored = await aside.boundingBox();
+		expect(boxRestored).not.toBeNull();
+		expect(boxRestored!.width).toBeGreaterThan(boxAfter!.width);
+	}).toPass();
 });
 
 test('aside-collapsed modifier collapses aside on sidecar-right layout at widescreen @desktop', async ({
@@ -584,7 +592,9 @@ test('aside-collapsed modifier collapses aside on sidecar-right layout at widesc
 	await expect(aside).toBeVisible();
 
 	// Get aside width before collapse
-	const widthBefore = await aside.evaluate(el => el.getBoundingClientRect().width);
+	const boxBefore = await aside.boundingBox();
+	expect(boxBefore).not.toBeNull();
+	const widthBefore = boxBefore!.width;
 
 	// Toggle aside-collapsed modifier
 	await page.locator(toggleAsideCollapsedSelector).click();
@@ -594,8 +604,9 @@ test('aside-collapsed modifier collapses aside on sidecar-right layout at widesc
 
 	// Aside should still be visible but narrower
 	await expect(aside).toBeVisible();
-	const widthAfter = await aside.evaluate(el => el.getBoundingClientRect().width);
-	expect(widthAfter).toBeLessThan(widthBefore);
+	const boxAfter = await aside.boundingBox();
+	expect(boxAfter).not.toBeNull();
+	expect(boxAfter!.width).toBeLessThan(widthBefore);
 
 	// Main should still be visible
 	const main = layoutWithModifier.locator('.layout-body-main');
@@ -603,51 +614,11 @@ test('aside-collapsed modifier collapses aside on sidecar-right layout at widesc
 
 	// Toggle again to expand aside
 	await page.locator(toggleAsideCollapsedSelector).click();
-	const widthRestored = await aside.evaluate(el => el.getBoundingClientRect().width);
-	expect(widthRestored).toBeGreaterThan(widthAfter);
-});
-
-test('aside-collapsed modifier collapses aside on twin layout at widescreen @desktop', async ({
-	page
-}, testInfo) => {
-	test.skip(
-		testInfo.project.name !== 'Widescreen Chromium',
-		'Skip test if display screen is not widescreen'
-	);
-
-	await page.goto('/components/layout.html');
-	await page.waitForLoadState('domcontentloaded');
-
-	// Switch to twin layout
-	await page.locator(setTwinLayoutSelector).click();
-	await page.waitForTimeout(300);
-
-	const layoutHtml = page.locator('.layout.layout-twin');
-	await expect(layoutHtml).toBeVisible();
-
-	const aside = page.locator('.layout-body-aside');
-	await expect(aside).toBeVisible();
-
-	// Get aside width before collapse
-	const widthBefore = await aside.evaluate(el => el.getBoundingClientRect().width);
-
-	// Toggle aside-collapsed modifier
-	await page.locator(toggleAsideCollapsedSelector).click();
-
-	const layoutWithModifier = page.locator('.layout.layout-twin.layout-aside-collapsed');
-	await expect(layoutWithModifier).toBeVisible();
-
-	// Aside should still be visible but narrower
-	await expect(aside).toBeVisible();
-	const widthAfter = await aside.evaluate(el => el.getBoundingClientRect().width);
-	expect(widthAfter).toBeLessThan(widthBefore);
-
-	// Main should still be visible
-	const main = layoutWithModifier.locator('.layout-body-main');
-	await expect(main).toBeVisible();
-
-	// Toggle again to expand aside
-	await page.locator(toggleAsideCollapsedSelector).click();
-	const widthRestored = await aside.evaluate(el => el.getBoundingClientRect().width);
-	expect(widthRestored).toBeGreaterThan(widthAfter);
+	await expect(layoutWithModifier).toBeHidden();
+	// Wait for view transition to complete and aside to reach expanded width
+	await expect(async () => {
+		const boxRestored = await aside.boundingBox();
+		expect(boxRestored).not.toBeNull();
+		expect(boxRestored!.width).toBeGreaterThan(boxAfter!.width);
+	}).toPass();
 });

--- a/integration/tests/layout.spec.ts
+++ b/integration/tests/layout.spec.ts
@@ -6,6 +6,7 @@ const setTwinLayoutSelector = '[data-set-layout="layout-twin"]';
 const setSidecarLeftLayoutSelector = '[data-set-layout="layout-sidecar-left"]';
 const setSidecarRightLayoutSelector = '[data-set-layout="layout-sidecar-right"]';
 const toggleMenuCollapsedSelector = '#main [data-menu-collapse-toggle]';
+const toggleAsideCollapsedSelector = '#main [data-aside-collapse-toggle]';
 const constrainLayoutSelector = '[data-toggle-layout-height-constraint]';
 const hideHeroSelector = '[data-toggle-hero-visibility]';
 const toggleFlyoutSelector = '[data-toggle-flyout-visibility]';
@@ -517,4 +518,136 @@ test('menu-collapsed modifier collapses menu on sidecar-left layout at widescree
 	await page.locator(toggleMenuCollapsedSelector).click();
 	await expect(menuContent).toBeVisible();
 	await expect(collapsedButton).toBeHidden();
+});
+
+test('aside-collapsed modifier collapses aside on holy-grail layout at widescreen @desktop', async ({
+	page
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'Widescreen Chromium',
+		'Skip test if display screen is not widescreen'
+	);
+
+	await page.goto('/components/layout.html');
+	await page.waitForLoadState('domcontentloaded');
+
+	// Ensure we're on holy-grail layout (default)
+	const layoutHtml = page.locator('.layout.layout-holy-grail');
+	await expect(layoutHtml).toBeVisible();
+
+	const aside = page.locator('.layout-body-aside');
+	await expect(aside).toBeVisible();
+
+	// Get aside width before collapse
+	const widthBefore = await aside.evaluate(el => el.getBoundingClientRect().width);
+
+	// Toggle aside-collapsed modifier
+	await page.locator(toggleAsideCollapsedSelector).click();
+
+	const layoutWithModifier = page.locator('.layout.layout-holy-grail.layout-aside-collapsed');
+	await expect(layoutWithModifier).toBeVisible();
+
+	// Aside should still be visible but narrower
+	await expect(aside).toBeVisible();
+	const widthAfter = await aside.evaluate(el => el.getBoundingClientRect().width);
+	expect(widthAfter).toBeLessThan(widthBefore);
+
+	// Main should still be visible
+	const main = layoutWithModifier.locator('.layout-body-main');
+	await expect(main).toBeVisible();
+
+	// Toggle again to expand aside
+	await page.locator(toggleAsideCollapsedSelector).click();
+	const widthRestored = await aside.evaluate(el => el.getBoundingClientRect().width);
+	expect(widthRestored).toBeGreaterThan(widthAfter);
+});
+
+test('aside-collapsed modifier collapses aside on sidecar-right layout at widescreen @desktop', async ({
+	page
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'Widescreen Chromium',
+		'Skip test if display screen is not widescreen'
+	);
+
+	await page.goto('/components/layout.html');
+	await page.waitForLoadState('domcontentloaded');
+
+	// Switch to sidecar-right layout
+	await page.locator(setSidecarRightLayoutSelector).click();
+	await page.waitForTimeout(300);
+
+	const layoutHtml = page.locator('.layout.layout-sidecar-right');
+	await expect(layoutHtml).toBeVisible();
+
+	const aside = page.locator('.layout-body-aside');
+	await expect(aside).toBeVisible();
+
+	// Get aside width before collapse
+	const widthBefore = await aside.evaluate(el => el.getBoundingClientRect().width);
+
+	// Toggle aside-collapsed modifier
+	await page.locator(toggleAsideCollapsedSelector).click();
+
+	const layoutWithModifier = page.locator('.layout.layout-sidecar-right.layout-aside-collapsed');
+	await expect(layoutWithModifier).toBeVisible();
+
+	// Aside should still be visible but narrower
+	await expect(aside).toBeVisible();
+	const widthAfter = await aside.evaluate(el => el.getBoundingClientRect().width);
+	expect(widthAfter).toBeLessThan(widthBefore);
+
+	// Main should still be visible
+	const main = layoutWithModifier.locator('.layout-body-main');
+	await expect(main).toBeVisible();
+
+	// Toggle again to expand aside
+	await page.locator(toggleAsideCollapsedSelector).click();
+	const widthRestored = await aside.evaluate(el => el.getBoundingClientRect().width);
+	expect(widthRestored).toBeGreaterThan(widthAfter);
+});
+
+test('aside-collapsed modifier collapses aside on twin layout at widescreen @desktop', async ({
+	page
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'Widescreen Chromium',
+		'Skip test if display screen is not widescreen'
+	);
+
+	await page.goto('/components/layout.html');
+	await page.waitForLoadState('domcontentloaded');
+
+	// Switch to twin layout
+	await page.locator(setTwinLayoutSelector).click();
+	await page.waitForTimeout(300);
+
+	const layoutHtml = page.locator('.layout.layout-twin');
+	await expect(layoutHtml).toBeVisible();
+
+	const aside = page.locator('.layout-body-aside');
+	await expect(aside).toBeVisible();
+
+	// Get aside width before collapse
+	const widthBefore = await aside.evaluate(el => el.getBoundingClientRect().width);
+
+	// Toggle aside-collapsed modifier
+	await page.locator(toggleAsideCollapsedSelector).click();
+
+	const layoutWithModifier = page.locator('.layout.layout-twin.layout-aside-collapsed');
+	await expect(layoutWithModifier).toBeVisible();
+
+	// Aside should still be visible but narrower
+	await expect(aside).toBeVisible();
+	const widthAfter = await aside.evaluate(el => el.getBoundingClientRect().width);
+	expect(widthAfter).toBeLessThan(widthBefore);
+
+	// Main should still be visible
+	const main = layoutWithModifier.locator('.layout-body-main');
+	await expect(main).toBeVisible();
+
+	// Toggle again to expand aside
+	await page.locator(toggleAsideCollapsedSelector).click();
+	const widthRestored = await aside.evaluate(el => el.getBoundingClientRect().width);
+	expect(widthRestored).toBeGreaterThan(widthAfter);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,10 +33,10 @@
 		},
 		"css": {
 			"name": "@microsoft/atlas-css",
-			"version": "4.3.0",
+			"version": "5.0.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@microsoft/stylelint-config-atlas": "4.1.0",
+				"@microsoft/stylelint-config-atlas": "5.0.0",
 				"@parcel/transformer-sass": "2.16.3",
 				"css-tree": "^2.3.1",
 				"eslint-plugin-security": "^1.7.1",
@@ -275,9 +275,9 @@
 		},
 		"extension": {
 			"name": "atlas-design-system-tools",
-			"version": "0.0.8",
+			"version": "0.0.9",
 			"dependencies": {
-				"@microsoft/atlas-css": "^4.0.0"
+				"@microsoft/atlas-css": "^5.0.0"
 			},
 			"devDependencies": {
 				"@types/glob": "^8.1.0",
@@ -17460,7 +17460,7 @@
 		},
 		"plugins/stylelint-config-atlas": {
 			"name": "@microsoft/stylelint-config-atlas",
-			"version": "4.1.0",
+			"version": "5.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"postcss-scss": "^4.0.9",
@@ -17668,10 +17668,10 @@
 		},
 		"site": {
 			"name": "@microsoft/atlas-site",
-			"version": "0.67.0",
+			"version": "1.0.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@microsoft/atlas-css": "4.3.0",
+				"@microsoft/atlas-css": "5.0.0",
 				"@microsoft/atlas-js": "^1.15.0",
 				"@microsoft/parcel-transformer-markdown-html": "2.7.2",
 				"@parcel/transformer-sass": "2.16.3",

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -16,20 +16,21 @@ The layout component provides a flexible and efficient way to structure the majo
 
 This page is utilizing the holy grail layout, but you can use the buttons below to toggle layouts and test them out by resizing the screen. Try the "Toggle container labels" button below to see the css classes on each of the containers inside `.layout`.
 
-<div class="buttons buttons-addons margin-top-sm display-flex">
+<div class="buttons buttons-addons margin-top-sm">
   <button class="button" data-set-layout="layout-holy-grail" aria-pressed="true">Holy grail</button>
   <button class="button" data-set-layout="layout-twin">Twin</button>
   <button class="button" data-set-layout="layout-single">Single</button>
   <button class="button" data-set-layout="layout-sidecar-left">Sidecar left</button>
   <button class="button" data-set-layout="layout-sidecar-right">Sidecar right</button>
 </div>
-<div class="buttons buttons-addons display-flex">
+<div class="buttons">
 	<button class="button" data-menu-collapse-toggle aria-expanded="true">Collapse menu</button>
+	<button class="button" data-aside-collapse-toggle aria-expanded="true">Collapse aside</button>
 	<button class="button" data-toggle-debug aria-pressed="false">Toggle container labels</button>
 	<button class="button" data-toggle-layout-height-constraint aria-pressed="false">Constrain layout height</button>
 	
 </div>
-<div class="buttons buttons-addons display-flex">
+<div class="buttons">
 	<button class="button button-filled" data-toggle-hero-visibility aria-pressed="true">Toggle hero</button>
 	<button class="button button-filled" data-toggle-footer-visibility aria-pressed="true">Toggle footer</button>
 	<button class="button" data-toggle-flyout-visibility aria-pressed="false">Toggle flyout</button>
@@ -79,7 +80,7 @@ The layout components behavior is inextricably bound to Atlas's breakpoints. On 
 
 ## Available layouts
 
-There are two available layouts.
+There are five available layouts.
 
 - [`layout-single`](#layout-single)
 - [`layout-holy-grail`](#holy-grail-layout)
@@ -100,6 +101,8 @@ Allowed elements: all.
 Can have its height constrained? No.
 
 Can have its menu collapsed? No.
+
+Can have its aside collapsed? No.
 
 ```Text
    Narrow
@@ -138,10 +141,12 @@ Can have its height constrained? Yes, on desktop screens and wider. This differs
 
 Can have its menu collapsed? Yes, on tablet screens and wider.
 
+Can have its aside collapsed? Yes, on desktop screens and wider.
+
 The following block is arranged from narrow widths on the left to wider widths on the right.
 
 ```Text
-   Narrow         Tablet           Widescreen
+   Narrow         Tablet           Desktop
   ┌────────────┐ ┌──────────────┐ ┌──────────────────────┐
   │ Header     │ │Header        │ │ Header               │
   ├────────────┤ ├──────────────┤ ├──────────────────────┤
@@ -159,12 +164,11 @@ The following block is arranged from narrow widths on the left to wider widths o
 
 The specification for this layout is as follows.
 
-| Screensize | Behavior                                                                                                                      |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| Narrow     | All elements are stacked.                                                                                                     |
-| Tablet     | Menu and main are side by side. Main is wider than menu. Aside has a collapsed height and is tucked under main.               |
-| Desktop    | Menu, main, aside are side by side. Main is wider than menu.                                                                  |
-| Widescreen | Same as desktop with scaling gutter that keeps combined width of menu, main, aside to the width of the widescreen breakpoint. |
+| Screensize | Behavior                                                                                                        |
+| ---------- | --------------------------------------------------------------------------------------------------------------- |
+| Narrow     | All elements are stacked.                                                                                       |
+| Tablet     | Menu and main are side by side. Main is wider than menu. Aside has a collapsed height and is tucked under main. |
+| Desktop    | Menu, main, aside are side by side. Main is wider than menu.                                                    |
 
 ### Sidecar left layout
 
@@ -180,32 +184,33 @@ Can have its height constrained? Yes, on tablet screens and wider.
 
 Can have its menu collapsed? Yes, on tablet screens and wider.
 
+Can have its aside collapsed? No (aside is not present).
+
 The following block is arranged from narrow widths on the left to wider widths on the right.
 
 ```txt
-   Narrow           Tablet           Widescreen
-  ┌────────────┐   ┌──────────────┐ ┌──────────────────────┐
-  │ Header     │   │Header        │ │ Header               │
-  ├────────────┤   ├──────────────┤ ├──────────────────────┤
-  │ Hero       │   │Hero          │ │ Hero                 │
-  ├────────────┤   ├─────┬────────┤ ├──────┬───────────────┤
-  │ Menu       │   │Menu │ Main   │ │ Menu │ Main          │
-  ├────────────┤   │     │        │ │      │               │
-  │ Main       │   │     │        │ │      │               │
-  │            │   │     │        │ │      │               │
-  │            │   │     │        │ │      │               │
-  ├────────────┤   ├─────┴────────┤ ├──────┴───────────────┤
-  │ Footer     │   │Footer        │ │ Footer               │
-  └────────────┘   └──────────────┘ └──────────────────────┘
+   Narrow           Tablet and wider
+  ┌────────────┐   ┌──────────────┐
+  │ Header     │   │Header        │
+  ├────────────┤   ├──────────────┤
+  │ Hero       │   │Hero          │
+  ├────────────┤   ├─────┬────────┤
+  │ Menu       │   │Menu │ Main   │
+  ├────────────┤   │     │        │
+  │ Main       │   │     │        │
+  │            │   │     │        │
+  │            │   │     │        │
+  ├────────────┤   ├─────┴────────┤
+  │ Footer     │   │Footer        │
+  └────────────┘   └──────────────┘
 ```
 
 The specification for this layout is as follows.
 
-| Screensize       | Behavior                                                                                                                         |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| Narrow           | All elements are stacked.                                                                                                        |
-| Tablet - desktop | Menu and main are side by side. Main is wider than menu.                                                                         |
-| Widescreen       | Same as tablet-desktop with scaling gutter that keeps combined width of menu and main to the width of the widescreen breakpoint. |
+| Screensize       | Behavior                                                 |
+| ---------------- | -------------------------------------------------------- |
+| Narrow           | All elements are stacked.                                |
+| Tablet and wider | Menu and main are side by side. Main is wider than menu. |
 
 ### Sidecar right layout
 
@@ -219,34 +224,35 @@ Allowed elements: all except `layout-body-menu`.
 
 Can have its height constrained? Yes, on tablet screens and wider.
 
-Can have its menu collapsed? No
+Can have its menu collapsed? No.
+
+Can have its aside collapsed? Yes, on tablet screens and wider.
 
 The following block is arranged from narrow widths on the left to wider widths on the right.
 
 ```txt
-  Narrow           Tablet                   Widescreen
- ┌──────────────┐ ┌──────────────────────┐ ┌──────────────────────┐
- │Header        │ │ Header               │ │ Header               │
- ├──────────────┤ ├──────────────────────┤ ├──────────────────────┤
- │Hero          │ │ Hero                 │ │ Hero                 │
- ├──────────────┤ ├───────────────┬──────┤ ├───────────────┬──────┤
- │Main          │ │ Main          │ Aside│ │ Main          │ Aside│
- │              │ │               │      │ │               │      │
- │              │ │               │      │ │               │      │
- ├──────────────┤ │               │      │ │               │      │
- │Aside         │ │               │      │ │               │      │
- ├──────────────┤ ├───────────────┴──────┤ ├───────────────┴──────┤
- │Footer        │ │ Footer               │ │ Footer               │
- └──────────────┘ └──────────────────────┘ └──────────────────────┘
+  Narrow           Tablet and wider
+ ┌──────────────┐ ┌──────────────────────┐
+ │Header        │ │ Header               │
+ ├──────────────┤ ├──────────────────────┤
+ │Hero          │ │ Hero                 │
+ ├──────────────┤ ├───────────────┬──────┤
+ │Main          │ │ Main          │ Aside│
+ │              │ │               │      │
+ │              │ │               │      │
+ ├──────────────┤ │               │      │
+ │Aside         │ │               │      │
+ ├──────────────┤ ├───────────────┴──────┤
+ │Footer        │ │ Footer               │
+ └──────────────┘ └──────────────────────┘
 ```
 
 The specification for this layout is as follows.
 
-| Screensize       | Behavior                                                                                                                          |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| Narrow           | All elements are stacked.                                                                                                         |
-| Tablet - desktop | Main and aside are side by side. Main is wider than aside.                                                                        |
-| Widescreen       | Same as tablet-desktop with scaling gutter that keeps combined width of main and aside to the width of the widescreen breakpoint. |
+| Screensize       | Behavior                                                   |
+| ---------------- | ---------------------------------------------------------- |
+| Narrow           | All elements are stacked.                                  |
+| Tablet and wider | Main and aside are side by side. Main is wider than aside. |
 
 ### Twin layout
 
@@ -259,6 +265,8 @@ Required elements: all except `layout-body-hero` and `layout-body-menu` (see all
 Allowed elements: all except `layout-body-menu`.
 
 Can have its height constrained? Yes, on tablet screens and wider.
+
+Can have its aside collapsed? Yes, on tablet screens and wider.
 
 The following block is arranged from narrow widths on the left to wider widths on the right.
 
@@ -313,9 +321,7 @@ A flyout is a container that appears on the side of the screen. It provides addi
 
 1. **It is not available on narrow and tablet-size screens.** There simply isn't room for it. This means that whatever content is available in this sidebar, should be rendered elsewhere on narrow/tablet screen sizes. Typically, this would be done in a modal that renders "on top" of the other containers. Atlas does not implement this for you.
 1. The flyout can be shown/hidden by adding/removing the `.layout-flyout-active` class to the `.layout` element.
-1. The default widths of the flyout on both desktop and widescreen can be customized with the following CSS variables.
-   1. `--layout-flyout-width-desktop` will affect the desktop breakpoint.
-   1. `--layout-flyout-width-widescreen` will affect the widescreen (largest) breakpoint.
+1. The default width of the flyout on desktop can be customized with the `--layout-flyout-width-desktop` CSS variable.
 1. This means developers must handle mobile and tablet widths with a different solution, such using a modal on narrow screens.
 1. On expand/collapse of the flyout, it's recommended developers perform manual focus handling to ensure that focus is not lost for screenreaders.
 1. The same should happen on resize.
@@ -323,6 +329,10 @@ A flyout is a container that appears on the side of the screen. It provides addi
 ## Collapsing the left-hand menu
 
 In certain scenarios, it may be advantageous to collapse the left-hand menu element on layouts that have this container. To do this, add `.layout-menu-collapsed` to the `html` element of your page. This will hide the menu element and rearrange containers on layouts that support it, such as `layout-holy-grail` and `layout-sidecar-left`.
+
+## Collapsing the right-hand aside
+
+Similarly, the right-hand aside can be collapsed by adding `.layout-aside-collapsed` to the `html` element. This narrows the aside to a minimal width on layouts that support it: `layout-holy-grail`, `layout-sidecar-right`, and `layout-twin`.
 
 ## Accessibility Concerns
 
@@ -342,6 +352,55 @@ Grid areas, the CSS feature powering the layout component, have the potential to
 1. Footer
 
 See WCAG on [Making the DOM order match the visual order](https://www.w3.org/TR/WCAG20-TECHS/C27.html) for more information on this topic.
+
+## Customizing layout dimensions with CSS variables
+
+The layout component exposes several CSS custom properties that let you tune column widths and spacing without writing new grid definitions. Override these variables on the `.layout` element (or any ancestor) to customize dimensions site-wide, or scope them to a specific page.
+
+### Menu and aside widths
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `--layout-menu-expanded-target-width` | `275px` | The width of the menu column when expanded. |
+| `--layout-menu-collapsed-width` | `68px` | The width of the menu column when collapsed via `.layout-menu-collapsed`. |
+| `--layout-aside-expanded-target-width` | `275px` | The width of the aside column when expanded. |
+| `--layout-aside-collapsed-width` | `68px` | The width of the aside column when collapsed via `.layout-aside-collapsed`. |
+
+For example, to make the menu wider on a particular page:
+
+```css
+.layout {
+	--layout-menu-expanded-target-width: 350px;
+}
+```
+
+Or to make the aside narrower:
+
+```css
+.layout {
+	--layout-aside-expanded-target-width: 200px;
+}
+```
+
+### Flyout width
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `--layout-flyout-width-desktop` | `320px` | The width of the flyout container on desktop screens. |
+
+```css
+.layout {
+	--layout-flyout-width-desktop: 400px;
+}
+```
+
+### Layout gap
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `--layout-gap` | `16px` (narrow), `24px` (desktop) | The inline padding applied by `.layout-padding` and consumed by full-width elements like hero and site header. |
+
+These variables are consumed by the grid definitions internally — you do not need to redefine any grid templates. Simply set the variable and the layout will adapt.
 
 ## Advanced topic - switching layouts on the fly
 

--- a/site/src/scaffold/scripts/full-screen-toggle.ts
+++ b/site/src/scaffold/scripts/full-screen-toggle.ts
@@ -13,12 +13,14 @@ export function initFullScreenToggle() {
 async function handleFullscreen() {
 	const main = document.getElementById('main');
 	const article = document.getElementById('article');
-	if (!main || !article) {
+	const mainColumn = document.getElementById('main-column');
+	if (!main || !article || !mainColumn) {
 		return;
 	}
 
 	const isFullScreened = main?.dataset.isFullScreened === 'true';
 	if (!isFullScreened) {
+		mainColumn.classList.remove('reading-width');
 		article.style.overflow = 'visible';
 		main.style.display = 'block';
 		main.style.overflowX = 'auto';
@@ -27,6 +29,7 @@ async function handleFullscreen() {
 	} else {
 		main.dataset.isFullScreened = 'false';
 		article.style.cssText = '';
+		mainColumn.classList.add('reading-width');
 
 		if (document.fullscreenElement) {
 			await document.exitFullscreen();

--- a/site/src/scaffold/scripts/layout-page.ts
+++ b/site/src/scaffold/scripts/layout-page.ts
@@ -43,12 +43,20 @@ export function initLayoutPageControls() {
 		}
 
 		safeViewTransition(() => {
-			if (!collapseBehaviorAllowed(layoutToSet)) {
+			if (!menuCollapseBehaviorAllowed(layoutToSet)) {
 				const collapseTrigger = document.querySelector(
 					'[data-menu-collapse-toggle]'
 				) as HTMLButtonElement;
 				if (collapseTrigger) {
 					handleMenuCollapse(collapseTrigger, false);
+				}
+			}
+			if (!asideCollapseBehaviorAllowed(layoutToSet)) {
+				const collapseTrigger = document.querySelector(
+					'[data-aside-collapse-toggle]'
+				) as HTMLButtonElement;
+				if (collapseTrigger) {
+					handleAsideCollapse(collapseTrigger, false);
 				}
 			}
 			setLayoutClass(layoutToSet);
@@ -98,13 +106,33 @@ export function initLayoutPageControls() {
 		}
 
 		const currentLayout = getCurrentLayoutClass();
-		if (!collapseBehaviorAllowed(currentLayout)) {
+		if (!menuCollapseBehaviorAllowed(currentLayout)) {
 			return;
 		}
 
 		const isCollapsed = document.documentElement.classList.contains('layout-menu-collapsed');
 		safeViewTransition(() => {
 			handleMenuCollapse(trigger, !isCollapsed);
+		});
+	});
+
+	// Aside collapse behavior
+	window.addEventListener('click', (e: MouseEvent) => {
+		const trigger =
+			e.target instanceof Element &&
+			(e.target.closest('[data-aside-collapse-toggle]') as HTMLElement);
+		if (!trigger) {
+			return;
+		}
+
+		const currentLayout = getCurrentLayoutClass();
+		if (!asideCollapseBehaviorAllowed(currentLayout)) {
+			return;
+		}
+
+		const isCollapsed = document.documentElement.classList.contains('layout-aside-collapsed');
+		safeViewTransition(() => {
+			handleAsideCollapse(trigger, !isCollapsed);
 		});
 	});
 
@@ -211,6 +239,25 @@ function safeViewTransition(cb: () => void) {
 	}
 }
 
-function collapseBehaviorAllowed(layoutClass: string) {
+function handleAsideCollapse(trigger: HTMLElement, shouldCollapse: boolean) {
+	const method: 'add' | 'remove' = shouldCollapse ? 'add' : 'remove';
+	// eslint-disable-next-line security/detect-object-injection
+	trigger.classList[method]('button-filled');
+	trigger.setAttribute('aria-expanded', String(!shouldCollapse));
+	// eslint-disable-next-line security/detect-object-injection
+	document.documentElement.classList[method]('layout-aside-collapsed');
+
+	window.dispatchEvent(new CustomEvent('atlas-layout-change-event'));
+}
+
+function menuCollapseBehaviorAllowed(layoutClass: string) {
 	return layoutClass === 'layout-holy-grail' || layoutClass === 'layout-sidecar-left';
+}
+
+function asideCollapseBehaviorAllowed(layoutClass: string) {
+	return (
+		layoutClass === 'layout-holy-grail' ||
+		layoutClass === 'layout-sidecar-right' ||
+		layoutClass === 'layout-twin'
+	);
 }

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -14,7 +14,7 @@
 		<link rel="icon" href="~/src/atlas-light.svg" type="image/svg+xml">
 	</head>
 	<body id="body" class="layout-body">
-		<header id="header" class="layout-body-header">
+		<header id="header" class="layout-body-header background-color-body-medium">
 			<div id="header-body" class="site-header justify-content-space-between">
 				<div class="display-flex justify-content-flex-start align-items-center gap-xxs">
 					<!-- MS logo -->
@@ -72,39 +72,41 @@
 		</section>
 		{{/hero}}
 
-		<nav id="menu" class="layout-body-menu background-color-body">
-			{{#toc}}
-				<div id="menu-content" class="display-none display-block-tablet layout-padding padding-block-md hide-on-menu-collapsed">
-					<button data-full-screen-nav type="button" class="display-none burger button button-clear position-fixed margin-right-sm margin-top-sm top-0 right-0" aria-label="Mobile menu toggle">
-						<span class="burger-top"></span>
-						<span class="burger-middle"></span>
-						<span class="burger-bottom"></span>
-					</button>
-					{{#entries}}
-						
-						{{#isDirectory}}
-							<div>
-								<p class="font-weight-bold font-size-xl  {{#isFirst}}margin-bottom-xxs{{/isFirst}}{{^isFirst}}margin-bottom-xxs margin-top-sm{{/isFirst}}">{{name}}</p>
-								<div class="">
-									{{#children}}
-										<a class="display-block text-decoration-none margin-top-xxs font-weight-semibold font-size-lg" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
-									{{/children}}
+		<nav id="menu" class="layout-body-menu background-color-body-medium border-right">
+			<div>
+				{{#toc}}
+					<div id="menu-content" class="display-none display-block-tablet layout-padding padding-block-md hide-on-menu-collapsed">
+						<button data-full-screen-nav type="button" class="display-none burger button button-clear position-fixed margin-right-sm margin-top-sm top-0 right-0" aria-label="Mobile menu toggle">
+							<span class="burger-top"></span>
+							<span class="burger-middle"></span>
+							<span class="burger-bottom"></span>
+						</button>
+						{{#entries}}
+							
+							{{#isDirectory}}
+								<div>
+									<p class="font-weight-bold font-size-xl  {{#isFirst}}margin-bottom-xxs{{/isFirst}}{{^isFirst}}margin-bottom-xxs margin-top-sm{{/isFirst}}">{{name}}</p>
+									<div class="">
+										{{#children}}
+											<a class="display-block text-decoration-none margin-top-xxs font-weight-semibold font-size-lg" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+										{{/children}}
+									</div>
 								</div>
-							</div>
-						{{/isDirectory}}
-						{{^children.0}}
-							<a class="font-size-lg display-block margin-top-xs margin-bottom-sm font-weight-semibold" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
-						{{/children.0}}
-					{{/entries}}
-				</div>
-			{{/toc}}
-			<button class="button button-clear show-on-menu-collapsed display-none display-inline-flex-tablet margin-left-sm margin-top-sm" data-menu-collapse-only-trigger aria-label="Expand menu" aria-expanded="false">
-				<span class="icon font-size-xl" aria-hidden="true">
-					<svg width="24" height="24" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-						<path class="fill-current-color" d="M9.647 9.147l.646-.647H8.502a.5.5 0 010-1h1.791l-.646-.646a.5.5 0 11.707-.707l1.5 1.5a.5.5 0 010 .707l-1.5 1.5a.5.5 0 11-.707-.707z"></path><path class="fill-current-color" d="M2 4.999a2 2 0 012-2h8a2 2 0 012 2v6.002a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm2-1a1 1 0 00-1 1v6.002a1 1 0 001 1h2.002V4H4zm3.002 0v8.002H12a1 1 0 001-1V5a1 1 0 00-1-1H7.002z"></path>
-					</svg>
-				</span>
-			</button>
+							{{/isDirectory}}
+							{{^children.0}}
+								<a class="font-size-lg display-block margin-top-xs margin-bottom-sm font-weight-semibold" href="{{{href}}}" {{#isHidden}}hidden{{/isHidden}}>{{name}}</a>
+							{{/children.0}}
+						{{/entries}}
+					</div>
+				{{/toc}}
+				<button class="button button-clear show-on-menu-collapsed display-none display-block-tablet margin-top-xxs margin-inline-auto" data-menu-collapse-only-trigger aria-label="Expand menu" aria-expanded="false">
+					<span class="icon font-size-xl" aria-hidden="true">
+						<svg width="24" height="24" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+							<path class="fill-current-color" d="M9.647 9.147l.646-.647H8.502a.5.5 0 010-1h1.791l-.646-.646a.5.5 0 11.707-.707l1.5 1.5a.5.5 0 010 .707l-1.5 1.5a.5.5 0 11-.707-.707z"></path><path class="fill-current-color" d="M2 4.999a2 2 0 012-2h8a2 2 0 012 2v6.002a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm2-1a1 1 0 00-1 1v6.002a1 1 0 001 1h2.002V4H4zm3.002 0v8.002H12a1 1 0 001-1V5a1 1 0 00-1-1H7.002z"></path>
+						</svg>
+					</span>
+				</button>
+			</div>
 		</nav>
 
 		<main id="main" class="layout-body-main">

--- a/site/src/scaffold/token.html
+++ b/site/src/scaffold/token.html
@@ -14,7 +14,7 @@
 		<link rel="icon" href="~/src/atlas-light.svg" type="image/svg+xml">
 	</head>
 	<body id="body" class="layout-body">
-		<header id="header" class="layout-body-header">
+		<header id="header" class="layout-body-header background-color-body-medium">
 			<div id="header-body" class="site-header justify-content-space-between">
 				<div class="display-flex justify-content-flex-start align-items-center gap-xxs">
 					<!-- MS logo -->
@@ -72,7 +72,7 @@
 		</section>
 		{{/hero}}
 
-		<nav id="menu" class="layout-body-menu background-color-body">
+		<nav id="menu" class="layout-body-menu background-color-body-medium border-right">
 			{{#toc}}
 				<div id="menu-content" class="display-none display-block-tablet layout-padding padding-block-md">
 					<button data-full-screen-nav type="button" class="display-none burger button button-clear position-fixed margin-right-sm margin-top-sm top-0 right-0" aria-label="Mobile menu toggle">


### PR DESCRIPTION
Remove max layout width, update layout sidebar width, allow collapsible right container (aside) and update several components to fit this new approach. This entails changing the site header, heroes, a few more components to not apply the previous max width. Not that the mixins that apply media queries targeting widescreen are available for use elsewhere. See active changesets for more details.

Links:

- [layouts](http://localhost:1111/components/layout.html)
- [site-header](http://localhost:1111/components/site-header.html)
- [hero](http://localhost:1111/components/hero.html)
- [banner](http://localhost:1111/components/banner.html)

## Testing

1. Run locally.
1. Visit layout page. Toggle container labels on and/or open dev tools. Toggle containers while resizing to various screen sizes.
2. Visit other component documentation pages. Expand page content to be full width. Resize screen.

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [x] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [x] Does your pull request change any transforms? Did you test they work on right to left?
