### PR TITLE
adjust scaling sidebar widths on wider screens

### DIFF
--- a/.changeset/seven-bars-scream.md
+++ b/.changeset/seven-bars-scream.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-site': minor
+'@microsoft/atlas-css': minor
+---
+
+Adjust the maximum widths of sidebar elements on relevant layouts. The menu and aside elements will continue to have a default width of 275px, but scale up to 320px at 1500px, then 450px at 1800px wide. When the flyout is active and the screen width is below 2300px, each of those containers will scale down one step lower. For example, the `.layout-body-menu` at 1600px will decrease from 320px wide to 275px wide when the flyout is active. Added relevant documentation to the site.

--- a/css/src/components/layout.scss
+++ b/css/src/components/layout.scss
@@ -7,6 +7,8 @@ $layout-menu-collapsed-width: 68px !default;
 $layout-menu-expanded-target-width: 275px !default;
 $layout-aside-collapsed-width: 68px !default;
 $layout-aside-expanded-target-width: 275px !default;
+$layout-sidebar-width-medium: 320px !default;
+$layout-sidebar-width-wide: 450px !default;
 
 :root {
 	--window-inner-height: 100vh; // to be overwritten by JS
@@ -45,6 +47,16 @@ $layout-aside-expanded-target-width: 275px !default;
 
 	@include mixins.widescreen {
 		#{tokens.$layout-flyout-width-desktop-custom-property-name}: $default-flyout-width-widescreen;
+	}
+
+	@include mixins.discouraged-sidebar-medium {
+		#{tokens.$layout-menu-expanded-target-width-name}: $layout-sidebar-width-medium;
+		#{tokens.$layout-aside-expanded-target-width-name}: $layout-sidebar-width-medium;
+	}
+
+	@include mixins.discouraged-sidebar-wide {
+		#{tokens.$layout-menu-expanded-target-width-name}: $layout-sidebar-width-wide;
+		#{tokens.$layout-aside-expanded-target-width-name}: $layout-sidebar-width-wide;
 	}
 }
 
@@ -307,6 +319,23 @@ $layout-aside-expanded-target-width: 275px !default;
 		var(#{tokens.$layout-aside-expanded-target-width-name}) -
 			var(#{tokens.$layout-aside-collapsed-width-name})
 	);
+}
+
+.layout.layout-flyout-active {
+	@include mixins.discouraged-sidebar-medium {
+		#{tokens.$layout-menu-expanded-target-width-name}: $layout-menu-expanded-target-width;
+		#{tokens.$layout-aside-expanded-target-width-name}: $layout-aside-expanded-target-width;
+	}
+
+	@include mixins.discouraged-sidebar-wide {
+		#{tokens.$layout-menu-expanded-target-width-name}: $layout-sidebar-width-medium;
+		#{tokens.$layout-aside-expanded-target-width-name}: $layout-sidebar-width-medium;
+	}
+
+	@include mixins.discouraged-sidebar-ultrawide {
+		#{tokens.$layout-menu-expanded-target-width-name}: $layout-sidebar-width-wide;
+		#{tokens.$layout-aside-expanded-target-width-name}: $layout-sidebar-width-wide;
+	}
 }
 
 .layout.layout-menu-collapsed {

--- a/css/src/components/layout.scss
+++ b/css/src/components/layout.scss
@@ -7,8 +7,10 @@ $layout-menu-collapsed-width: 68px !default;
 $layout-menu-expanded-target-width: 275px !default;
 $layout-aside-collapsed-width: 68px !default;
 $layout-aside-expanded-target-width: 275px !default;
-$layout-sidebar-width-medium: 320px !default;
-$layout-sidebar-width-wide: 450px !default;
+$layout-menu-width-medium: 320px !default;
+$layout-menu-width-wide: 450px !default;
+$layout-aside-width-medium: 320px !default;
+$layout-aside-width-wide: 450px !default;
 
 :root {
 	--window-inner-height: 100vh; // to be overwritten by JS
@@ -50,13 +52,13 @@ $layout-sidebar-width-wide: 450px !default;
 	}
 
 	@include mixins.discouraged-sidebar-medium {
-		#{tokens.$layout-menu-expanded-target-width-name}: $layout-sidebar-width-medium;
-		#{tokens.$layout-aside-expanded-target-width-name}: $layout-sidebar-width-medium;
+		#{tokens.$layout-menu-expanded-target-width-name}: $layout-menu-width-medium;
+		#{tokens.$layout-aside-expanded-target-width-name}: $layout-aside-width-medium;
 	}
 
 	@include mixins.discouraged-sidebar-wide {
-		#{tokens.$layout-menu-expanded-target-width-name}: $layout-sidebar-width-wide;
-		#{tokens.$layout-aside-expanded-target-width-name}: $layout-sidebar-width-wide;
+		#{tokens.$layout-menu-expanded-target-width-name}: $layout-menu-width-wide;
+		#{tokens.$layout-aside-expanded-target-width-name}: $layout-aside-width-wide;
 	}
 }
 
