### PR TITLE
Updating form behavior to catch unexpected errors in form's action

### DIFF
--- a/.changeset/cyan-oranges-invite.md
+++ b/.changeset/cyan-oranges-invite.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': patch
+---
+
+Updating form behavior to catch unexpected errors in form's action

--- a/integration/tests/form-behavior.spec.ts
+++ b/integration/tests/form-behavior.spec.ts
@@ -164,3 +164,247 @@ test.describe('form behavior validation', () => {
 		expect(accessibilityScanResults.violations).toEqual([]);
 	});
 });
+
+test.describe('form behavior - submission error handling', () => {
+	// Helper to fill form with valid data using JavaScript
+	async function fillFormWithValidData(page: any) {
+		await page.evaluate(() => {
+			(document.querySelector('#sample-input') as HTMLInputElement).value = 'Test Input';
+			(document.querySelector('#sample-input-min') as HTMLInputElement).value = 'Lorem ipsum';
+			(document.querySelector('#sample-text-area') as HTMLTextAreaElement).value =
+				'Lorem ipsum dolor sit amet';
+			(document.querySelector('#question-id-1') as HTMLInputElement).checked = true;
+			(document.querySelector('#sample-checkbox') as HTMLInputElement).checked = true;
+			(document.querySelector('#sample-multi-checkbox-2') as HTMLInputElement).checked = true;
+		});
+	}
+
+	test('show notAuthenticated message when form action returns 401', async ({
+		page,
+		errorContainer,
+		submitBtn
+	}) => {
+		await fillFormWithValidData(page);
+
+		// Intercept fetch and return 401 response
+		await page.route('**/*', route => {
+			if (route.request().method() === 'POST') {
+				route.fulfill({
+					status: 401,
+					body: JSON.stringify({ error: 'Unauthorized' })
+				});
+				return;
+			}
+			route.continue();
+		});
+
+		await submitBtn.click();
+
+		expect(errorContainer).toContainText('You are not authenticated');
+	});
+
+	test('show notAuthorized message when form action returns 403', async ({
+		page,
+		errorContainer,
+		submitBtn
+	}) => {
+		await fillFormWithValidData(page);
+
+		await page.route('**/*', route => {
+			if (route.request().method() === 'POST') {
+				route.fulfill({
+					status: 403,
+					body: JSON.stringify({ error: 'Forbidden' })
+				});
+				return;
+			}
+			route.continue();
+		});
+
+		await submitBtn.click();
+
+		expect(errorContainer).toContainText('You are not authorized');
+	});
+
+	test('show contentHasChanged message when form action returns 412', async ({
+		page,
+		errorContainer,
+		submitBtn
+	}) => {
+		await fillFormWithValidData(page);
+
+		await page.route('**/*', route => {
+			if (route.request().method() === 'POST') {
+				route.fulfill({
+					status: 412,
+					body: JSON.stringify({ error: 'Precondition Failed' })
+				});
+				return;
+			}
+			route.continue();
+		});
+
+		await submitBtn.click();
+
+		expect(errorContainer).toContainText('Content has changed');
+	});
+
+	test('show tooManyRequests message when form action returns 429', async ({
+		page,
+		errorContainer,
+		submitBtn
+	}) => {
+		await fillFormWithValidData(page);
+
+		await page.route('**/*', route => {
+			if (route.request().method() === 'POST') {
+				route.fulfill({
+					status: 429,
+					body: JSON.stringify({ error: 'Too Many Requests' })
+				});
+				return;
+			}
+			route.continue();
+		});
+
+		await submitBtn.click();
+
+		expect(errorContainer).toContainText('too many requests');
+	});
+
+	test('show generic error message for other error responses', async ({
+		page,
+		errorContainer,
+		submitBtn
+	}) => {
+		await fillFormWithValidData(page);
+
+		await page.route('**/*', route => {
+			if (route.request().method() === 'POST') {
+				route.fulfill({
+					status: 500,
+					body: JSON.stringify({ error: 'Internal Server Error' })
+				});
+				return;
+			}
+			route.continue();
+		});
+
+		await submitBtn.click();
+
+		expect(errorContainer).toContainText('We encountered an unexpected error');
+	});
+
+	test('show generic error message when fetch throws an error', async ({
+		page,
+		errorContainer,
+		submitBtn
+	}) => {
+		await fillFormWithValidData(page);
+
+		// Mock fetch to throw an error
+		await page.route('**/*', route => {
+			if (route.request().method() === 'POST') {
+				route.abort('failed');
+				return;
+			}
+			route.continue();
+		});
+
+		await submitBtn.click();
+
+		expect(errorContainer).toContainText('We encountered an unexpected error');
+	});
+
+	test('dispatch submission-error event on failed response', async ({ page, submitBtn }) => {
+		await fillFormWithValidData(page);
+
+		// Listen for submission-error event
+		const submissionErrorPromise = page.evaluate(() => {
+			return new Promise(resolve => {
+				document.querySelector('form-behavior')?.addEventListener('submission-error', (e: any) => {
+					resolve({
+						hasRequest: !!e.detail.request,
+						hasResponse: !!e.detail.response,
+						hasForm: !!e.detail.form
+					});
+				});
+			});
+		});
+
+		await page.route('**/*', route => {
+			if (route.request().method() === 'POST') {
+				route.fulfill({
+					status: 400,
+					body: JSON.stringify({ error: 'Bad Request' })
+				});
+				return;
+			}
+			route.continue();
+		});
+
+		await submitBtn.click();
+
+		const eventDetail = await submissionErrorPromise;
+		expect(eventDetail).toEqual({ hasRequest: true, hasResponse: true, hasForm: true });
+	});
+
+	test('dispatch submission-error event on network error', async ({ page, submitBtn }) => {
+		await fillFormWithValidData(page);
+
+		// Listen for submission-error event
+		const submissionErrorPromise = page.evaluate(() => {
+			return new Promise(resolve => {
+				document.querySelector('form-behavior')?.addEventListener('submission-error', (e: any) => {
+					resolve({
+						hasRequest: !!e.detail.request,
+						hasResponse: !!e.detail.response,
+						hasForm: !!e.detail.form
+					});
+				});
+			});
+		});
+
+		await page.route('**/*', route => {
+			if (route.request().method() === 'POST') {
+				route.abort('failed');
+				return;
+			}
+			route.continue();
+		});
+
+		await submitBtn.click();
+
+		const eventDetail = await submissionErrorPromise;
+		expect(eventDetail).toEqual({ hasRequest: true, hasResponse: false, hasForm: true });
+	});
+
+	test('error alert is visible and focused after submission error', async ({
+		page,
+		errorContainer,
+		submitBtn
+	}) => {
+		await fillFormWithValidData(page);
+
+		await page.route('**/*', route => {
+			if (route.request().method() === 'POST') {
+				route.fulfill({
+					status: 500,
+					body: JSON.stringify({ error: 'Internal Server Error' })
+				});
+				return;
+			}
+			route.continue();
+		});
+
+		await submitBtn.click();
+
+		const alertHidden = await errorContainer.evaluate((el: HTMLElement) => el.hidden);
+		const focusedElementAttr = await page.evaluate(() =>
+			document.activeElement?.getAttribute('data-form-error-alert')
+		);
+
+		expect(alertHidden).toBe(false);
+		expect(focusedElementAttr).toBe('');
+	});
+});

