### PR TITLE
Update component disabled backgrounds to body-background-dark

### DIFF
--- a/.changeset/deep-windows-create.md
+++ b/.changeset/deep-windows-create.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Button, input, textarea, select and site-header colors changed to reflect the change in the $body-background-medium variable.

--- a/css/src/components/button.scss
+++ b/css/src/components/button.scss
@@ -22,7 +22,7 @@ $button-hover-color: tokens.$text !default;
 $button-hover-border-color: tokens.$default-hover !default;
 $button-hover-background-color: tokens.$default-hover-invert !default;
 
-$button-disabled-background-color: tokens.$body-background-medium !default;
+$button-disabled-background-color: tokens.$body-background-dark !default;
 $button-disabled-shadow: none !default;
 $button-disabled-opacity: 0.5 !default;
 

--- a/css/src/components/form/input.scss
+++ b/css/src/components/form/input.scss
@@ -12,7 +12,7 @@ $input-hover-border-color: tokens.$default-hover !default;
 $input-focus-border-color: tokens.$primary !default;
 
 $input-disabled-color: tokens.$text-subtle !default;
-$input-disabled-background-color: tokens.$body-background-medium !default;
+$input-disabled-background-color: tokens.$body-background-dark !default;
 $input-disabled-border-color: tokens.$table-border-dark !default;
 
 $input-danger-border-color: tokens.$danger !default;

--- a/css/src/components/form/select.scss
+++ b/css/src/components/form/select.scss
@@ -14,7 +14,7 @@ $select-hover-border-color: tokens.$default-hover !default;
 $select-focus-border-color: tokens.$primary !default;
 
 $select-disabled-color: tokens.$text-subtle !default;
-$select-disabled-background-color: tokens.$body-background-medium !default;
+$select-disabled-background-color: tokens.$body-background-dark !default;
 $select-disabled-border-color: tokens.$table-border-dark !default;
 
 $select-danger-border-color: tokens.$danger !default;

--- a/css/src/components/form/textarea.scss
+++ b/css/src/components/form/textarea.scss
@@ -12,7 +12,7 @@ $textarea-hover-border-color: tokens.$default-hover !default;
 $textarea-focus-border-color: tokens.$primary !default;
 
 $textarea-disabled-color: tokens.$text-subtle !default;
-$textarea-disabled-background-color: tokens.$body-background-medium !default;
+$textarea-disabled-background-color: tokens.$body-background-dark !default;
 $textarea-disabled-border-color: tokens.$table-border-dark !default;
 
 $textarea-danger-border-color: tokens.$danger !default;

--- a/css/src/components/site-header.scss
+++ b/css/src/components/site-header.scss
@@ -23,7 +23,7 @@ $site-header-hover-underline-border: $site-header-hover-underline-border-width s
 $site-header-logo-width: 1.625em !default;
 $site-header-divider-height: 1.5em !default;
 
-$site-header-panel-background-color: tokens.$body-background-medium !default;
+$site-header-panel-background-color: tokens.$body-background-dark !default;
 $site-header-panel-min-height: 350px !default;
 $site-header-panel-block-padding: tokens.$layout-4 !default;
 $site-header-panel-gap: tokens.$layout-2 !default;


### PR DESCRIPTION
## Summary

Replaces `body-background-medium` with `body-background-dark` token in component disabled/panel background defaults.

### Changed files
- **button.scss** - disabled button background
- **form/input.scss** - disabled input background
- **form/textarea.scss** - disabled textarea background
- **form/select.scss** - disabled select background
- **site-header.scss** - header panel background

### Verification
- CSS build passes
- Lint passes