### PR TITLE
add scrollbar-width-thin atomic class

### DIFF
--- a/.changeset/jolly-ducks-dig.md
+++ b/.changeset/jolly-ducks-dig.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Add `scrollbar-width-thin` atomic class for applying `scrollbar-width: thin` to scrollable elements.

--- a/css/src/atomics/overflow.scss
+++ b/css/src/atomics/overflow.scss
@@ -18,6 +18,10 @@
 	}
 }
 
+.scrollbar-width-thin {
+	scrollbar-width: thin !important;
+}
+
 .scrollbar-gutter-stable {
 	scrollbar-gutter: stable !important;
 }

--- a/site/src/atomics/overflow.md
+++ b/site/src/atomics/overflow.md
@@ -5,6 +5,7 @@ template: standard
 classType: Atomics
 classPrefixes:
   - overflow
+  - scrollbar-width
   - scrollbar-gutter
 ---
 
@@ -16,6 +17,7 @@ At times, you'll need to determine the overflow behavior of an element. Atlas pr
 | ------------------ | ----------------------------- | ---------- |
 | `overflow`         | `hidden`                      | `tablet`   |
 | `overflow-x`       | `hidden`                      | `tablet`   |
+| `scrollbar-width`  | `thin`                        |            |
 | `scrollbar-gutter` | `stable`, `stable-both-edges` |            |
 
 ## Usage
@@ -45,6 +47,26 @@ You can use `.overflow-x-hidden` to set the clipping behavior for the left/right
 			</p>
 		</div>
 	</div>
+</div>
+```
+
+## Scrollbar width
+
+Use `.scrollbar-width-thin` to render a thinner scrollbar on elements with overflow. This is useful for reducing visual weight on scrollable containers where a full-size scrollbar feels heavy.
+
+```html
+<div
+	class="scrollbar-width-thin scroll-vertical max-height-30vh background-color-primary inner-focus"
+	data-focusable-if-scrollable
+	style="resize: vertical"
+>
+	<p class="color-success-invert font-size-xl margin-bottom">
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+		labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+		laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+		voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+		non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+	</p>
 </div>
 ```
 


### PR DESCRIPTION
Add .scrollbar-width-thin atomic to overflow.scss for applying scrollbar-width: thin to scrollable elements. Update overflow documentation with usage example.

Link: [preview](http://localhost:1111/)

## Testing

1. Run locally, view documentation page.

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.