### PR TITLE
feat: add tree component stylings

### DIFF
--- a/.changeset/four-dryers-strive.md
+++ b/.changeset/four-dryers-strive.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-css': minor
+'@microsoft/atlas-site': minor
+---
+
+Add `.tree` component for hierarchical navigation with expand/collapse, selected state, static variant, icon leaf layout, focus delegation, RTL support, and forced-colors accessibility. Documentation and examples added to the site.

--- a/css/src/components/index.scss
+++ b/css/src/components/index.scss
@@ -31,5 +31,6 @@
 @forward './stretched-link.scss';
 @forward './segmented-control.scss';
 @forward './timeline.scss';
+@forward './tree.scss';
 @forward './layout.scss';
 @forward './reading-width.scss';

--- a/css/src/components/tree.scss
+++ b/css/src/components/tree.scss
@@ -123,8 +123,15 @@ $tree-selected-font-weight: tokens.$weight-semibold !default;
 		}
 	}
 
-	&-item.is-expanded > .tree-expander::before {
-		transform: mixins.$chevron-down-rotate translate(calc(mixins.$chevron-arrow-size / 2), 0);
+	&-item.is-expanded > .tree-expander {
+		&::before {
+			transform: mixins.$chevron-down-rotate translate(calc(mixins.$chevron-arrow-size / 2), 0);
+		}
+
+		&:dir(rtl)::before {
+			transform: mixins.$chevron-down-rotate-rtl
+				translate(calc(mixins.$chevron-arrow-size / 2 * -1), 0);
+		}
 	}
 
 	&.tree-static {

--- a/css/src/components/tree.scss
+++ b/css/src/components/tree.scss
@@ -126,7 +126,7 @@ $tree-selected-font-weight: tokens.$weight-semibold !default;
 	}
 
 	&-item.is-expanded > .tree-expander > .tree-expander-indicator {
-		rotate: $tree-expanded-rotation;
+		rotate: $tree-expanded-rotation; // TODO: compare expanded chevron between this and prod - see if docs-ui is influencing the styling
 	}
 
 	&.tree-static {

--- a/css/src/components/tree.scss
+++ b/css/src/components/tree.scss
@@ -18,7 +18,6 @@ $tree-selected-font-weight: tokens.$weight-semibold !default;
 
 	&,
 	&-group {
-		list-style-type: none;
 		margin-block-end: 0;
 	}
 

--- a/css/src/components/tree.scss
+++ b/css/src/components/tree.scss
@@ -1,0 +1,137 @@
+@use '../tokens/index.scss' as tokens;
+@use '../mixins/index.scss' as mixins;
+
+$tree-font-size: tokens.$font-size-8 !default;
+$tree-indent: tokens.$spacer-5 !default;
+$tree-item-vertical-padding: tokens.$spacer-2 !default;
+$tree-item-gap: tokens.$spacer-2 !default;
+$tree-easing: ease-in-out !default;
+$tree-transition-duration: 0.15s !default;
+$tree-expanded-rotation: 90deg !default;
+$tree-selected-color: tokens.$text-glow-high-contrast !default;
+$tree-selected-background: tokens.$selected-background-subtle !default;
+$tree-selected-font-weight: tokens.$weight-semibold !default;
+
+.tree {
+	position: relative;
+	font-size: $tree-font-size;
+	line-height: 1.75;
+
+	&,
+	&-group {
+		list-style-type: none;
+		margin-block-end: 0;
+	}
+
+	&-group {
+		margin-inline-start: $tree-indent;
+	}
+
+	&-item {
+		margin-block-start: $tree-item-gap;
+
+		> .tree-group {
+			display: none;
+		}
+
+		&.is-expanded > .tree-group {
+			display: block;
+		}
+
+		&.tree-leaf {
+			color: tokens.$text !important;
+		}
+
+		&.is-selected {
+			background-color: $tree-selected-background;
+			color: $tree-selected-color !important;
+			font-weight: $tree-selected-font-weight;
+
+			@include mixins.forced-colors {
+				background-color: SelectedItem;
+				color: SelectedItemText !important;
+				forced-color-adjust: none;
+			}
+		}
+	}
+
+	&-item.tree-leaf.has-icon {
+		display: flex;
+
+		&:hover {
+			text-decoration: none;
+		}
+
+		.icon {
+			flex-shrink: 0;
+			align-items: baseline;
+			width: 1rem;
+			font-size: tokens.$font-size-9;
+			line-height: 2;
+		}
+
+		> span:not(.icon) {
+			padding-inline-start: tokens.$spacer-3;
+		}
+	}
+
+	/* stylelint-disable-next-line selector-max-specificity, rule-empty-line-before */
+	&-item.tree-leaf.has-icon > span:not(.icon):hover {
+		text-decoration: underline !important;
+	}
+
+	// Focus: suppress outline on branch nodes, delegate to expander
+
+	&-item:not(.tree-leaf) {
+		outline: none !important;
+
+		@include mixins.focus-visible {
+			> .tree-expander {
+				@include mixins.focus();
+			}
+		}
+	}
+
+	&-item.tree-leaf,
+	&-expander {
+		display: block;
+		padding-inline-start: $tree-indent;
+		padding-block-start: $tree-item-vertical-padding;
+		padding-block-end: $tree-item-vertical-padding;
+		border-radius: tokens.$border-radius;
+		outline-offset: -(tokens.$focus-width) !important;
+	}
+
+	&-expander {
+		position: relative;
+		cursor: pointer;
+		user-select: none;
+		word-wrap: break-word;
+
+		.tree-expander-indicator {
+			display: inline-block;
+			position: absolute;
+			inset-block-start: tokens.$spacer-3;
+			inset-inline-start: 0;
+			transition: rotate $tree-transition-duration $tree-easing;
+			rotate: 0deg;
+			color: tokens.$text-subtle;
+			font-size: tokens.$font-size-9;
+			font-weight: tokens.$weight-semibold;
+
+			&:dir(rtl) {
+				rotate: 180deg;
+			}
+		}
+	}
+
+	&-item.is-expanded > .tree-expander > .tree-expander-indicator {
+		rotate: $tree-expanded-rotation;
+	}
+
+	&.tree-static {
+		.tree-item.tree-leaf {
+			padding-inline-start: 0 !important;
+		}
+	}
+}

--- a/css/src/components/tree.scss
+++ b/css/src/components/tree.scss
@@ -7,7 +7,6 @@ $tree-item-vertical-padding: tokens.$spacer-2 !default;
 $tree-item-gap: tokens.$spacer-2 !default;
 $tree-easing: ease-in-out !default;
 $tree-transition-duration: 0.15s !default;
-$tree-expanded-rotation: 90deg !default;
 $tree-selected-color: tokens.$text-glow-high-contrast !default;
 $tree-selected-background: tokens.$selected-background-subtle !default;
 $tree-selected-font-weight: tokens.$weight-semibold !default;
@@ -108,25 +107,24 @@ $tree-selected-font-weight: tokens.$weight-semibold !default;
 		user-select: none;
 		word-wrap: break-word;
 
-		.tree-expander-indicator {
-			display: inline-block;
-			position: absolute;
-			inset-block-start: tokens.$spacer-3;
-			inset-inline-start: 0;
-			transition: rotate $tree-transition-duration $tree-easing;
-			rotate: 0deg;
-			color: tokens.$text-subtle;
-			font-size: tokens.$font-size-9;
-			font-weight: tokens.$weight-semibold;
+		&::before {
+			@include mixins.chevron-right;
 
-			&:dir(rtl) {
-				rotate: 180deg;
-			}
+			position: absolute;
+			inset-block-start: tokens.$spacer-4;
+			inset-inline-start: 0;
+			inset-inline-end: auto;
+			transition: transform $tree-transition-duration $tree-easing;
+			font-size: tokens.$font-size-9;
+		}
+
+		&:dir(rtl)::before {
+			@include mixins.chevron-right-rtl;
 		}
 	}
 
-	&-item.is-expanded > .tree-expander > .tree-expander-indicator {
-		rotate: $tree-expanded-rotation; // TODO: compare expanded chevron between this and prod - see if docs-ui is influencing the styling
+	&-item.is-expanded > .tree-expander::before {
+		transform: mixins.$chevron-down-rotate translate(calc(mixins.$chevron-arrow-size / 2), 0);
 	}
 
 	&.tree-static {

--- a/css/src/components/tree.scss
+++ b/css/src/components/tree.scss
@@ -32,7 +32,7 @@ $tree-selected-font-weight: tokens.$weight-semibold !default;
 			display: none;
 		}
 
-		&.is-expanded > .tree-group {
+		&[aria-expanded='true'] > .tree-group {
 			display: block;
 		}
 
@@ -63,7 +63,7 @@ $tree-selected-font-weight: tokens.$weight-semibold !default;
 		outline-offset: -(tokens.$focus-width) !important;
 	}
 
-	.tree-item.tree-leaf:where(.has-icon) {
+	.tree-item.tree-leaf:where(:has(.icon)) {
 		display: flex;
 
 		&:hover {
@@ -83,7 +83,7 @@ $tree-selected-font-weight: tokens.$weight-semibold !default;
 		}
 	}
 
-	.tree-item:where(.tree-leaf.has-icon) > span:not(.icon):hover {
+	.tree-item:where(.tree-leaf:has(.icon)) > span:not(.icon):hover {
 		text-decoration: underline !important;
 	}
 
@@ -122,7 +122,7 @@ $tree-selected-font-weight: tokens.$weight-semibold !default;
 		}
 	}
 
-	.tree-item:where(.is-expanded) > .tree-expander {
+	.tree-item:where([aria-expanded='true']) > .tree-expander {
 		&::before {
 			transform: mixins.$chevron-down-rotate translate(calc(mixins.$chevron-arrow-size / 2), 0);
 		}

--- a/css/src/components/tree.scss
+++ b/css/src/components/tree.scss
@@ -17,15 +17,15 @@ $tree-selected-font-weight: tokens.$weight-semibold !default;
 	line-height: 1.75;
 
 	&,
-	&-group {
+	.tree-group {
 		margin-block-end: 0;
 	}
 
-	&-group {
+	.tree-group {
 		margin-inline-start: $tree-indent;
 	}
 
-	&-item {
+	.tree-item {
 		margin-block-start: $tree-item-gap;
 
 		> .tree-group {
@@ -53,7 +53,17 @@ $tree-selected-font-weight: tokens.$weight-semibold !default;
 		}
 	}
 
-	&-item.tree-leaf.has-icon {
+	.tree-item.tree-leaf,
+	.tree-expander {
+		display: block;
+		padding-inline-start: $tree-indent;
+		padding-block-start: $tree-item-vertical-padding;
+		padding-block-end: $tree-item-vertical-padding;
+		border-radius: tokens.$border-radius;
+		outline-offset: -(tokens.$focus-width) !important;
+	}
+
+	.tree-item.tree-leaf:where(.has-icon) {
 		display: flex;
 
 		&:hover {
@@ -73,14 +83,13 @@ $tree-selected-font-weight: tokens.$weight-semibold !default;
 		}
 	}
 
-	/* stylelint-disable-next-line selector-max-specificity, rule-empty-line-before */
-	&-item.tree-leaf.has-icon > span:not(.icon):hover {
+	.tree-item:where(.tree-leaf.has-icon) > span:not(.icon):hover {
 		text-decoration: underline !important;
 	}
 
 	// Focus: suppress outline on branch nodes, delegate to expander
 
-	&-item:not(.tree-leaf) {
+	.tree-item:not(.tree-leaf) {
 		outline: none !important;
 
 		@include mixins.focus-visible {
@@ -90,17 +99,7 @@ $tree-selected-font-weight: tokens.$weight-semibold !default;
 		}
 	}
 
-	&-item.tree-leaf,
-	&-expander {
-		display: block;
-		padding-inline-start: $tree-indent;
-		padding-block-start: $tree-item-vertical-padding;
-		padding-block-end: $tree-item-vertical-padding;
-		border-radius: tokens.$border-radius;
-		outline-offset: -(tokens.$focus-width) !important;
-	}
-
-	&-expander {
+	.tree-expander {
 		position: relative;
 		cursor: pointer;
 		user-select: none;
@@ -123,7 +122,7 @@ $tree-selected-font-weight: tokens.$weight-semibold !default;
 		}
 	}
 
-	&-item.is-expanded > .tree-expander {
+	.tree-item:where(.is-expanded) > .tree-expander {
 		&::before {
 			transform: mixins.$chevron-down-rotate translate(calc(mixins.$chevron-arrow-size / 2), 0);
 		}

--- a/css/src/components/tree.scss
+++ b/css/src/components/tree.scss
@@ -115,6 +115,7 @@ $tree-selected-font-weight: tokens.$weight-semibold !default;
 			inset-inline-start: 0;
 			inset-inline-end: auto;
 			transition: transform $tree-transition-duration $tree-easing;
+			border-color: tokens.$text-subtle;
 			font-size: tokens.$font-size-9;
 		}
 
@@ -131,12 +132,6 @@ $tree-selected-font-weight: tokens.$weight-semibold !default;
 		&:dir(rtl)::before {
 			transform: mixins.$chevron-down-rotate-rtl
 				translate(calc(mixins.$chevron-arrow-size / 2 * -1), 0);
-		}
-	}
-
-	&.tree-static {
-		.tree-item.tree-leaf {
-			padding-inline-start: 0 !important;
 		}
 	}
 }

--- a/integration/config/page.ts
+++ b/integration/config/page.ts
@@ -51,6 +51,7 @@ export const pages: LocalPageConfig[] = [
 	{ pathname: '/components/textarea.html', name: 'Components/textarea', routes },
 	{ pathname: '/components/timeline.html', name: 'Components/timeline', routes },
 	{ pathname: '/components/toggle.html', name: 'Components/toggle', routes },
+	{ pathname: '/components/tree.html', name: 'Components/tree', routes },
 	{ pathname: '/patterns/article-header.html', name: 'Patterns/article-header', routes },
 	{ pathname: '/patterns/form-validation.html', name: 'Patterns/form-validation', routes },
 	{ pathname: '/patterns/thread-history.html', name: 'Patterns/thread-history', routes }

--- a/integration/tests/accessibility.spec.ts
+++ b/integration/tests/accessibility.spec.ts
@@ -56,6 +56,7 @@ const pathnames = [
 	'/components/textarea.html',
 	'/components/timeline.html',
 	'/components/toggle.html',
+	'/components/tree.html',
 	'/patterns/article-header.html',
 	'/patterns/chat.html',
 	'/patterns/thread-history.html',

--- a/site/src/components/tree.md
+++ b/site/src/components/tree.md
@@ -1,0 +1,86 @@
+---
+title: Tree
+description: The tree component in the Atlas Design System
+template: standard
+classType: Component
+classPrefixes:
+  - tree
+---
+
+# Tree
+
+A hierarchical list component implementing the [WAI-ARIA TreeView pattern](https://www.w3.org/TR/wai-aria-practices-1.1/examples/treeview/treeview-2/treeview-2a.html). Used for navigable structures like tables of contents, file browsers, or nested menus.
+
+## Basic collapsible tree
+
+A tree with expandable branch nodes and selectable leaf nodes. Branch nodes use `aria-expanded` to communicate state.
+
+```html
+<ul class="tree" role="tree" aria-label="Table of contents">
+	<li class="tree-item is-expanded" role="treeitem" aria-expanded="true" tabindex="0" aria-level="1" aria-setsize="3" aria-posinset="1">
+		<span class="tree-expander">
+			<span class="tree-expander-indicator" aria-hidden="true"><svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M4.65 2.15a.5.5 0 0 0 0 .7L7.79 6 4.65 9.15a.5.5 0 1 0 .7.7l3.5-3.5a.5.5 0 0 0 0-.7l-3.5-3.5a.5.5 0 0 0-.7 0Z"/></svg></span>
+			Getting started
+		</span>
+		<ul class="tree-group" role="group">
+			<li role="none">
+				<a class="tree-item tree-leaf is-selected" role="treeitem" tabindex="-1" aria-current="page" aria-level="2" aria-setsize="2" aria-posinset="1" href="#">Overview</a>
+			</li>
+			<li role="none">
+				<a class="tree-item tree-leaf" role="treeitem" tabindex="-1" aria-level="2" aria-setsize="2" aria-posinset="2" href="#">Installation</a>
+			</li>
+		</ul>
+	</li>
+	<li class="tree-item" role="treeitem" aria-expanded="false" tabindex="-1" aria-level="1" aria-setsize="3" aria-posinset="2">
+		<span class="tree-expander">
+			<span class="tree-expander-indicator" aria-hidden="true"><svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M4.65 2.15a.5.5 0 0 0 0 .7L7.79 6 4.65 9.15a.5.5 0 1 0 .7.7l3.5-3.5a.5.5 0 0 0 0-.7l-3.5-3.5a.5.5 0 0 0-.7 0Z"/></svg></span>
+			Configuration
+		</span>
+	</li>
+	<li role="none">
+		<a class="tree-item tree-leaf" role="treeitem" tabindex="-1" aria-level="1" aria-setsize="3" aria-posinset="3" href="#">FAQ</a>
+	</li>
+</ul>
+```
+
+## Static tree
+
+A non-collapsible tree where all items are visible. Add the `tree-static` class to the root element.
+
+```html
+<ul class="tree tree-static" role="tree" aria-label="Page sections">
+	<li role="none">
+		<a class="tree-item tree-leaf is-selected" role="treeitem" tabindex="0" aria-current="page" aria-level="1" aria-setsize="4" aria-posinset="1" href="#">Introduction</a>
+	</li>
+	<li role="none">
+		<a class="tree-item tree-leaf" role="treeitem" tabindex="-1" aria-level="1" aria-setsize="4" aria-posinset="2" href="#">Prerequisites</a>
+	</li>
+	<li role="none">
+		<a class="tree-item tree-leaf" role="treeitem" tabindex="-1" aria-level="1" aria-setsize="4" aria-posinset="3" href="#">Steps</a>
+	</li>
+	<li role="none">
+		<a class="tree-item tree-leaf" role="treeitem" tabindex="-1" aria-level="1" aria-setsize="4" aria-posinset="4" href="#">Next steps</a>
+	</li>
+</ul>
+```
+
+## DOM contract
+
+| Class | Element | Purpose |
+|---|---|---|
+| `.tree` | `ul` | Root tree container |
+| `.tree-static` | modifier | Non-collapsible tree variant (no expanders) |
+| `.tree-group` | `ul` | Nested group of child items |
+| `.tree-item` | `li` or `a` | A tree node (branch or leaf) |
+| `.tree-leaf` | `a` | Leaf node (no children) |
+| `.tree-expander` | `span` | Clickable expander for branch nodes |
+| `.tree-expander-indicator` | `span` | Icon indicating expand/collapse state |
+| `.is-expanded` | modifier | Applied to expanded branch nodes |
+| `.is-selected` | modifier | Applied to the currently active item |
+
+## Accessibility
+
+- Branch nodes (`li.tree-item`) carry `role="treeitem"` and `aria-expanded`.
+- Leaf nodes (`a.tree-item.tree-leaf`) carry `role="treeitem"`. Their parent `li` uses `role="none"`.
+- Focus is managed via `tabindex`: only one item has `tabindex="0"` at a time (roving tabindex).
+- Keyboard navigation (arrow keys, Home, End) should be handled by the consuming application's JavaScript.

--- a/site/src/components/tree.md
+++ b/site/src/components/tree.md
@@ -41,6 +41,27 @@ A tree with expandable branch nodes and selectable leaf nodes. Branch nodes use 
 </ul>
 ```
 
+## Static tree
+
+A tree without expanders — all items are leaf nodes. No additional class is needed; simply omit `.tree-expander` elements.
+
+```html
+<ul class="tree" role="tree" aria-label="Page sections">
+	<li role="none">
+		<a class="tree-item tree-leaf is-selected" role="treeitem" tabindex="0" aria-current="page" aria-level="1" aria-setsize="4" aria-posinset="1" href="#">Introduction</a>
+	</li>
+	<li role="none">
+		<a class="tree-item tree-leaf" role="treeitem" tabindex="-1" aria-level="1" aria-setsize="4" aria-posinset="2" href="#">Prerequisites</a>
+	</li>
+	<li role="none">
+		<a class="tree-item tree-leaf" role="treeitem" tabindex="-1" aria-level="1" aria-setsize="4" aria-posinset="3" href="#">Steps</a>
+	</li>
+	<li role="none">
+		<a class="tree-item tree-leaf" role="treeitem" tabindex="-1" aria-level="1" aria-setsize="4" aria-posinset="4" href="#">Next steps</a>
+	</li>
+</ul>
+```
+
 ## Accessibility
 
 Keyboard navigation (arrow keys, Home, End) and focus management should be handled by the consuming application's JavaScript.

--- a/site/src/components/tree.md
+++ b/site/src/components/tree.md
@@ -19,7 +19,6 @@ A tree with expandable branch nodes and selectable leaf nodes. Branch nodes use 
 <ul class="tree" role="tree" aria-label="Table of contents">
 	<li class="tree-item is-expanded" role="treeitem" aria-expanded="true" tabindex="0" aria-level="1" aria-setsize="3" aria-posinset="1">
 		<span class="tree-expander">
-			<span class="tree-expander-indicator" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 448 448" fill="currentColor"><path d="M328.968 224l-187.31 187.312-22.626-22.625L283.72 224 119.032 59.312l22.625-22.624L328.967 224z"/></svg></span>
 			Getting started
 		</span>
 		<ul class="tree-group" role="group">
@@ -33,7 +32,6 @@ A tree with expandable branch nodes and selectable leaf nodes. Branch nodes use 
 	</li>
 	<li class="tree-item" role="treeitem" aria-expanded="false" tabindex="-1" aria-level="1" aria-setsize="3" aria-posinset="2">
 		<span class="tree-expander">
-			<span class="tree-expander-indicator" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 448 448" fill="currentColor"><path d="M328.968 224l-187.31 187.312-22.626-22.625L283.72 224 119.032 59.312l22.625-22.624L328.967 224z"/></svg></span>
 			Configuration
 		</span>
 	</li>
@@ -73,8 +71,7 @@ A non-collapsible tree where all items are visible. Add the `tree-static` class 
 | `.tree-group` | `ul` | Nested group of child items |
 | `.tree-item` | `li` or `a` | A tree node (branch or leaf) |
 | `.tree-leaf` | `a` | Leaf node (no children) |
-| `.tree-expander` | `span` | Clickable expander for branch nodes |
-| `.tree-expander-indicator` | `span` | Icon indicating expand/collapse state |
+| `.tree-expander` | `span` | Clickable expander for branch nodes (chevron drawn via CSS `::before`) |
 | `.is-expanded` | modifier | Applied to expanded branch nodes |
 | `.is-selected` | modifier | Applied to the currently active item |
 

--- a/site/src/components/tree.md
+++ b/site/src/components/tree.md
@@ -17,7 +17,7 @@ A tree with expandable branch nodes and selectable leaf nodes. Branch nodes use 
 
 ```html
 <ul class="tree" role="tree" aria-label="Table of contents">
-	<li class="tree-item is-expanded" role="treeitem" aria-expanded="true" tabindex="0" aria-level="1" aria-setsize="3" aria-posinset="1">
+	<li class="tree-item" role="treeitem" aria-expanded="true" tabindex="0" aria-level="1" aria-setsize="3" aria-posinset="1">
 		<span class="tree-expander">
 			Getting started
 		</span>
@@ -64,4 +64,4 @@ A tree without expanders — all items are leaf nodes. No additional class is ne
 
 ## Accessibility
 
-Keyboard navigation (arrow keys, Home, End) and focus management should be handled by the consuming application's JavaScript.
+The tree component relies on ARIA attributes — `aria-expanded`, `aria-level`, `aria-setsize`, and `aria-posinset` — to convey structure and state to assistive technologies. Keyboard navigation (arrow keys, Home, End) and focus management should be handled by the consuming application's JavaScript.

--- a/site/src/components/tree.md
+++ b/site/src/components/tree.md
@@ -9,7 +9,7 @@ classPrefixes:
 
 # Tree
 
-A hierarchical list component implementing the [WAI-ARIA TreeView pattern](https://www.w3.org/TR/wai-aria-practices-1.1/examples/treeview/treeview-2/treeview-2a.html). Used for navigable structures like tables of contents, file browsers, or nested menus.
+A hierarchical list component that styles the [WAI-ARIA TreeView pattern](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/). Used for navigable structures like tables of contents, file browsers, or nested menus.
 
 ## Basic collapsible tree
 
@@ -41,43 +41,6 @@ A tree with expandable branch nodes and selectable leaf nodes. Branch nodes use 
 </ul>
 ```
 
-## Static tree
-
-A non-collapsible tree where all items are visible. Add the `tree-static` class to the root element.
-
-```html
-<ul class="tree tree-static" role="tree" aria-label="Page sections">
-	<li role="none">
-		<a class="tree-item tree-leaf is-selected" role="treeitem" tabindex="0" aria-current="page" aria-level="1" aria-setsize="4" aria-posinset="1" href="#">Introduction</a>
-	</li>
-	<li role="none">
-		<a class="tree-item tree-leaf" role="treeitem" tabindex="-1" aria-level="1" aria-setsize="4" aria-posinset="2" href="#">Prerequisites</a>
-	</li>
-	<li role="none">
-		<a class="tree-item tree-leaf" role="treeitem" tabindex="-1" aria-level="1" aria-setsize="4" aria-posinset="3" href="#">Steps</a>
-	</li>
-	<li role="none">
-		<a class="tree-item tree-leaf" role="treeitem" tabindex="-1" aria-level="1" aria-setsize="4" aria-posinset="4" href="#">Next steps</a>
-	</li>
-</ul>
-```
-
-## DOM contract
-
-| Class | Element | Purpose |
-|---|---|---|
-| `.tree` | `ul` | Root tree container |
-| `.tree-static` | modifier | Non-collapsible tree variant (no expanders) |
-| `.tree-group` | `ul` | Nested group of child items |
-| `.tree-item` | `li` or `a` | A tree node (branch or leaf) |
-| `.tree-leaf` | `a` | Leaf node (no children) |
-| `.tree-expander` | `span` | Clickable expander for branch nodes (chevron drawn via CSS `::before`) |
-| `.is-expanded` | modifier | Applied to expanded branch nodes |
-| `.is-selected` | modifier | Applied to the currently active item |
-
 ## Accessibility
 
-- Branch nodes (`li.tree-item`) carry `role="treeitem"` and `aria-expanded`.
-- Leaf nodes (`a.tree-item.tree-leaf`) carry `role="treeitem"`. Their parent `li` uses `role="none"`.
-- Focus is managed via `tabindex`: only one item has `tabindex="0"` at a time (roving tabindex).
-- Keyboard navigation (arrow keys, Home, End) should be handled by the consuming application's JavaScript.
+Keyboard navigation (arrow keys, Home, End) and focus management should be handled by the consuming application's JavaScript.

--- a/site/src/components/tree.md
+++ b/site/src/components/tree.md
@@ -9,7 +9,7 @@ classPrefixes:
 
 # Tree
 
-A hierarchical list component that styles the [WAI-ARIA TreeView pattern](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/). Used for navigable structures like tables of contents, file browsers, or nested menus.
+A hierarchical list component for navigable structures like tables of contents, file browsers, or nested menus. Intended to style the [WAI-ARIA TreeView pattern](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/).
 
 ## Basic collapsible tree
 
@@ -17,47 +17,47 @@ A tree with expandable branch nodes and selectable leaf nodes. Branch nodes use 
 
 ```html
 <ul class="tree" role="tree" aria-label="Table of contents">
-	<li class="tree-item" role="treeitem" aria-expanded="true" tabindex="0" aria-level="1" aria-setsize="3" aria-posinset="1">
+	<li class="tree-item" role="treeitem" aria-expanded="true" aria-level="1" aria-setsize="3" aria-posinset="1">
 		<span class="tree-expander">
 			Getting started
 		</span>
 		<ul class="tree-group" role="group">
 			<li role="none">
-				<a class="tree-item tree-leaf is-selected" role="treeitem" tabindex="-1" aria-current="page" aria-level="2" aria-setsize="2" aria-posinset="1" href="#">Overview</a>
+				<a class="tree-item tree-leaf is-selected" role="treeitem" aria-current="page" aria-level="2" aria-setsize="2" aria-posinset="1" href="#">Overview</a>
 			</li>
 			<li role="none">
-				<a class="tree-item tree-leaf" role="treeitem" tabindex="-1" aria-level="2" aria-setsize="2" aria-posinset="2" href="#">Installation</a>
+				<a class="tree-item tree-leaf" role="treeitem" aria-level="2" aria-setsize="2" aria-posinset="2" href="#">Installation</a>
 			</li>
 		</ul>
 	</li>
-	<li class="tree-item" role="treeitem" aria-expanded="false" tabindex="-1" aria-level="1" aria-setsize="3" aria-posinset="2">
+	<li class="tree-item" role="treeitem" aria-expanded="false" aria-level="1" aria-setsize="3" aria-posinset="2">
 		<span class="tree-expander">
 			Configuration
 		</span>
 	</li>
 	<li role="none">
-		<a class="tree-item tree-leaf" role="treeitem" tabindex="-1" aria-level="1" aria-setsize="3" aria-posinset="3" href="#">FAQ</a>
+		<a class="tree-item tree-leaf" role="treeitem" aria-level="1" aria-setsize="3" aria-posinset="3" href="#">FAQ</a>
 	</li>
 </ul>
 ```
 
 ## Static tree
 
-A tree without expanders — all items are leaf nodes. No additional class is needed; simply omit `.tree-expander` elements.
+A tree without expanders — all items are leaf nodes. Simply omit `.tree-expander` elements.
 
 ```html
 <ul class="tree" role="tree" aria-label="Page sections">
 	<li role="none">
-		<a class="tree-item tree-leaf is-selected" role="treeitem" tabindex="0" aria-current="page" aria-level="1" aria-setsize="4" aria-posinset="1" href="#">Introduction</a>
+		<a class="tree-item tree-leaf is-selected" role="treeitem" aria-current="page" aria-level="1" aria-setsize="4" aria-posinset="1" href="#">Introduction</a>
 	</li>
 	<li role="none">
-		<a class="tree-item tree-leaf" role="treeitem" tabindex="-1" aria-level="1" aria-setsize="4" aria-posinset="2" href="#">Prerequisites</a>
+		<a class="tree-item tree-leaf" role="treeitem" aria-level="1" aria-setsize="4" aria-posinset="2" href="#">Prerequisites</a>
 	</li>
 	<li role="none">
-		<a class="tree-item tree-leaf" role="treeitem" tabindex="-1" aria-level="1" aria-setsize="4" aria-posinset="3" href="#">Steps</a>
+		<a class="tree-item tree-leaf" role="treeitem" aria-level="1" aria-setsize="4" aria-posinset="3" href="#">Steps</a>
 	</li>
 	<li role="none">
-		<a class="tree-item tree-leaf" role="treeitem" tabindex="-1" aria-level="1" aria-setsize="4" aria-posinset="4" href="#">Next steps</a>
+		<a class="tree-item tree-leaf" role="treeitem" aria-level="1" aria-setsize="4" aria-posinset="4" href="#">Next steps</a>
 	</li>
 </ul>
 ```

--- a/site/src/components/tree.md
+++ b/site/src/components/tree.md
@@ -19,7 +19,7 @@ A tree with expandable branch nodes and selectable leaf nodes. Branch nodes use 
 <ul class="tree" role="tree" aria-label="Table of contents">
 	<li class="tree-item is-expanded" role="treeitem" aria-expanded="true" tabindex="0" aria-level="1" aria-setsize="3" aria-posinset="1">
 		<span class="tree-expander">
-			<span class="tree-expander-indicator" aria-hidden="true"><svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M4.65 2.15a.5.5 0 0 0 0 .7L7.79 6 4.65 9.15a.5.5 0 1 0 .7.7l3.5-3.5a.5.5 0 0 0 0-.7l-3.5-3.5a.5.5 0 0 0-.7 0Z"/></svg></span>
+			<span class="tree-expander-indicator" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 448 448" fill="currentColor"><path d="M328.968 224l-187.31 187.312-22.626-22.625L283.72 224 119.032 59.312l22.625-22.624L328.967 224z"/></svg></span>
 			Getting started
 		</span>
 		<ul class="tree-group" role="group">
@@ -33,7 +33,7 @@ A tree with expandable branch nodes and selectable leaf nodes. Branch nodes use 
 	</li>
 	<li class="tree-item" role="treeitem" aria-expanded="false" tabindex="-1" aria-level="1" aria-setsize="3" aria-posinset="2">
 		<span class="tree-expander">
-			<span class="tree-expander-indicator" aria-hidden="true"><svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M4.65 2.15a.5.5 0 0 0 0 .7L7.79 6 4.65 9.15a.5.5 0 1 0 .7.7l3.5-3.5a.5.5 0 0 0 0-.7l-3.5-3.5a.5.5 0 0 0-.7 0Z"/></svg></span>
+			<span class="tree-expander-indicator" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 448 448" fill="currentColor"><path d="M328.968 224l-187.31 187.312-22.626-22.625L283.72 224 119.032 59.312l22.625-22.624L328.967 224z"/></svg></span>
 			Configuration
 		</span>
 	</li>


### PR DESCRIPTION
## Overview

Add a reusable tree CSS component for hierarchical navigation (tables of contents, file browsers, nested menus).


### Features
- Expand/collapse with indicator rotation and RTL support
- Selected state with configurable tokens and forced-colors accessibility
- Focus delegation to expander via focus-visible mixin
- Static (non-collapsible) tree variant (\.tree-static\)
- Icon leaf layout (\.has-icon\)
- Border-radius on interactive items
- Logical properties throughout
- All values use Atlas tokens

### Notes
- The expand/collapse indicator uses a DOM element (not CSS pseudo-elements like accordion) to stay compatible with the existing JS markup contract in consuming apps. This could be aligned to the accordion pattern in a future iteration.
- Documentation page with examples, DOM contract, and accessibility section included.
- Accessibility and visual diff tests registered.

Related work item: [#1143601](https://dev.azure.com/ceapex/Engineering/_workitems/edit/1143601)