### PR TITLE
update h6 without changing variables

### DIFF
--- a/.changeset/chubby-memes-attack.md
+++ b/.changeset/chubby-memes-attack.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Revert former change that reassigned font-size-6 to 1rem, since font-size-7 was already that value. Applies font-size-7 to h6s in `.markdown` class.

--- a/css/src/components/markdown.scss
+++ b/css/src/components/markdown.scss
@@ -133,7 +133,7 @@ $list-top-spacing: 1rem !default;
 	}
 
 	h6 {
-		font-size: tokens.$font-size-6;
+		font-size: tokens.$font-size-7;
 		margin-block-start: 2.25rem;
 		margin-block-end: 0.375rem;
 		letter-spacing: 1px;

--- a/css/src/tokens/typography.scss
+++ b/css/src/tokens/typography.scss
@@ -10,11 +10,11 @@ $document-font-size: 16px;
 $font-size-9: 0.75rem !default; // 12px
 $font-size-8: 0.875rem !default; // 14px
 $font-size-7: 1rem !default; // 16px
-$font-size-6: 1rem !default; // 16px
+$font-size-6: 1.125rem !default; // 18px
 $font-size-5: 1.25rem !default; // 20px
 $font-size-4: 1.5rem !default; // 24px
 $font-size-3: 1.75rem !default; // 28px
-$font-size-2: 2rem !default; // 32px
+$font-size-2: 2rem !default; // 34px
 $font-size-1: 2.5rem !default; // 40px
 $font-size-0: 3.375rem !default; // 54px
 

--- a/css/src/tokens/typography.scss
+++ b/css/src/tokens/typography.scss
@@ -14,7 +14,7 @@ $font-size-6: 1.125rem !default; // 18px
 $font-size-5: 1.25rem !default; // 20px
 $font-size-4: 1.5rem !default; // 24px
 $font-size-3: 1.75rem !default; // 28px
-$font-size-2: 2rem !default; // 34px
+$font-size-2: 2rem !default; // 32px
 $font-size-1: 2.5rem !default; // 40px
 $font-size-0: 3.375rem !default; // 54px
 


### PR DESCRIPTION
Link: [preview](http://localhost:1111/)

Avoid untested affects downstream due to the re-assignment of a font-ramp value to a duplicative value. Keeps the ramp, simply using the font-size-7 value in the same place.

## Testing

1. Run locally, see h6s on markdown page and validate they are 1rem.

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.

