### PR TITLE
add word-break: break-word atomic

### DIFF
--- a/.changeset/funny-sites-hunt.md
+++ b/.changeset/funny-sites-hunt.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Add `word-break-break-word` typography atomic for `word-break: break-word`.

--- a/css/src/atomics/typography.scss
+++ b/css/src/atomics/typography.scss
@@ -230,3 +230,9 @@
 .white-space-pre-wrap {
 	white-space: pre-wrap !important;
 }
+
+// Word break
+
+.word-break-break-word {
+	word-break: break-word !important;
+}

--- a/site/src/atomics/typography.md
+++ b/site/src/atomics/typography.md
@@ -14,6 +14,7 @@ classPrefixes:
   - text-wrap
   - line-height
   - white-space
+  - word-break
 ---
 
 # Typography Atomics
@@ -32,6 +33,7 @@ The typography scale is designed for great readability across the platform. This
 | `text-wrap`       | `pretty`, `balance`                                                         | N\A        |
 | `line-height`     | `normal`                                                         | N\A        |
 | `white-space`     | `normal`, `nowrap`, `pre`, `pre-wrap`                            | N\A        |
+| `word-break`      | `break-word`                                                     | N\A        |
 
 ## Font size
 
@@ -159,5 +161,15 @@ For example, show white space:
 <p class="white-space-pre-wrap">
 	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
 	labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
+</p>
+```
+
+## Word break
+
+Use `.word-break-break-word` to allow long words to break between characters to prevent overflow. This is useful for content that may contain long, unbreakable strings such as URLs or file paths.
+
+```html
+<p class="word-break-break-word">
+	Thisisaverylongwordthatwillnotbreakwithoutthewordbreakbreakwordclasshttps://example.com/very/long/url/that/keeps/going/and/going
 </p>
 ```


### PR DESCRIPTION
Link: [preview](http://localhost:1111/)

Adds a word-break: break-word atomic class. A small but occasionally useful addition to the toolkit.

## Testing

1. See typography atomics test page while running locally.

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