@@ -328,13 +330,13 @@ $layout-sidebar-width-wide: 450px !default;
 	}
 
 	@include mixins.discouraged-sidebar-wide {
-		#{tokens.$layout-menu-expanded-target-width-name}: $layout-sidebar-width-medium;
-		#{tokens.$layout-aside-expanded-target-width-name}: $layout-sidebar-width-medium;
+		#{tokens.$layout-menu-expanded-target-width-name}: $layout-menu-width-medium;
+		#{tokens.$layout-aside-expanded-target-width-name}: $layout-aside-width-medium;
 	}
 
 	@include mixins.discouraged-sidebar-ultrawide {
-		#{tokens.$layout-menu-expanded-target-width-name}: $layout-sidebar-width-wide;
-		#{tokens.$layout-aside-expanded-target-width-name}: $layout-sidebar-width-wide;
+		#{tokens.$layout-menu-expanded-target-width-name}: $layout-menu-width-wide;
+		#{tokens.$layout-aside-expanded-target-width-name}: $layout-aside-width-wide;
 	}
 }
 

--- a/css/src/mixins/media-queries.scss
+++ b/css/src/mixins/media-queries.scss
@@ -50,6 +50,26 @@
 	}
 }
 
+// Layout-specific breakpoints for scaling sidebar widths on wider screens.
+// These are custom one-offs and should not be used outside of the layout component.
+@mixin discouraged-sidebar-medium {
+	@media screen and (width >= 1500px) {
+		@content;
+	}
+}
+
+@mixin discouraged-sidebar-wide {
+	@media screen and (width >= 1800px) {
+		@content;
+	}
+}
+
+@mixin discouraged-sidebar-ultrawide {
+	@media screen and (width >= 2300px) {
+		@content;
+	}
+}
+
 @mixin print {
 	@media print {
 		@content;

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -334,6 +334,27 @@ In certain scenarios, it may be advantageous to collapse the left-hand menu elem
 
 Similarly, the right-hand aside can be collapsed by adding `.layout-aside-collapsed` to the `html` element. This narrows the aside to a minimal width on layouts that support it: `layout-holy-grail`, `layout-sidecar-right`, and `layout-twin`.
 
+## Scaling container widths
+
+On wider screens, the menu and aside containers automatically scale up to give navigation and supplementary content more room. This happens at two breakpoints:
+
+| Screen width | Sidebar width |
+| --- | --- |
+| Below `1500px` | `275px` (default) |
+| `1500px` and above | `320px` |
+| `1800px` and above | `450px` |
+
+When the [flyout](#an-optional-flyout-container) is active, sidebar widths step down one notch to make room for the flyout column. If the sidebars are already at the default `275px`, no further reduction occurs.
+
+| Screen width | Sidebar width (flyout active) |
+| --- | --- |
+| Below `1500px` | `275px` (unchanged) |
+| `1500px` and above | `275px` (stepped down from `320px`) |
+| `1800px` and above | `320px` (stepped down from `450px`) |
+| `2300px` and above | `450px` (no reduction) |
+
+This scaling is built in and requires no additional classes or configuration. The values can still be overridden with the `--layout-menu-expanded-target-width` and `--layout-aside-expanded-target-width` CSS variables described in [Customizing layout dimensions with CSS variables](#customizing-layout-dimensions-with-css-variables).
+
 ## Accessibility Concerns
 
 ### ARIA landmarks


### PR DESCRIPTION
Link: [preview](http://localhost:1111/)

Adjust the maximum widths of sidebar elements on relevant layouts. The menu and aside elements will continue to have a default width of 275px, but scale up to 320px at 1500px, then 450px at 1800px wide. When the flyout is active and the screen width is below 2300px, each of those containers will scale down one step lower. For example, the `.layout-body-menu` at 1600px will decrease from 320px wide to 275px wide when the flyout is active. Added relevant documentation to the site.

## Testing

1. Open layout page.
2. Test layouts that have sidebars.
3. You should see the sidebar widths scale as described above.

## Additional information

[Optional]

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
