### PR TITLE
update scroll / overflow docs with a cross link

### DIFF
--- a/.changeset/dark-lies-glow.md
+++ b/.changeset/dark-lies-glow.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': minor
+---
+
+Update docs related to atomics/overflow and components/scroll to point at each other.

--- a/site/src/atomics/overflow.md
+++ b/site/src/atomics/overflow.md
@@ -11,7 +11,7 @@ classPrefixes:
 
 # Overflow
 
-At times, you'll need to determine the overflow behavior of an element. Atlas provides several classes to do this.
+At times, you'll need to determine the overflow behavior of an element. Atlas provides several classes to do this. For directional scrolling containers and snap scroll patterns, see the [scroll component](~/src/components/scroll.md).
 
 | cssproperty        | value                         | screensize |
 | ------------------ | ----------------------------- | ---------- |
@@ -72,7 +72,7 @@ Use `.scrollbar-width-thin` to render a thinner scrollbar on elements with overf
 
 ## Scrollbar gutter
 
-When using automatic overflow, as with the [scrolling components](../components/scroll.md), the sudden appearance or disappearance of a container's scrollbar can cause the container's content to jump around. While this might be fine if the scrollbar appears or disappears as a result of the user zooming or resizing their browser, it can look clunky otherwise — such as when messages are appended to a constrained-width or constrained-height chat container, resulting in a scrollbar where there wasn't one previously.
+When using automatic overflow, as with the [scrolling components](~/src/components/scroll.md), the sudden appearance or disappearance of a container's scrollbar can cause the container's content to jump around. While this might be fine if the scrollbar appears or disappears as a result of the user zooming or resizing their browser, it can look clunky otherwise — such as when messages are appended to a constrained-width or constrained-height chat container, resulting in a scrollbar where there wasn't one previously.
 
 To see this default behavior, resize the below example until its scrollbar appears.
 

--- a/site/src/components/scroll.md
+++ b/site/src/components/scroll.md
@@ -9,7 +9,7 @@ classPrefixes:
 
 # Scrolling
 
-There are two components that help modify the scroll direction of a particular container.
+There are two components that help modify the scroll direction of a particular container. For overflow-related utility classes such as `overflow-hidden`, `scrollbar-width-thin`, and scrollbar gutter helpers, see [overflow atomics](~/src/atomics/overflow.md).
 
 ## Horizontal scrolling
 
@@ -143,4 +143,4 @@ _Note: `data-focusable-if-scrollable`, the attribute we use to programmatically 
 
 ## Avoiding jumping text with scrollbar gutters
 
-In some cases, the appearance or disappearance of a scrollbar can cause that container's contents to jump around. This might be fine if the scrollbar is appearing as a result of the user opting to zoom or resize their browser, but when that's not the case, the jumping can be extra noticeable. If you're noticing this in your scrolling component, consider applying a [scrollbar gutter atomic](../atomics/overflow.md#scrollbar-gutter).
+In some cases, the appearance or disappearance of a scrollbar can cause that container's contents to jump around. This might be fine if the scrollbar is appearing as a result of the user opting to zoom or resize their browser, but when that's not the case, the jumping can be extra noticeable. If you're noticing this in your scrolling component, consider applying a [scrollbar gutter atomic](~/src/atomics/overflow.md#scrollbar-gutter).


### PR DESCRIPTION
Link: [preview](http://localhost:1111/)

In the previous PR folks noted that the arrangement of component/scroll and atomics/overflow has some confusing crossover. Although I'm not positive I can fix that perfectly, I'm adding a cross reference on each page.

<img width="615" height="116" alt="image" src="https://github.com/user-attachments/assets/164e2c00-45b9-44c2-a609-0b2d35a23e04" />
and
<img width="704" height="209" alt="image" src="https://github.com/user-attachments/assets/1a2f49bc-fa3d-40cd-93e4-cbca1642952a" />

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.

