### PR TITLE
Add icon mirroring modifiers for RTL

### DIFF
--- a/.changeset/crisp-snakes-scream.md
+++ b/.changeset/crisp-snakes-scream.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Add icon-mirrored-rtl modifier to the .icon component. icon-mirrored-rtl flips an icon along its inline axis in RTL only.

--- a/.changeset/ripe-cars-strive.md
+++ b/.changeset/ripe-cars-strive.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-site': minor
+---
+
+Document icon-mirrored-rtl on the .icon component.

--- a/css/src/components/icon.scss
+++ b/css/src/components/icon.scss
@@ -17,4 +17,10 @@ $icon-dimensions: 1em !default;
 		padding: 0.6rem; // ensures icon is not cut off by rounded border
 		border-radius: 50%;
 	}
+
+	&.icon-mirrored-rtl {
+		&:dir(rtl) {
+			scale: -1 1;
+		}
+	}
 }

--- a/site/src/components/icon.md
+++ b/site/src/components/icon.md
@@ -71,3 +71,19 @@ SVG elements can also be placed within an Icon element.
 	</svg>
 </button>
 ```
+
+### Direction-aware icons
+
+Some icons like arrows should point the opposite way in right-to-left (RTL) reading modes, so they continue to follow the document's writing direction.
+
+The `icon-mirrored-rtl` modifier mirrors the icon along its inline axis in RTL only. It has no effect in left-to-right (LTR) reading mode.
+
+> **Only apply `icon-mirrored-rtl` to icons that should be mirrored in RTL.** Many icons, such as logos, must look identical in both directions. As a rule of thumb: only mirror icons that point or move left/right.
+
+```html
+<button class="button" aria-label="Collapse navigation">
+	<span class="icon icon-mirrored-rtl" aria-hidden="true">
+		<svg viewBox="0 0 24 24"><path d="M15 6l-6 6 6 6" /></svg>
+	</span>
+</button>
+```


### PR DESCRIPTION
Link: [preview link](http://localhost:1111/components/icon.html#direction-aware-icons)

This PR adds icon mirroring modifiers for RTL to the icon component.

## Testing

1. Navigate to [preview link](http://localhost:1111/components/icon.html#direction-aware-icons)
2. Click the button in the top right to change the layout direction
<img width="1197" height="83" alt="image" src="https://github.com/user-attachments/assets/c97da1d2-8ea4-4733-bbe5-f73617c2c51c" />
3. View the Direction-aware icons section

 Expected result:
 LTR:
<img width="996" height="303" alt="image" src="https://github.com/user-attachments/assets/b2d55f88-5481-47fd-b1e8-d7afc3326f7a" />
RTL:
<img width="943" height="319" alt="image" src="https://github.com/user-attachments/assets/ac4aa2e4-5db0-4217-952f-f25af64eed0f" />

## Contributor checklist

- [ ] Did you update the description of this pull request with a review link and test steps?
- [ ] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
- [ ] Does your pull request change any transforms? Did you test they work on right to left?
