### PR TITLE
expand reading-width to 900px at widescreen breakpoint

### DIFF
--- a/.changeset/reading-width-widescreen.md
+++ b/.changeset/reading-width-widescreen.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Expand reading-width max width to 900px at the widescreen breakpoint.

--- a/css/src/components/reading-width.scss
+++ b/css/src/components/reading-width.scss
@@ -1,5 +1,10 @@
 @use '../tokens/index.scss' as tokens;
+@use '../mixins/index.scss' as mixins;
 
 .reading-width {
 	max-inline-size: min(100%, #{tokens.$reading-width-padded});
+
+	@include mixins.widescreen {
+		max-inline-size: min(100%, #{tokens.$reading-width-padded-widescreen});
+	}
 }

--- a/css/src/tokens/typography.scss
+++ b/css/src/tokens/typography.scss
@@ -34,9 +34,13 @@ $line-height-normal: 1.3;
 
 // Reading width
 $optimal-reading-width: 688px !default;
+$optimal-reading-width-widescreen: 900px !default;
 $reading-width-padding: 24px !default;
 $reading-width-padded: calc(
 	#{$optimal-reading-width} + (var(#{layout.$layout-gap-custom-property-name}) * 2)
+) !default;
+$reading-width-padded-widescreen: calc(
+	#{$optimal-reading-width-widescreen} + (var(#{layout.$layout-gap-custom-property-name}) * 2)
 ) !default;
 
 //@end-sass-export-section

--- a/site/src/components/reading-width.md
+++ b/site/src/components/reading-width.md
@@ -9,7 +9,7 @@ classPrefixes:
 
 # Reading width
 
-The reading width component constrains an element's maximum width to an optimal reading measure. This improves readability for long-form text content by preventing lines from becoming too wide, which can make it difficult for readers to track from the end of one line to the beginning of the next.
+The reading width component constrains an element's maximum width to an optimal reading measure. This improves readability for long-form text content by preventing lines from becoming too wide, which can make it difficult for readers to track from the end of one line to the beginning of the next. On widescreen viewports (1800px and above), the maximum width expands to 900px to take advantage of the additional space.
 
 ## Usage
 


### PR DESCRIPTION
Expands the .reading-width component max width from ~688px to 900px at the widescreen breakpoint (1800px+). Adds token, applies via widescreen mixin, updates docs.