### PR TITLE
update dark theme body-background-dark variable to be a lighter

### DIFF
--- a/.changeset/calm-buckets-float.md
+++ b/.changeset/calm-buckets-float.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+update dark theme body-background-dark variable to be a little lighter, instead of black

--- a/css/src/tokens/themes.scss
+++ b/css/src/tokens/themes.scss
@@ -179,7 +179,7 @@ $themes: (
 		'body-background': palette.$palette-grey-280,
 		'body-background-accent': palette.$palette-blue-black,
 		'body-background-medium': palette.$palette-grey-250,
-		'body-background-dark': palette.$palette-grey-300,
+		'body-background-dark': palette.$palette-grey-260,
 		'alternate-background': palette.$palette-grey-20-deprecated,
 		'alternate-background-medium': palette.$palette-grey-10-deprecated,
 		'border': palette.$palette-grey-100-deprecated,


### PR DESCRIPTION
Black becomes #242424 for the body-background-dark theme property.

Link: [preview](http://localhost:1111/atomics/colors.html)

[Explain the context of this pull request here]

## Testing

1. Run locally, view link above or see screenshot.

<img width="578" height="260" alt="image" src="https://github.com/user-attachments/assets/5db9f9e4-c5d3-4e8d-90b2-6066f4dac2d8" />


## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.