### PR TITLE
Increase widescreen sidebar breakpoints to 2000px and 2500px

### DIFF
--- a/.changeset/moody-cups-glow.md
+++ b/.changeset/moody-cups-glow.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Modify the sidebar specific breakpoints to be wider. Sidebars to scale to 450px wide at 2000px. Flyout active downscaling to start at 2500px screen width.

--- a/css/src/mixins/media-queries.scss
+++ b/css/src/mixins/media-queries.scss
@@ -52,6 +52,7 @@
 
 // Layout-specific breakpoints for scaling sidebar widths on wider screens.
 // These are custom one-offs and should not be used outside of the layout component.
+// They also don't have tokens associated with them, because they are not widely used.
 @mixin discouraged-sidebar-medium {
 	@media screen and (width >= 1500px) {
 		@content;
@@ -59,13 +60,13 @@
 }
 
 @mixin discouraged-sidebar-wide {
-	@media screen and (width >= 1800px) {
+	@media screen and (width >= 2000px) {
 		@content;
 	}
 }
 
 @mixin discouraged-sidebar-ultrawide {
-	@media screen and (width >= 2300px) {
+	@media screen and (width >= 2500px) {
 		@content;
 	}
 }

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -342,7 +342,7 @@ On wider screens, the menu and aside containers automatically scale up to give n
 | --- | --- |
 | Below `1500px` | `275px` (default) |
 | `1500px` and above | `320px` |
-| `1800px` and above | `450px` |
+| `2000px` and above | `450px` |
 
 When the [flyout](#an-optional-flyout-container) is active, sidebar widths step down one notch to make room for the flyout column. If the sidebars are already at the default `275px`, no further reduction occurs.
 
@@ -350,8 +350,8 @@ When the [flyout](#an-optional-flyout-container) is active, sidebar widths step 
 | --- | --- |
 | Below `1500px` | `275px` (unchanged) |
 | `1500px` and above | `275px` (stepped down from `320px`) |
-| `1800px` and above | `320px` (stepped down from `450px`) |
-| `2300px` and above | `450px` (no reduction) |
+| `2000px` and above | `320px` (stepped down from `450px`) |
+| `2500px` and above | `450px` (no reduction) |
 
 This scaling is built in and requires no additional classes or configuration. The values can still be overridden with the `--layout-menu-expanded-target-width` and `--layout-aside-expanded-target-width` CSS variables described in [Customizing layout dimensions with CSS variables](#customizing-layout-dimensions-with-css-variables).
 


### PR DESCRIPTION
Update the widescreen breakpoint token from 1800px to 2000px and the ultrawide media query from 2300px to 2500px.

Modify the sidebar specific breakpoints to be wider. Sidebars to scale to 450px wide at 2000px. Flyout active downscaling to start at 2500px screen width.