--- a/integration/tests/form-behavior.spec.ts
+++ b/integration/tests/form-behavior.spec.ts
@@ -1,8 +1,13 @@
 import AxeBuilder from '@axe-core/playwright';
 import { test as base, expect } from '@playwright/test';
+import type { Locator } from '@playwright/test';
+interface FormBehaviorFixtures {
+	errorContainer: Locator;
+	submitBtn: Locator;
+}
 
 // form validation fixture
-export const test = base.extend({
+export const test = base.extend<FormBehaviorFixtures>({
 	page: async ({ page }, use) => {
 		await page.goto('/components/form.html');
 		await use(page);
@@ -169,6 +174,10 @@ test.describe('form behavior - submission error handling', () => {
 	// Helper to fill form with valid data using JavaScript
 	async function fillFormWithValidData(page: any) {
 		await page.evaluate(() => {
+			(document.querySelector('#sample-form-complex') as HTMLFormElement)?.setAttribute(
+				'data-test-disable-before-submit',
+				''
+			);
 			(document.querySelector('#sample-input') as HTMLInputElement).value = 'Test Input';
 			(document.querySelector('#sample-input-min') as HTMLInputElement).value = 'Lorem ipsum';
 			(document.querySelector('#sample-text-area') as HTMLTextAreaElement).value =
@@ -200,6 +209,8 @@ test.describe('form behavior - submission error handling', () => {
 
 		await submitBtn.click();
 
+		expect(errorContainer).toBeVisible();
+		expect(errorContainer).toContainText('Please fix the following issues to continue:');
 		expect(errorContainer).toContainText('You are not authenticated');
 	});
 
@@ -223,6 +234,8 @@ test.describe('form behavior - submission error handling', () => {
 
 		await submitBtn.click();
 
+		expect(errorContainer).toBeVisible();
+		expect(errorContainer).toContainText('Please fix the following issues to continue:');
 		expect(errorContainer).toContainText('You are not authorized');
 	});
 
@@ -246,6 +259,8 @@ test.describe('form behavior - submission error handling', () => {
 
 		await submitBtn.click();
 
+		expect(errorContainer).toBeVisible();
+		expect(errorContainer).toContainText('Please fix the following issues to continue:');
 		expect(errorContainer).toContainText('Content has changed');
 	});
 
@@ -269,6 +284,8 @@ test.describe('form behavior - submission error handling', () => {
 
 		await submitBtn.click();
 
+		expect(errorContainer).toBeVisible();
+		expect(errorContainer).toContainText('Please fix the following issues to continue:');
 		expect(errorContainer).toContainText('too many requests');
 	});
 
@@ -292,6 +309,8 @@ test.describe('form behavior - submission error handling', () => {
 
 		await submitBtn.click();
 
+		expect(errorContainer).toBeVisible();
+		expect(errorContainer).toContainText('Please fix the following issues to continue:');
 		expect(errorContainer).toContainText('We encountered an unexpected error');
 	});
 
@@ -313,6 +332,8 @@ test.describe('form behavior - submission error handling', () => {
 
 		await submitBtn.click();
 
+		expect(errorContainer).toBeVisible();
+		expect(errorContainer).toContainText('Please fix the following issues to continue:');
 		expect(errorContainer).toContainText('We encountered an unexpected error');
 	});
 
@@ -377,34 +398,5 @@ test.describe('form behavior - submission error handling', () => {
 
 		const eventDetail = await submissionErrorPromise;
 		expect(eventDetail).toEqual({ hasRequest: true, hasResponse: false, hasForm: true });
-	});
-
-	test('error alert is visible and focused after submission error', async ({
-		page,
-		errorContainer,
-		submitBtn
-	}) => {
-		await fillFormWithValidData(page);
-
-		await page.route('**/*', route => {
-			if (route.request().method() === 'POST') {
-				route.fulfill({
-					status: 500,
-					body: JSON.stringify({ error: 'Internal Server Error' })
-				});
-				return;
-			}
-			route.continue();
-		});
-
-		await submitBtn.click();
-
-		const alertHidden = await errorContainer.evaluate((el: HTMLElement) => el.hidden);
-		const focusedElementAttr = await page.evaluate(() =>
-			document.activeElement?.getAttribute('data-form-error-alert')
-		);
-
-		expect(alertHidden).toBe(false);
-		expect(focusedElementAttr).toBe('');
 	});
 });

--- a/integration/tests/form-behavior.spec.ts
+++ b/integration/tests/form-behavior.spec.ts
@@ -175,7 +175,7 @@ test.describe('form behavior - submission error handling', () => {
 	async function fillFormWithValidData(page: any) {
 		await page.evaluate(() => {
 			(document.querySelector('#sample-form-complex') as HTMLFormElement)?.setAttribute(
-				'data-test-disable-before-submit',
+				'data-test-allow-default-action',
 				''
 			);
 			(document.querySelector('#sample-input') as HTMLInputElement).value = 'Test Input';

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -257,55 +257,79 @@ export class FormBehaviorElement extends HTMLElement {
 			}
 
 			const request = new Request(beforeSubmitEvent.detail.url, beforeSubmitEvent.detail.init);
-			const response = await fetch(request);
-			if (response.ok) {
-				this.removeAttribute('new');
-				this.initialData = formData;
-				this.setDirty();
+			let response: Response;
 
-				this.dispatchEvent(
-					new CustomEvent('aftersubmit', {
-						detail: {
-							request,
-							response
-						},
-						bubbles: true
-					})
-				);
-				isNavigating = this.navigate(
-					response.headers.get('location') ?? this.getAttribute('navigation-href')
-				);
-			} else {
+			try {
+				response = await fetch(request);
+
+				if (response.ok) {
+					this.removeAttribute('new');
+					this.initialData = formData;
+					this.setDirty();
+
+					this.dispatchEvent(
+						new CustomEvent('aftersubmit', {
+							detail: {
+								request,
+								response
+							},
+							bubbles: true
+						})
+					);
+					isNavigating = this.navigate(
+						response.headers.get('location') ?? this.getAttribute('navigation-href')
+					);
+				} else {
+					const { errorAlert, errorList } = this.getErrorAlert(form);
+					const errorText = document.createElement('li');
+					errorText.innerText = this.locStrings.weEncounteredAnUnexpectedError;
+
+					// custom text for version mismatch
+					if (response.status === 401) {
+						errorText.innerText = this.locStrings.notAuthenticated;
+					}
+					if (response.status === 403) {
+						errorText.innerText = this.locStrings.notAuthorized;
+					}
+					if (response.status === 412) {
+						errorText.innerText = this.locStrings.contentHasChanged;
+					}
+					if (response.status === 429) {
+						errorText.innerText = this.locStrings.tooManyRequests;
+					}
+					this.dispatchEvent(
+						new CustomEvent('submission-error', {
+							detail: {
+								form,
+								request,
+								response
+							},
+							bubbles: true
+						})
+					);
+
+					errorList.appendChild(errorText);
+					errorAlert.hidden = false;
+					errorAlert.focus();
+				}
+			} catch {
 				const { errorAlert, errorList } = this.getErrorAlert(form);
 				const errorText = document.createElement('li');
 				errorText.innerText = this.locStrings.weEncounteredAnUnexpectedError;
-				// custom text for version mismatch
-				if (response.status === 401) {
-					errorText.innerText = this.locStrings.notAuthenticated;
-				}
-				if (response.status === 403) {
-					errorText.innerText = this.locStrings.notAuthorized;
-				}
-				if (response.status === 412) {
-					errorText.innerText = this.locStrings.contentHasChanged;
-				}
-				if (response.status === 429) {
-					errorText.innerText = this.locStrings.tooManyRequests;
-				}
 				this.dispatchEvent(
 					new CustomEvent('submission-error', {
 						detail: {
 							form,
 							request,
-							response
+							response: undefined
 						},
 						bubbles: true
 					})
 				);
-
 				errorList.appendChild(errorText);
 				errorAlert.hidden = false;
 				errorAlert.focus();
+				return;
 			}
 		} finally {
 			this.submitting = isNavigating;

--- a/js/src/elements/form-behavior.ts
+++ b/js/src/elements/form-behavior.ts
@@ -256,10 +256,11 @@ export class FormBehaviorElement extends HTMLElement {
 				return;
 			}
 
-			const request = new Request(beforeSubmitEvent.detail.url, beforeSubmitEvent.detail.init);
-			let response: Response;
+			let request: Request | undefined;
+			let response: Response | undefined;
 
 			try {
+				request = new Request(beforeSubmitEvent.detail.url, beforeSubmitEvent.detail.init);
 				response = await fetch(request);
 
 				if (response.ok) {
@@ -280,55 +281,33 @@ export class FormBehaviorElement extends HTMLElement {
 						response.headers.get('location') ?? this.getAttribute('navigation-href')
 					);
 				} else {
-					const { errorAlert, errorList } = this.getErrorAlert(form);
-					const errorText = document.createElement('li');
-					errorText.innerText = this.locStrings.weEncounteredAnUnexpectedError;
+					let errorHeadingText = this.locStrings.weEncounteredAnUnexpectedError;
 
 					// custom text for version mismatch
-					if (response.status === 401) {
-						errorText.innerText = this.locStrings.notAuthenticated;
+					switch (response.status) {
+						case 401:
+							errorHeadingText = this.locStrings.notAuthenticated;
+							break;
+						case 403:
+							errorHeadingText = this.locStrings.notAuthorized;
+							break;
+						case 412:
+							errorHeadingText = this.locStrings.contentHasChanged;
+							break;
+						case 429:
+							errorHeadingText = this.locStrings.tooManyRequests;
+							break;
 					}
-					if (response.status === 403) {
-						errorText.innerText = this.locStrings.notAuthorized;
-					}
-					if (response.status === 412) {
-						errorText.innerText = this.locStrings.contentHasChanged;
-					}
-					if (response.status === 429) {
-						errorText.innerText = this.locStrings.tooManyRequests;
-					}
-					this.dispatchEvent(
-						new CustomEvent('submission-error', {
-							detail: {
-								form,
-								request,
-								response
-							},
-							bubbles: true
-						})
-					);
 
-					errorList.appendChild(errorText);
-					errorAlert.hidden = false;
-					errorAlert.focus();
+					this.submissionError(form, errorHeadingText, request, response);
 				}
 			} catch {
-				const { errorAlert, errorList } = this.getErrorAlert(form);
-				const errorText = document.createElement('li');
-				errorText.innerText = this.locStrings.weEncounteredAnUnexpectedError;
-				this.dispatchEvent(
-					new CustomEvent('submission-error', {
-						detail: {
-							form,
-							request,
-							response: undefined
-						},
-						bubbles: true
-					})
+				this.submissionError(
+					form,
+					this.locStrings.weEncounteredAnUnexpectedError,
+					request,
+					response
 				);
-				errorList.appendChild(errorText);
-				errorAlert.hidden = false;
-				errorAlert.focus();
 				return;
 			}
 		} finally {
@@ -377,6 +356,30 @@ export class FormBehaviorElement extends HTMLElement {
 			};
 		}
 		return this.createErrorAlert(form);
+	}
+
+	submissionError(
+		form: HTMLFormElement,
+		errorHeading: string,
+		request?: Request,
+		response?: Response
+	) {
+		const { errorAlert, errorList } = this.getErrorAlert(form);
+		const errorText = document.createElement('li');
+		errorText.innerText = errorHeading;
+		this.dispatchEvent(
+			new CustomEvent('submission-error', {
+				detail: {
+					form,
+					request,
+					response
+				},
+				bubbles: true
+			})
+		);
+		errorList.appendChild(errorText);
+		errorAlert.hidden = false;
+		errorAlert.focus();
 	}
 
 	validateRequired(input: HTMLValueElement, label: string): string | null {

--- a/site/src/scaffold/scripts/form-submit.ts
+++ b/site/src/scaffold/scripts/form-submit.ts
@@ -50,6 +50,11 @@ export function handleMockFormSubmit() {
 		form.addEventListener(
 			'beforesubmit',
 			e => {
+				// Opt-out flag for tests or scenarios that need the real form-behavior submission flow.
+				if (form.hasAttribute('data-test-disable-before-submit')) {
+					return;
+				}
+
 				e.preventDefault();
 
 				if (form.hasAttribute('test-async-before-submit')) {

--- a/site/src/scaffold/scripts/form-submit.ts
+++ b/site/src/scaffold/scripts/form-submit.ts
@@ -50,8 +50,10 @@ export function handleMockFormSubmit() {
 		form.addEventListener(
 			'beforesubmit',
 			e => {
-				// Opt-out flag for tests or scenarios that need the form submission flow.
-				if (!form.hasAttribute('data-test-disable-before-submit')) {
+				// By default, prevent the real form submission so the demo form on a doc page
+				// can only show the preview of what data would be submitted.
+				// Adding `data-test-allow-default-action` to the form allows the submission to proceed normally.
+				if (!form.hasAttribute('data-test-allow-default-action')) {
 					e.preventDefault();
 				}
 

--- a/site/src/scaffold/scripts/form-submit.ts
+++ b/site/src/scaffold/scripts/form-submit.ts
@@ -50,12 +50,10 @@ export function handleMockFormSubmit() {
 		form.addEventListener(
 			'beforesubmit',
 			e => {
-				// Opt-out flag for tests or scenarios that need the real form-behavior submission flow.
-				if (form.hasAttribute('data-test-disable-before-submit')) {
-					return;
+				// Opt-out flag for tests or scenarios that need the form submission flow.
+				if (!form.hasAttribute('data-test-disable-before-submit')) {
+					e.preventDefault();
 				}
-
-				e.preventDefault();
 
 				if (form.hasAttribute('test-async-before-submit')) {
 					const customEvent = e as CustomEventInit<{ callback: () => Promise<void> }>;


### PR DESCRIPTION
Link: [Form page](http://localhost:1111/components/form.html)

Updating form behavior to catch unexpected errors in form's action

## Testing

1. Review code
2. `git checkout olga/form-behavior-fetch-fix; npm run start`
3. Visit form's page. Make sure form's validation works the same. 
4. To test alert is rendered on network issues, assign to the form that has action `data-test-allow-default-action` attribute (to unblock form's submit action), `npm start`, open network tab in dev tools, and then click on `submit` button. You should see the error after requests goes through and returns 405. Block that request URL (right click, block request) and click submit again. You should see the same error alert

<img width="763" height="227" alt="image" src="https://github.com/user-attachments/assets/7e391a27-c4ec-441d-ac33-c7a7e9405519" />


## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
- [ ] Does your pull request change any transforms? Did you test they work on right to left?
