### PR TITLE
fix: resolve Dart Sass deprecation warnings

### DIFF
--- a/.changeset/major-flowers-sneeze.md
+++ b/.changeset/major-flowers-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Resolve Dart Sass deprecation warnings. `nth` to `list.nth`; `if(` to `@if `; `transparentize` to `color.adjust(color, alpha)`; `map-get` to `map.get`.

--- a/css/src/atomics/border.scss
+++ b/css/src/atomics/border.scss
@@ -1,3 +1,4 @@
+@use 'sass:list';
 @use '../tokens/index.scss' as tokens;
 @use '../mixins/index.scss' as mixins;
 
@@ -100,7 +101,7 @@
 // Colors
 
 @each $name, $color-set in tokens.$colors {
-	$base: nth($color-set, tokens.$color-index-base);
+	$base: list.nth($color-set, tokens.$color-index-base);
 
 	.border-color-#{$name} {
 		border-color: $base !important;

--- a/css/src/atomics/colors.scss
+++ b/css/src/atomics/colors.scss
@@ -1,15 +1,16 @@
+@use 'sass:list';
 @use '../tokens/index.scss' as tokens;
 @use '../mixins/index.scss' as mixins;
 
 // Framework colors
 
 @each $name, $color-set in tokens.$colors {
-	$base: nth($color-set, tokens.$color-index-base);
-	$background: nth($color-set, tokens.$color-index-background);
-	$dark: nth($color-set, tokens.$color-index-dark);
-	$hover: nth($color-set, tokens.$color-index-hover);
-	$active: nth($color-set, tokens.$color-index-active);
-	$invert: nth($color-set, tokens.$color-index-invert);
+	$base: list.nth($color-set, tokens.$color-index-base);
+	$background: list.nth($color-set, tokens.$color-index-background);
+	$dark: list.nth($color-set, tokens.$color-index-dark);
+	$hover: list.nth($color-set, tokens.$color-index-hover);
+	$active: list.nth($color-set, tokens.$color-index-active);
+	$invert: list.nth($color-set, tokens.$color-index-invert);
 
 	.color-#{$name} {
 		@if $name == 'warning' {
@@ -64,8 +65,8 @@
 
 @include mixins.tablet {
 	@each $name, $color-set in tokens.$colors {
-		$base: nth($color-set, tokens.$color-index-base);
-		$invert: nth($color-set, tokens.$color-index-invert);
+		$base: list.nth($color-set, tokens.$color-index-base);
+		$invert: list.nth($color-set, tokens.$color-index-invert);
 
 		.background-color-#{$name}-tablet {
 			outline-color: $invert;

--- a/css/src/atomics/gap.scss
+++ b/css/src/atomics/gap.scss
@@ -1,3 +1,4 @@
+@use 'sass:list';
 @use '../tokens/index.scss' as tokens;
 @use '../mixins/index.scss' as mixins;
 
@@ -16,12 +17,16 @@ $gap-sizes: (
 );
 
 @function sizeValue($key, $value) {
-	@return if($key == 'none', 0, $value);
+	@if $key == 'none' {
+		@return 0;
+	}
+
+	@return $value;
 }
 
 @each $size in $gap-sizes {
-	$sizeKey: nth($size, 1);
-	$sizeValue: nth($size, 2);
+	$sizeKey: list.nth($size, 1);
+	$sizeValue: list.nth($size, 2);
 
 	// .<property>-<value>
 	.gap#{$separator}#{$sizeKey} {
@@ -31,8 +36,8 @@ $gap-sizes: (
 
 @include mixins.tablet {
 	@each $size in $gap-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
+		$sizeKey: list.nth($size, 1);
+		$sizeValue: list.nth($size, 2);
 
 		.gap#{$separator}#{$sizeKey}#{$separator}tablet {
 			gap: $sizeValue !important;
@@ -42,8 +47,8 @@ $gap-sizes: (
 
 @include mixins.desktop {
 	@each $size in $gap-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
+		$sizeKey: list.nth($size, 1);
+		$sizeValue: list.nth($size, 2);
 
 		.gap#{$separator}#{$sizeKey}#{$separator}desktop {
 			gap: $sizeValue !important;
@@ -53,8 +58,8 @@ $gap-sizes: (
 
 @include mixins.widescreen {
 	@each $size in $gap-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
+		$sizeKey: list.nth($size, 1);
+		$sizeValue: list.nth($size, 2);
 
 		.gap#{$separator}#{$sizeKey}#{$separator}widescreen {
 			gap: $sizeValue !important;

--- a/css/src/atomics/spacing-auto.scss
+++ b/css/src/atomics/spacing-auto.scss
@@ -1,3 +1,4 @@
+@use 'sass:list';
 @use '../mixins/index.scss' as mixins;
 
 $auto-spacing-properties: (
@@ -10,8 +11,8 @@ $auto-spacing-properties: (
 $separator: '-';
 
 @each $property in $auto-spacing-properties {
-	$classicProp: nth($property, 1);
-	$logicalProp: nth($property, 2);
+	$classicProp: list.nth($property, 1);
+	$logicalProp: list.nth($property, 2);
 
 	// .<property>-auto
 	.#{$classicProp}#{$separator}auto {
@@ -21,8 +22,8 @@ $separator: '-';
 
 // .<property>-auto-<screensize>
 @each $property in $auto-spacing-properties {
-	$classicProp: nth($property, 1);
-	$logicalProp: nth($property, 2);
+	$classicProp: list.nth($property, 1);
+	$logicalProp: list.nth($property, 2);
 
 	@include mixins.tablet {
 		.#{$classicProp}#{$separator}auto#{$separator}tablet {
@@ -32,8 +33,8 @@ $separator: '-';
 }
 
 @each $property in $auto-spacing-properties {
-	$classicProp: nth($property, 1);
-	$logicalProp: nth($property, 2);
+	$classicProp: list.nth($property, 1);
+	$logicalProp: list.nth($property, 2);
 
 	@include mixins.desktop {
 		.#{$classicProp}#{$separator}auto#{$separator}desktop {
@@ -43,8 +44,8 @@ $separator: '-';
 }
 
 @each $property in $auto-spacing-properties {
-	$classicProp: nth($property, 1);
-	$logicalProp: nth($property, 2);
+	$classicProp: list.nth($property, 1);
+	$logicalProp: list.nth($property, 2);
 
 	@include mixins.widescreen {
 		.#{$classicProp}#{$separator}auto#{$separator}widescreen {

--- a/css/src/atomics/spacing.scss
+++ b/css/src/atomics/spacing.scss
@@ -1,3 +1,4 @@
+@use 'sass:list';
 @use '../tokens/index.scss' as tokens;
 @use '../mixins/index.scss' as mixins;
 
@@ -32,18 +33,22 @@ $layout-sizes: (
 );
 
 @function sizeValue($key, $value) {
-	@return if($key == 'none', 0, $value);
+	@if $key == 'none' {
+		@return 0;
+	}
+
+	@return $value;
 }
 
 // Pattern: <cssproperty>-<value>-<screen>
 
 @each $property in $logical-spacing-properties {
-	$classicProp: nth($property, 1);
-	$logicalProp: nth($property, 2);
+	$classicProp: list.nth($property, 1);
+	$logicalProp: list.nth($property, 2);
 
 	@each $size in $layout-sizes {
-		$sizeKey: nth($size, 1);
-		$sizeValue: nth($size, 2);
+		$sizeKey: list.nth($size, 1);
+		$sizeValue: list.nth($size, 2);
 
 		// .<property>-<value>
 		.#{$classicProp}#{$separator}#{$sizeKey} {
@@ -54,12 +59,12 @@ $layout-sizes: (
 
 @include mixins.tablet {
 	@each $property in $logical-spacing-properties {
-		$classicProp: nth($property, 1);
-		$logicalProp: nth($property, 2);
+		$classicProp: list.nth($property, 1);
+		$logicalProp: list.nth($property, 2);
 
 		@each $size in $layout-sizes {
-			$sizeKey: nth($size, 1);
-			$sizeValue: nth($size, 2);
+			$sizeKey: list.nth($size, 1);
+			$sizeValue: list.nth($size, 2);
 
 			.#{$classicProp}#{$separator}#{$sizeKey}#{$separator}tablet {
 				#{$logicalProp}: $sizeValue !important;
@@ -70,12 +75,12 @@ $layout-sizes: (
 
 @include mixins.desktop {
 	@each $property in $logical-spacing-properties {
-		$classicProp: nth($property, 1);
-		$logicalProp: nth($property, 2);
+		$classicProp: list.nth($property, 1);
+		$logicalProp: list.nth($property, 2);
 
 		@each $size in $layout-sizes {
-			$sizeKey: nth($size, 1);
-			$sizeValue: nth($size, 2);
+			$sizeKey: list.nth($size, 1);
+			$sizeValue: list.nth($size, 2);
 
 			.#{$classicProp}#{$separator}#{$sizeKey}#{$separator}desktop {
 				#{$logicalProp}: $sizeValue !important;
@@ -86,12 +91,12 @@ $layout-sizes: (
 
 @include mixins.widescreen {
 	@each $property in $logical-spacing-properties {
-		$classicProp: nth($property, 1);
-		$logicalProp: nth($property, 2);
+		$classicProp: list.nth($property, 1);
+		$logicalProp: list.nth($property, 2);
 
 		@each $size in $layout-sizes {
-			$sizeKey: nth($size, 1);
-			$sizeValue: nth($size, 2);
+			$sizeKey: list.nth($size, 1);
+			$sizeValue: list.nth($size, 2);
 
 			.#{$classicProp}#{$separator}#{$sizeKey}#{$separator}widescreen {
 				#{$logicalProp}: $sizeValue !important;

--- a/css/src/atomics/width.scss
+++ b/css/src/atomics/width.scss
@@ -12,7 +12,12 @@ $all-widths: list.join($universal-widths, $mobile-incompatible-widths);
 }
 
 @each $width in $universal-widths {
-	$unit: if($width != auto and $width != fit-content, 'px', '');
+	$unit: '';
+
+	@if $width != auto and $width != fit-content {
+		$unit: 'px';
+	}
+
 	.width-#{$width} {
 		width: #{$width}#{$unit} !important;
 	}
@@ -24,7 +29,12 @@ $all-widths: list.join($universal-widths, $mobile-incompatible-widths);
 	}
 
 	@each $width in $all-widths {
-		$unit: if($width != auto and $width != unset and $width != fit-content, 'px', '');
+		$unit: '';
+
+		@if $width != auto and $width != unset and $width != fit-content {
+			$unit: 'px';
+		}
+
 		.width-#{$width}-tablet {
 			width: #{$width}#{$unit} !important;
 		}
@@ -37,7 +47,12 @@ $all-widths: list.join($universal-widths, $mobile-incompatible-widths);
 	}
 
 	@each $width in $all-widths {
-		$unit: if($width != auto and $width != unset and $width != fit-content, 'px', '');
+		$unit: '';
+
+		@if $width != auto and $width != unset and $width != fit-content {
+			$unit: 'px';
+		}
+
 		.width-#{$width}-desktop {
 			width: #{$width}#{$unit} !important;
 		}

--- a/css/src/components/badge.scss
+++ b/css/src/components/badge.scss
@@ -1,3 +1,4 @@
+@use 'sass:list';
 @use '../tokens/index.scss' as tokens;
 
 $badge-icon-padding-block: 0.5em !default;
@@ -31,10 +32,10 @@ $badge-border-radius: tokens.$border-radius-rounded !default;
 	gap: $badge-gap-size;
 
 	@each $name, $color-set in tokens.$colors {
-		$base: nth($color-set, tokens.$color-index-base);
-		$invert: nth($color-set, tokens.$color-index-invert);
-		$dark: nth($color-set, tokens.$color-index-dark);
-		$background: nth($color-set, tokens.$color-index-background);
+		$base: list.nth($color-set, tokens.$color-index-base);
+		$invert: list.nth($color-set, tokens.$color-index-invert);
+		$dark: list.nth($color-set, tokens.$color-index-dark);
+		$background: list.nth($color-set, tokens.$color-index-background);
 
 		@if $name == 'secondary' {
 			border-color: $dark;
@@ -56,10 +57,10 @@ $badge-border-radius: tokens.$border-radius-rounded !default;
 
 	&.badge-filled {
 		@each $name, $color-set in tokens.$colors {
-			$base: nth($color-set, tokens.$color-index-base);
-			$invert: nth($color-set, tokens.$color-index-invert);
-			$dark: nth($color-set, tokens.$color-index-dark);
-			$background: nth($color-set, tokens.$color-index-background);
+			$base: list.nth($color-set, tokens.$color-index-base);
+			$invert: list.nth($color-set, tokens.$color-index-invert);
+			$dark: list.nth($color-set, tokens.$color-index-dark);
+			$background: list.nth($color-set, tokens.$color-index-background);
 
 			@if $name == 'secondary' {
 				border-color: $base;

--- a/css/src/components/button.scss
+++ b/css/src/components/button.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+@use 'sass:list';
 @use '../tokens/index.scss' as tokens;
 @use '../mixins/index.scss' as mixins;
 
@@ -125,13 +127,13 @@ $button-font-weight: tokens.$weight-semibold !default;
 	}
 
 	@each $name, $color-set in tokens.$colors {
-		$base: nth($color-set, tokens.$color-index-base);
-		$dark: nth($color-set, tokens.$color-index-dark);
-		$background: nth($color-set, tokens.$color-index-background);
-		$background-selected: nth($color-set, tokens.$color-index-background-selected);
-		$selected: nth($color-set, tokens.$color-index-selected);
-		$foreground-selected: nth($color-set, tokens.$color-index-foreground-selected);
-		$border-selected: nth($color-set, tokens.$color-index-stroke-selected);
+		$base: list.nth($color-set, tokens.$color-index-base);
+		$dark: list.nth($color-set, tokens.$color-index-dark);
+		$background: list.nth($color-set, tokens.$color-index-background);
+		$background-selected: list.nth($color-set, tokens.$color-index-background-selected);
+		$selected: list.nth($color-set, tokens.$color-index-selected);
+		$foreground-selected: list.nth($color-set, tokens.$color-index-foreground-selected);
+		$border-selected: list.nth($color-set, tokens.$color-index-stroke-selected);
 
 		&.button-#{$name} {
 			@if $name == 'warning' {
@@ -165,7 +167,7 @@ $button-font-weight: tokens.$weight-semibold !default;
 	}
 }
 
-$button-clear-hover-background-color: transparentize(#8e8e8e, 0.95) !default;
+$button-clear-hover-background-color: color.adjust(#8e8e8e, $alpha: -0.95) !default;
 $button-clear-selected-background-color: tokens.$selected-background-subtle !default;
 
 .button.button-clear {
@@ -196,12 +198,12 @@ $button-clear-selected-background-color: tokens.$selected-background-subtle !def
 	}
 
 	@each $name, $color-set in tokens.$colors {
-		$base: nth($color-set, tokens.$color-index-base);
-		$dark: nth($color-set, tokens.$color-index-dark);
-		$background: nth($color-set, tokens.$color-index-background);
-		$background-selected: nth($color-set, tokens.$color-index-background-selected);
-		$selected: nth($color-set, tokens.$color-index-selected);
-		$foreground-selected: nth($color-set, tokens.$color-index-foreground-selected);
+		$base: list.nth($color-set, tokens.$color-index-base);
+		$dark: list.nth($color-set, tokens.$color-index-dark);
+		$background: list.nth($color-set, tokens.$color-index-background);
+		$background-selected: list.nth($color-set, tokens.$color-index-background-selected);
+		$selected: list.nth($color-set, tokens.$color-index-selected);
+		$foreground-selected: list.nth($color-set, tokens.$color-index-foreground-selected);
 
 		&.button-#{$name} {
 			color: $base;
@@ -259,13 +261,13 @@ $button-filled-background-color-selected: tokens.$secondary-selected !default;
 	}
 
 	@each $name, $color-set in tokens.$colors {
-		$base: nth($color-set, tokens.$color-index-base);
-		$hover: nth($color-set, tokens.$color-index-hover);
-		$active: nth($color-set, tokens.$color-index-active);
-		$invert: nth($color-set, tokens.$color-index-invert);
-		$background: nth($color-set, tokens.$color-index-background);
-		$selected: nth($color-set, tokens.$color-index-selected);
-		$selected-invert: nth($color-set, tokens.$color-index-foreground-selected-invert);
+		$base: list.nth($color-set, tokens.$color-index-base);
+		$hover: list.nth($color-set, tokens.$color-index-hover);
+		$active: list.nth($color-set, tokens.$color-index-active);
+		$invert: list.nth($color-set, tokens.$color-index-invert);
+		$background: list.nth($color-set, tokens.$color-index-background);
+		$selected: list.nth($color-set, tokens.$color-index-selected);
+		$selected-invert: list.nth($color-set, tokens.$color-index-foreground-selected-invert);
 
 		&.button-#{$name} {
 			border-color: $base;

--- a/css/src/components/gradient.scss
+++ b/css/src/components/gradient.scss
@@ -1,3 +1,4 @@
+@use 'sass:list';
 @use '../tokens/index.scss' as tokens;
 @use '../mixins/index.scss' as mixins;
 
@@ -77,8 +78,8 @@ $border-gradient-direction: (
 }
 
 @each $name, $gradient in tokens.$gradients {
-	$colorStart: nth($gradient, tokens.$gradient-color-start-index);
-	$colorEnd: nth($gradient, tokens.$gradient-color-end-index);
+	$colorStart: list.nth($gradient, tokens.$gradient-color-start-index);
+	$colorEnd: list.nth($gradient, tokens.$gradient-color-end-index);
 
 	.gradient-text-#{$name} {
 		@include mixins.gradient-text($colorStart, $colorEnd);

--- a/css/src/components/notification.scss
+++ b/css/src/components/notification.scss
@@ -1,3 +1,4 @@
+@use 'sass:list';
 @use '../tokens/index.scss' as tokens;
 @use '../mixins/index.scss' as mixins;
 
@@ -33,9 +34,9 @@ $notification-dismiss-margin: tokens.$spacer-2 !default;
 	word-break: break-word;
 
 	@each $name, $color-set in tokens.$colors {
-		$base: nth($color-set, tokens.$color-index-base);
-		$dark: nth($color-set, tokens.$color-index-dark);
-		$background: nth($color-set, tokens.$color-index-background);
+		$base: list.nth($color-set, tokens.$color-index-base);
+		$dark: list.nth($color-set, tokens.$color-index-dark);
+		$background: list.nth($color-set, tokens.$color-index-background);
 
 		&.notification-#{$name} {
 			border-color: $dark;

--- a/css/src/core/themes.scss
+++ b/css/src/core/themes.scss
@@ -64,7 +64,7 @@ $theme-names: map.keys(tokens.$themes);
 		// Set the rest of the themes, exclude them from print styling.
 		@media not print {
 			.theme-#{$key} {
-				@each $colorName, $colorVal in map-get(tokens.$themes, $key) {
+				@each $colorName, $colorVal in map.get(tokens.$themes, $key) {
 					// stylelint-disable-next-line custom-property-pattern
 					--theme-#{$colorName}: #{$colorVal};
 				}

--- a/css/src/mixins/font-size.scss
+++ b/css/src/mixins/font-size.scss
@@ -29,8 +29,10 @@ $font-size-scaling-factor: 0.75 !default;
 	$y: strip-units($start-rem) * strip-units(tokens.$document-font-size);
 	$x: strip-units($start-width);
 	$b: $y - $m * $x;
-	$importantValue: if($important, !important, '');
-
-	font-size: clamp(#{$start-rem}, #{$b}px + #{$m * 100}vw, #{$end-rem}) #{$importantValue};
+	@if $important {
+		font-size: clamp(#{$start-rem}, #{$b}px + #{$m * 100}vw, #{$end-rem}) !important;
+	} @else {
+		font-size: clamp(#{$start-rem}, #{$b}px + #{$m * 100}vw, #{$end-rem});
+	}
 }
 /* stylelint-enable */


### PR DESCRIPTION
Link: [preview](http://localhost:1111/)

Replace deprecated global built-in functions with their modern namespaced equivalents to prepare for Dart Sass 3.0.0:

- nth() -> list.nth() with @use 'sass:list'
- map-get() -> map.get() (sass:map already imported)
- transparentize() -> color.adjust() with @use 'sass:color'
- if() function -> @if/@else block conditionals

## Testing

1. Run `npm start` locally. No Scss related errors.

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.