### PR TITLE
Add Vitest setup to js package with CI integration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,6 +27,10 @@ npm run integration        # Run Playwright integration tests
 npm run integration:debug  # Debug mode with browser
 npx playwright test -g "test name"  # Run single test (from integration folder)
 
+# Unit testing (js package)
+npm run test               # Run Vitest unit tests
+npm run test:coverage      # Run with code coverage report
+
 # Visual regression
 npm run screenshots:light  # Light theme only
 npm run screenshots:all    # All themes

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,7 @@ npx playwright test -g "test name"  # Run single test (from integration folder)
 
 # Unit testing (js package)
 npm run test               # Run Vitest unit tests
-npm run test:coverage      # Run with code coverage report
+npm run test:cov            # Run with code coverage report
 
 # Visual regression
 npm run screenshots:light  # Light theme only

--- a/.github/instructions/js.instructions.md
+++ b/.github/instructions/js.instructions.md
@@ -1,6 +1,6 @@
 # Atlas JS - Copilot Instructions
 
-applyTo: "js/**"
+applyTo: "js/\*\*"
 
 This is the `@microsoft/atlas-js` package, providing TypeScript/JavaScript behaviors for the Atlas Design System.
 
@@ -63,6 +63,7 @@ Atlas prioritizes CSS-only solutions. Add JavaScript only when:
 ## Integration Testing
 
 Behavioral tests are in the `integration` package:
+
 - Tests use Playwright
 - Run from repository root: `npm run integration`
 
@@ -73,9 +74,9 @@ Unit tests use [Vitest](https://vitest.dev/) with a jsdom environment for DOM AP
 ### Running Tests
 
 - `npm run test` - Run all unit tests (from `js/` folder or repo root)
-- `npm run test:coverage` - Run tests with code coverage report
+- `npm run test:cov` - Run tests with code coverage report
 - `npx vitest --watch` - Watch mode during development (from `js/` folder)
-- `npx vitest run src/utilities/util.test.ts` - Run a specific test file
+- `npx vitest run test/utilities/util.test.ts` - Run a specific test file
 
 ### Writing Tests
 

--- a/.github/instructions/js.instructions.md
+++ b/.github/instructions/js.instructions.md
@@ -20,6 +20,7 @@ js/
 │   ├── elements/     # Custom elements / web components
 │   ├── utilities/    # Shared utility functions
 │   └── index.ts      # Main entry point
+├── test/             # Unit tests (mirrors src/ structure)
 └── dist/             # Compiled JavaScript output
 ```
 
@@ -78,7 +79,7 @@ Unit tests use [Vitest](https://vitest.dev/) with a jsdom environment for DOM AP
 
 ### Writing Tests
 
-1. **Place test files next to source** - Use `*.test.ts` suffix (e.g., `util.test.ts` beside `util.ts`)
+1. **Place test files in `test/`** - Mirror the `src/` folder structure (e.g., `test/utilities/util.test.ts` for `src/utilities/util.ts`)
 2. **Import from vitest** - Use `import { describe, it, expect } from 'vitest'`
 3. **Use jsdom for DOM tests** - The test environment provides `document`, `window`, etc.
 4. **Test pure functions directly** - For utilities, test inputs and outputs

--- a/.github/instructions/js.instructions.md
+++ b/.github/instructions/js.instructions.md
@@ -29,7 +29,7 @@ js/
 - `npm run build` - Compile TypeScript to JavaScript
 - `npm run lint` - Run ESLint on TypeScript files
 - `npm run test` - Run unit tests with Vitest
-- `npm run test:coverage` - Run unit tests with code coverage report
+- `npm run test:cov` - Run unit tests with code coverage report
 - `npm run prepublishOnly` - Lint and build before publishing
 
 ## When to Add JavaScript

--- a/.github/instructions/js.instructions.md
+++ b/.github/instructions/js.instructions.md
@@ -27,6 +27,8 @@ js/
 
 - `npm run build` - Compile TypeScript to JavaScript
 - `npm run lint` - Run ESLint on TypeScript files
+- `npm run test` - Run unit tests with Vitest
+- `npm run test:coverage` - Run unit tests with code coverage report
 - `npm run prepublishOnly` - Lint and build before publishing
 
 ## When to Add JavaScript
@@ -63,9 +65,36 @@ Behavioral tests are in the `integration` package:
 - Tests use Playwright
 - Run from repository root: `npm run integration`
 
+## Unit Testing
+
+Unit tests use [Vitest](https://vitest.dev/) with a jsdom environment for DOM APIs.
+
+### Running Tests
+
+- `npm run test` - Run all unit tests (from `js/` folder or repo root)
+- `npm run test:coverage` - Run tests with code coverage report
+- `npx vitest --watch` - Watch mode during development (from `js/` folder)
+- `npx vitest run src/utilities/util.test.ts` - Run a specific test file
+
+### Writing Tests
+
+1. **Place test files next to source** - Use `*.test.ts` suffix (e.g., `util.test.ts` beside `util.ts`)
+2. **Import from vitest** - Use `import { describe, it, expect } from 'vitest'`
+3. **Use jsdom for DOM tests** - The test environment provides `document`, `window`, etc.
+4. **Test pure functions directly** - For utilities, test inputs and outputs
+5. **Test DOM behaviors** - For behaviors/elements, create DOM fixtures and assert side effects
+
+### Coverage
+
+- Coverage uses the `v8` provider via `@vitest/coverage-v8`
+- Reports are generated in `js/coverage/` (text, JSON summary, and HTML)
+- Coverage runs automatically in CI and is reported in the GitHub Actions job summary
+
 ## When Making Changes
 
 1. Run `npm run lint` before committing
 2. Build with `npm run build` to verify compilation
-3. Test interactively with the site package
-4. Add integration tests for new behaviors in the `integration` package
+3. Run `npm run test` to ensure all unit tests pass
+4. Test interactively with the site package
+5. Add unit tests for new utilities and pure functions
+6. Add integration tests for new behaviors in the `integration` package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Ensure build and lint
+name: Ensure build, lint, and test
 
 # Controls when the action will run.
 on:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,10 @@ jobs:
       - name: Run lint
         run: npm run lint;
 
+      # Run unit tests
+      - name: Run tests
+        run: npm test;
+
       # Run Dart Sass build
       - name: Build CSS
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
 
       # Run unit tests with coverage
       - name: Run tests
-        run: npm run test:coverage;
+        run: npm run test:cov;
 
       # Run Dart Sass build
       - name: Build CSS

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,9 +45,27 @@ jobs:
       - name: Run lint
         run: npm run lint;
 
-      # Run unit tests
+      # Run unit tests with coverage
       - name: Run tests
-        run: npm test;
+        run: npm run test:coverage;
+
+      - name: Report coverage summary
+        if: always()
+        run: |
+          $json = Get-Content js/coverage/coverage-summary.json | ConvertFrom-Json
+          $lines = $json.total.lines.pct
+          $branches = $json.total.branches.pct
+          $functions = $json.total.functions.pct
+          $statements = $json.total.statements.pct
+          Write-Output "## Code Coverage Summary" >> $env:GITHUB_STEP_SUMMARY
+          Write-Output "" >> $env:GITHUB_STEP_SUMMARY
+          Write-Output "| Metric | Coverage |" >> $env:GITHUB_STEP_SUMMARY
+          Write-Output "|--------|----------|" >> $env:GITHUB_STEP_SUMMARY
+          Write-Output "| Lines | ${lines}% |" >> $env:GITHUB_STEP_SUMMARY
+          Write-Output "| Branches | ${branches}% |" >> $env:GITHUB_STEP_SUMMARY
+          Write-Output "| Functions | ${functions}% |" >> $env:GITHUB_STEP_SUMMARY
+          Write-Output "| Statements | ${statements}% |" >> $env:GITHUB_STEP_SUMMARY
+        shell: pwsh
 
       # Run Dart Sass build
       - name: Build CSS

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,24 +49,6 @@ jobs:
       - name: Run tests
         run: npm run test:coverage;
 
-      - name: Report coverage summary
-        if: always()
-        run: |
-          $json = Get-Content js/coverage/coverage-summary.json | ConvertFrom-Json
-          $lines = $json.total.lines.pct
-          $branches = $json.total.branches.pct
-          $functions = $json.total.functions.pct
-          $statements = $json.total.statements.pct
-          Write-Output "## Code Coverage Summary" >> $env:GITHUB_STEP_SUMMARY
-          Write-Output "" >> $env:GITHUB_STEP_SUMMARY
-          Write-Output "| Metric | Coverage |" >> $env:GITHUB_STEP_SUMMARY
-          Write-Output "|--------|----------|" >> $env:GITHUB_STEP_SUMMARY
-          Write-Output "| Lines | ${lines}% |" >> $env:GITHUB_STEP_SUMMARY
-          Write-Output "| Branches | ${branches}% |" >> $env:GITHUB_STEP_SUMMARY
-          Write-Output "| Functions | ${functions}% |" >> $env:GITHUB_STEP_SUMMARY
-          Write-Output "| Statements | ${statements}% |" >> $env:GITHUB_STEP_SUMMARY
-        shell: pwsh
-
       # Run Dart Sass build
       - name: Build CSS
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ dist
 toc.json
 test-results/
 playwright-report/
+coverage/
 .wireit
 .netrc

--- a/extension/package.json
+++ b/extension/package.json
@@ -45,7 +45,7 @@
 		"esbuild-watch": "npm run esbuild-base -- --sourcemap --watch"
 	},
 	"dependencies": {
-		"@microsoft/atlas-css": "^6.0.0"
+		"@microsoft/atlas-css": "^6.6.1"
 	},
 	"devDependencies": {
 		"@types/glob": "^8.1.0",

--- a/js/.eslintrc.js
+++ b/js/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+	ignorePatterns: ['vitest.config.ts'],
 	env: {
 		browser: true,
 		node: false,

--- a/js/package.json
+++ b/js/package.json
@@ -9,7 +9,7 @@
 		"build": "tsc --project \"./tsconfig.json\" --outDir \"./dist\" --declaration true --declarationMap true",
 		"lint": "eslint . --ext .ts",
 		"prebuild": "rimraf dist",
-		"test": "echo \"Error: no test specified\" && exit 1",
+		"test": "vitest run",
 		"prepublishOnly": "npm run lint && npm run build"
 	},
 	"homepage": "https://github.com/microsoft/atlas-design",
@@ -42,8 +42,10 @@
 		"eslint-plugin-jasmine": "^4.1.3",
 		"eslint-plugin-jsdoc": "^46.3.0",
 		"eslint-plugin-security": "^1.7.1",
+		"jsdom": "^29.1.1",
 		"rimraf": "^5.0.1",
 		"tslib": "^2.6.0",
-		"typescript": "^5.1.5"
+		"typescript": "^5.1.5",
+		"vitest": "^4.1.6"
 	}
 }

--- a/js/package.json
+++ b/js/package.json
@@ -10,6 +10,7 @@
 		"lint": "eslint . --ext .ts",
 		"prebuild": "rimraf dist",
 		"test": "vitest run",
+		"test:coverage": "vitest run --coverage",
 		"prepublishOnly": "npm run lint && npm run build"
 	},
 	"homepage": "https://github.com/microsoft/atlas-design",
@@ -37,6 +38,7 @@
 	"author": "Microsoft Corporation",
 	"license": "MIT",
 	"devDependencies": {
+		"@vitest/coverage-v8": "^4.1.6",
 		"eslint": "^8.43.0",
 		"eslint-plugin-import": "^2.27.5",
 		"eslint-plugin-jasmine": "^4.1.3",

--- a/js/package.json
+++ b/js/package.json
@@ -10,7 +10,7 @@
 		"lint": "eslint . --ext .ts",
 		"prebuild": "rimraf dist",
 		"test": "vitest run",
-		"test:coverage": "vitest run --coverage",
+		"test:cov": "vitest run --coverage",
 		"prepublishOnly": "npm run lint && npm run build"
 	},
 	"homepage": "https://github.com/microsoft/atlas-design",

--- a/js/src/utilities/util.test.ts
+++ b/js/src/utilities/util.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { generateElementId, kebabToCamelCase } from './util';
+
+describe('generateElementId', () => {
+	it('should return a string starting with "bx-"', () => {
+		const id = generateElementId();
+		expect(id).toMatch(/^bx-\d+$/);
+	});
+
+	it('should return unique ids on subsequent calls', () => {
+		const id1 = generateElementId();
+		const id2 = generateElementId();
+		expect(id1).not.toBe(id2);
+	});
+});
+
+describe('kebabToCamelCase', () => {
+	it('should convert kebab-case to camelCase', () => {
+		expect(kebabToCamelCase('my-variable-name')).toBe('myVariableName');
+	});
+
+	it('should return the same string if no hyphens', () => {
+		expect(kebabToCamelCase('simple')).toBe('simple');
+	});
+
+	it('should handle single hyphen', () => {
+		expect(kebabToCamelCase('foo-bar')).toBe('fooBar');
+	});
+});

--- a/js/test/utilities/util.test.ts
+++ b/js/test/utilities/util.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateElementId, kebabToCamelCase } from './util';
+import { generateElementId, kebabToCamelCase } from '../../src/utilities/util';
 
 describe('generateElementId', () => {
 	it('should return a string starting with "bx-"', () => {

--- a/js/vitest.config.ts
+++ b/js/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		environment: 'jsdom',
+		include: ['src/**/*.test.ts']
+	}
+});

--- a/js/vitest.config.ts
+++ b/js/vitest.config.ts
@@ -3,13 +3,13 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
 	test: {
 		environment: 'jsdom',
-		include: ['src/**/*.test.ts'],
+		include: ['test/**/*.test.ts'],
 		coverage: {
 			provider: 'v8',
 			reporter: ['text', 'json-summary', 'html'],
 			reportsDirectory: './coverage',
 			include: ['src/**/*.ts'],
-			exclude: ['src/**/*.test.ts', 'src/index.ts']
+			exclude: ['src/index.ts']
 		}
 	}
 });

--- a/js/vitest.config.ts
+++ b/js/vitest.config.ts
@@ -10,13 +10,13 @@ export default defineConfig({
 			reporter: ['text', 'json-summary', 'html'],
 			reportsDirectory: './coverage',
 			include: ['src/**/*.ts'],
-			exclude: ['src/index.ts'],
-			thresholds: {
-				statements: 80,
-				branches: 80,
-				functions: 80,
-				lines: 80
-			}
+			exclude: ['src/index.ts']
+			// thresholds: {
+			// 	statements: 80,
+			// 	branches: 80,
+			// 	functions: 80,
+			// 	lines: 80
+			// }
 		}
 	}
 });

--- a/js/vitest.config.ts
+++ b/js/vitest.config.ts
@@ -10,7 +10,13 @@ export default defineConfig({
 			reporter: ['text', 'json-summary', 'html'],
 			reportsDirectory: './coverage',
 			include: ['src/**/*.ts'],
-			exclude: ['src/index.ts']
+			exclude: ['src/index.ts'],
+			thresholds: {
+				statements: 80,
+				branches: 80,
+				functions: 80,
+				lines: 80
+			}
 		}
 	}
 });

--- a/js/vitest.config.ts
+++ b/js/vitest.config.ts
@@ -3,6 +3,13 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
 	test: {
 		environment: 'jsdom',
-		include: ['src/**/*.test.ts']
+		include: ['src/**/*.test.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json-summary', 'html'],
+			reportsDirectory: './coverage',
+			include: ['src/**/*.ts'],
+			exclude: ['src/**/*.test.ts', 'src/index.ts']
+		}
 	}
 });

--- a/js/vitest.config.ts
+++ b/js/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
 	test: {
 		environment: 'jsdom',
 		include: ['test/**/*.test.ts'],
-		reporters: process.env.GITHUB_ACTIONS ? ['default', 'github-actions'] : ['default'],
+		reporters: process.env.GITHUB_ACTIONS === 'true' ? ['default', 'github-actions'] : ['default'],
 		coverage: {
 			provider: 'v8',
 			reporter: ['text', 'json-summary', 'html'],

--- a/js/vitest.config.ts
+++ b/js/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
 	test: {
 		environment: 'jsdom',
 		include: ['test/**/*.test.ts'],
+		reporters: process.env.GITHUB_ACTIONS ? ['default', 'github-actions'] : ['default'],
 		coverage: {
 			provider: 'v8',
 			reporter: ['text', 'json-summary', 'html'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -362,9 +362,11 @@
 				"eslint-plugin-jasmine": "^4.1.3",
 				"eslint-plugin-jsdoc": "^46.3.0",
 				"eslint-plugin-security": "^1.7.1",
+				"jsdom": "^29.1.1",
 				"rimraf": "^5.0.1",
 				"tslib": "^2.6.0",
-				"typescript": "^5.1.5"
+				"typescript": "^5.1.5",
+				"vitest": "^4.1.6"
 			},
 			"engines": {
 				"node": "24.15.0",
@@ -386,6 +388,173 @@
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "5.1.11",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+			"integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@csstools/css-calc": "^3.2.0",
+				"@csstools/css-color-parser": "^4.1.0",
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-calc": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+			"integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-color-parser": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+			"integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-parser-algorithms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-tokenizer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+			"integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@asamuzakjp/nwsapi": "^2.3.9",
+				"bidi-js": "^1.0.3",
+				"css-tree": "^3.2.1",
+				"is-potential-custom-element-name": "^1.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector/node_modules/css-tree": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector/node_modules/mdn-data": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
+			"license": "CC0-1.0"
+		},
+		"node_modules/@asamuzakjp/generational-cache": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+			"integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/nwsapi": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@axe-core/playwright": {
 			"version": "4.11.0",
@@ -601,6 +770,40 @@
 			"engines": {
 				"node": ">=6.9.0"
 			}
+		},
+		"node_modules/@bramus/specificity": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"css-tree": "^3.0.0"
+			},
+			"bin": {
+				"specificity": "bin/cli.js"
+			}
+		},
+		"node_modules/@bramus/specificity/node_modules/css-tree": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
+		"node_modules/@bramus/specificity/node_modules/mdn-data": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
+			"license": "CC0-1.0"
 		},
 		"node_modules/@cacheable/memory": {
 			"version": "2.0.7",
@@ -906,6 +1109,26 @@
 				"prettier": "^2.7.1"
 			}
 		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
 		"node_modules/@csstools/css-parser-algorithms": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
@@ -1020,6 +1243,40 @@
 				"url": "https://github.com/sponsors/JounQin"
 			}
 		},
+		"node_modules/@emnapi/core": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@es-joy/jsdoccomment": {
 			"version": "0.41.0",
 			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.41.0.tgz",
@@ -1115,6 +1372,24 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
+		"node_modules/@exodus/bytes": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+			"integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@noble/hashes": "^1.8.0 || ^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@noble/hashes": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@glideapps/ts-necessities": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/@glideapps/ts-necessities/-/ts-necessities-2.2.3.tgz",
@@ -1186,6 +1461,7 @@
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
 			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^5.1.2",
@@ -1203,6 +1479,7 @@
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
 			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -1215,6 +1492,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
 			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^6.0.1"
@@ -1225,6 +1503,13 @@
 			"funding": {
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@keyv/serialize": {
 			"version": "1.1.1",
@@ -1424,6 +1709,25 @@
 				"win32"
 			]
 		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1457,6 +1761,16 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.129.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
+			"integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
 			}
 		},
 		"node_modules/@parcel/bundler-default": {
@@ -7674,6 +7988,7 @@
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
 			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"engines": {
@@ -7696,10 +8011,299 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
+			"integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
+			"integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
+			"integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
+			"integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
+			"integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
+			"integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
+			"integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
+			"integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
+			"integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
+			"integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
+			"integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
+			"integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
+			"integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.10.0",
+				"@emnapi/runtime": "1.10.0",
+				"@napi-rs/wasm-runtime": "^1.1.4"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
+			"integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
+			"integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
+			"integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@rtsao/scc": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
 			"integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -7780,6 +8384,42 @@
 			"dependencies": {
 				"@swc/counter": "^0.1.3"
 			}
+		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/glob": {
 			"version": "8.1.0",
@@ -8095,6 +8735,92 @@
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+			"integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.6",
+				"@vitest/utils": "4.1.6",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+			"integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+			"integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.6",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+			"integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.6",
+				"@vitest/utils": "4.1.6",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+			"integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+			"integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.6",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
 		},
 		"node_modules/@vscode/test-electron": {
 			"version": "2.5.2",
@@ -8559,6 +9285,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/astral-regex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -8630,6 +9366,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/base-x": {
@@ -8682,6 +9419,16 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/bidi-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"require-from-string": "^2.0.2"
 			}
 		},
 		"node_modules/binary-extensions": {
@@ -8737,6 +9484,7 @@
 			"version": "1.1.14",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
 			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -8977,6 +9725,16 @@
 			],
 			"license": "CC-BY-4.0"
 		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -9103,6 +9861,7 @@
 			"version": "3.9.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
 			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -9289,6 +10048,14 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/core-util-is": {
@@ -9348,6 +10115,7 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -9423,6 +10191,68 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/data-urls": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/data-urls/node_modules/tr46": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/data-urls/node_modules/webidl-conversions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/data-urls/node_modules/whatwg-mimetype": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/data-urls/node_modules/whatwg-url": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.11.0",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
 		"node_modules/data-view-buffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -9493,6 +10323,13 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/decompress-response": {
 			"version": "6.0.0",
@@ -9780,6 +10617,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/ecdsa-sig-formatter": {
@@ -9802,6 +10640,7 @@
 			"version": "9.2.2",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/encoding-sniffer": {
@@ -9975,6 +10814,13 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/es-module-lexer": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -10075,6 +10921,431 @@
 				"@esbuild/win32-arm64": "0.25.12",
 				"@esbuild/win32-ia32": "0.25.12",
 				"@esbuild/win32-x64": "0.25.12"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+			"integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/android-arm": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+			"integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+			"integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/android-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+			"integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+			"integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+			"integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+			"integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+			"integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+			"integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+			"integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+			"integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+			"integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+			"integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+			"integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+			"integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+			"integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+			"integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+			"integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+			"integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+			"integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+			"integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+			"integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/escalade": {
@@ -10537,6 +11808,16 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -10600,6 +11881,16 @@
 			"optional": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/extendable-error": {
@@ -10708,6 +11999,24 @@
 				"pend": "~1.2.0"
 			}
 		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -10814,6 +12123,7 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
 			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"cross-spawn": "^7.0.6",
@@ -10830,6 +12140,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
@@ -11116,6 +12427,7 @@
 			"version": "10.5.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
 			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"foreground-child": "^3.1.0",
@@ -11149,6 +12461,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
 			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
@@ -11158,6 +12471,7 @@
 			"version": "9.0.9",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
 			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.2"
@@ -11282,6 +12596,7 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/graphemer": {
@@ -11437,12 +12752,26 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
 			"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.6.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/html-tags": {
@@ -12066,6 +13395,13 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/is-regex": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -12300,6 +13636,7 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
 			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/cliui": "^8.0.2"
@@ -12344,6 +13681,177 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "29.1.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+			"integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/css-color": "^5.1.11",
+				"@asamuzakjp/dom-selector": "^7.1.1",
+				"@bramus/specificity": "^2.4.2",
+				"@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+				"@exodus/bytes": "^1.15.0",
+				"css-tree": "^3.2.1",
+				"data-urls": "^7.0.0",
+				"decimal.js": "^10.6.0",
+				"html-encoding-sniffer": "^6.0.0",
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.3.5",
+				"parse5": "^8.0.1",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^6.0.1",
+				"undici": "^7.25.0",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^8.0.1",
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.1",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jsdom/node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+			"integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jsdom/node_modules/css-tree": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
+		"node_modules/jsdom/node_modules/entities": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/jsdom/node_modules/lru-cache": {
+			"version": "11.3.6",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+			"integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/jsdom/node_modules/mdn-data": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
+			"license": "CC0-1.0"
+		},
+		"node_modules/jsdom/node_modules/parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^8.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/jsdom/node_modules/tr46": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/jsdom/node_modules/webidl-conversions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/jsdom/node_modules/whatwg-mimetype": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/jsdom/node_modules/whatwg-url": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.11.0",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/json-buffer": {
@@ -12543,9 +14051,9 @@
 			}
 		},
 		"node_modules/lightningcss": {
-			"version": "1.31.1",
-			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
-			"integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
 			"license": "MPL-2.0",
 			"dependencies": {
 				"detect-libc": "^2.0.3"
@@ -12558,23 +14066,235 @@
 				"url": "https://opencollective.com/parcel"
 			},
 			"optionalDependencies": {
-				"lightningcss-android-arm64": "1.31.1",
-				"lightningcss-darwin-arm64": "1.31.1",
-				"lightningcss-darwin-x64": "1.31.1",
-				"lightningcss-freebsd-x64": "1.31.1",
-				"lightningcss-linux-arm-gnueabihf": "1.31.1",
-				"lightningcss-linux-arm64-gnu": "1.31.1",
-				"lightningcss-linux-arm64-musl": "1.31.1",
-				"lightningcss-linux-x64-gnu": "1.31.1",
-				"lightningcss-linux-x64-musl": "1.31.1",
-				"lightningcss-win32-arm64-msvc": "1.31.1",
-				"lightningcss-win32-x64-msvc": "1.31.1"
+				"lightningcss-android-arm64": "1.32.0",
+				"lightningcss-darwin-arm64": "1.32.0",
+				"lightningcss-darwin-x64": "1.32.0",
+				"lightningcss-freebsd-x64": "1.32.0",
+				"lightningcss-linux-arm-gnueabihf": "1.32.0",
+				"lightningcss-linux-arm64-gnu": "1.32.0",
+				"lightningcss-linux-arm64-musl": "1.32.0",
+				"lightningcss-linux-x64-gnu": "1.32.0",
+				"lightningcss-linux-x64-musl": "1.32.0",
+				"lightningcss-win32-arm64-msvc": "1.32.0",
+				"lightningcss-win32-x64-msvc": "1.32.0"
+			}
+		},
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+			"integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+			"integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+			"integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+			"integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+			"integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+			"integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+			"integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/lightningcss-win32-x64-msvc": {
-			"version": "1.31.1",
-			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz",
-			"integrity": "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==",
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+			"integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
 			"cpu": [
 				"x64"
 			],
@@ -12757,12 +14477,23 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
 		"node_modules/markdown-it": {
@@ -12971,6 +14702,7 @@
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
 			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
@@ -12993,6 +14725,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
 			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -13252,6 +14985,7 @@
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/nanoid": {
@@ -15289,6 +17023,17 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/obug": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT"
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -15573,6 +17318,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
 			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -15592,6 +17338,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
 			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true,
 			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/package-manager-detector": {
@@ -15835,6 +17582,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -15851,6 +17599,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
 			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"lru-cache": "^10.2.0",
@@ -15867,6 +17616,7 @@
 			"version": "10.4.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
 			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/path-type": {
@@ -15877,6 +17627,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/pend": {
 			"version": "1.2.0",
@@ -16692,6 +18449,7 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
 			"integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"mute-stream": "~0.0.4"
@@ -17003,6 +18761,40 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/rolldown": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
+			"integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "=0.129.0",
+				"@rolldown/pluginutils": "1.0.0"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.0.0",
+				"@rolldown/binding-darwin-arm64": "1.0.0",
+				"@rolldown/binding-darwin-x64": "1.0.0",
+				"@rolldown/binding-freebsd-x64": "1.0.0",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.0",
+				"@rolldown/binding-linux-arm64-musl": "1.0.0",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.0",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.0",
+				"@rolldown/binding-linux-x64-gnu": "1.0.0",
+				"@rolldown/binding-linux-x64-musl": "1.0.0",
+				"@rolldown/binding-openharmony-arm64": "1.0.0",
+				"@rolldown/binding-wasm32-wasi": "1.0.0",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.0",
+				"@rolldown/binding-win32-x64-msvc": "1.0.0"
+			}
+		},
 		"node_modules/run-applescript": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -17246,6 +19038,19 @@
 				"node": ">=11.0.0"
 			}
 		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
+		},
 		"node_modules/semver": {
 			"version": "7.7.3",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -17348,6 +19153,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -17360,6 +19166,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -17440,6 +19247,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/signal-exit": {
 			"version": "3.0.7",
@@ -17560,12 +19374,14 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
 			"integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+			"dev": true,
 			"license": "CC-BY-3.0"
 		},
 		"node_modules/spdx-expression-parse": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
 			"integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"spdx-exceptions": "^2.1.0",
@@ -17576,6 +19392,7 @@
 			"version": "3.0.22",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
 			"integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+			"dev": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/sprintf-js": {
@@ -17583,6 +19400,20 @@
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/stdin-discarder": {
 			"version": "0.2.2",
@@ -17632,6 +19463,7 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
 			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"eastasianwidth": "^0.2.0",
@@ -17650,6 +19482,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -17664,12 +19497,14 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/string-width/node_modules/ansi-regex": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
 			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -17682,6 +19517,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
 			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^6.0.1"
@@ -17769,6 +19605,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -18271,6 +20108,13 @@
 			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
 			"integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA=="
 		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/table": {
 			"version": "6.9.0",
 			"resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
@@ -18393,6 +20237,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/through": {
@@ -18406,6 +20251,70 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
 			"integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+			"integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.16",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tldts": {
+			"version": "7.0.30",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+			"integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^7.0.30"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "7.0.30",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+			"integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -18429,6 +20338,19 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+			"integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tldts": "^7.0.5"
+			},
+			"engines": {
+				"node": ">=16"
 			}
 		},
 		"node_modules/tr46": {
@@ -18814,6 +20736,229 @@
 				"uuid": "dist/bin/uuid"
 			}
 		},
+		"node_modules/vitest": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+			"integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.6",
+				"@vitest/mocker": "4.1.6",
+				"@vitest/pretty-format": "4.1.6",
+				"@vitest/runner": "4.1.6",
+				"@vitest/snapshot": "4.1.6",
+				"@vitest/spy": "4.1.6",
+				"@vitest/utils": "4.1.6",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.6",
+				"@vitest/browser-preview": "4.1.6",
+				"@vitest/browser-webdriverio": "4.1.6",
+				"@vitest/coverage-istanbul": "4.1.6",
+				"@vitest/coverage-v8": "4.1.6",
+				"@vitest/ui": "4.1.6",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/@vitest/mocker": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+			"integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.6",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/vitest/node_modules/vite": {
+			"version": "8.0.12",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
+			"integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.4",
+				"postcss": "^8.5.14",
+				"rolldown": "1.0.0",
+				"tinyglobby": "^0.2.16"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.1.18",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/weak-lru-cache": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
@@ -18879,6 +21024,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -18996,6 +21142,23 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/wireit": {
 			"version": "0.14.9",
 			"resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.9.tgz",
@@ -19071,6 +21234,7 @@
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
 			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^6.1.0",
@@ -19089,6 +21253,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -19106,12 +21271,14 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -19126,6 +21293,7 @@
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
 			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -19138,6 +21306,7 @@
 			"version": "6.2.3",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
 			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -19150,6 +21319,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
 			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^6.0.1"
@@ -19209,6 +21379,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/xml2js": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
@@ -19233,6 +21413,13 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -19247,6 +21434,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
@@ -19709,6 +21897,228 @@
 				"lightningcss-linux-x64-musl": "1.30.2",
 				"lightningcss-win32-arm64-msvc": "1.30.2",
 				"lightningcss-win32-x64-msvc": "1.30.2"
+			}
+		},
+		"site/node_modules/lightningcss-android-arm64": {
+			"version": "1.30.2",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
+			"integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"site/node_modules/lightningcss-darwin-arm64": {
+			"version": "1.30.2",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
+			"integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"site/node_modules/lightningcss-darwin-x64": {
+			"version": "1.30.2",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
+			"integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"site/node_modules/lightningcss-freebsd-x64": {
+			"version": "1.30.2",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
+			"integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"site/node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.30.2",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
+			"integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"site/node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.30.2",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
+			"integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"site/node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.30.2",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
+			"integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"site/node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.30.2",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
+			"integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"site/node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.30.2",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
+			"integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"site/node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.30.2",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
+			"integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"site/node_modules/lightningcss-win32-x64-msvc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -357,6 +357,7 @@
 			"version": "1.15.1",
 			"license": "MIT",
 			"devDependencies": {
+				"@vitest/coverage-v8": "^4.1.6",
 				"eslint": "^8.43.0",
 				"eslint-plugin-import": "^2.27.5",
 				"eslint-plugin-jasmine": "^4.1.3",
@@ -752,6 +753,16 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@babel/helper-validator-identifier": {
 			"version": "7.28.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
@@ -759,6 +770,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+			"integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.29.0"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@babel/runtime": {
@@ -769,6 +796,30 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@bcoe/v8-coverage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+			"integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@bramus/specificity": {
@@ -1504,12 +1555,33 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
 			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
 		},
 		"node_modules/@keyv/serialize": {
 			"version": "1.1.1",
@@ -8736,6 +8808,37 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/@vitest/coverage-v8": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+			"integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@bcoe/v8-coverage": "^1.0.2",
+				"@vitest/utils": "4.1.6",
+				"ast-v8-to-istanbul": "^1.0.0",
+				"istanbul-lib-coverage": "^3.2.2",
+				"istanbul-lib-report": "^3.0.1",
+				"istanbul-reports": "^3.2.0",
+				"magicast": "^0.5.2",
+				"obug": "^2.1.1",
+				"std-env": "^4.0.0-rc.1",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@vitest/browser": "4.1.6",
+				"vitest": "4.1.6"
+			},
+			"peerDependenciesMeta": {
+				"@vitest/browser": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@vitest/expect": {
 			"version": "4.1.6",
 			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
@@ -9294,6 +9397,25 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/ast-v8-to-istanbul": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+			"integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.31",
+				"estree-walker": "^3.0.3",
+				"js-tokens": "^10.0.0"
+			}
+		},
+		"node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/astral-regex": {
 			"version": "2.0.0",
@@ -12774,6 +12896,13 @@
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
+		"node_modules/html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/html-tags": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
@@ -13631,6 +13760,45 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"license": "ISC"
+		},
+		"node_modules/istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-report": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^4.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-reports": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+			"integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/jackspeak": {
 			"version": "3.4.3",
@@ -14494,6 +14662,34 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/magicast": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+			"integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"source-map-js": "^1.2.1"
+			}
+		},
+		"node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/markdown-it": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,102 +60,10 @@
 				"npm": "11.12.1"
 			}
 		},
-		"css/node_modules/@csstools/media-query-list-parser": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-3.0.1.tgz",
-			"integrity": "sha512-HNo8gGD02kHmcbX6PvCoUuOQvn4szyB9ca63vZHKX5A81QytgDG4oxG4IaEfHTlEZSZ6MjPEMWIVU+zF2PZcgw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.1",
-				"@csstools/css-tokenizer": "^3.0.1"
-			}
-		},
-		"css/node_modules/balanced-match": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
-			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"css/node_modules/cosmiconfig": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"env-paths": "^2.2.1",
-				"import-fresh": "^3.3.0",
-				"js-yaml": "^4.1.0",
-				"parse-json": "^5.2.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/d-fischer"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.9.5"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"css/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"css/node_modules/file-entry-cache": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-9.1.0.tgz",
-			"integrity": "sha512-/pqPFG+FdxWQj+/WSuzXSDaNzxgTLr/OrR1QuqfEZzDakpdYE70PwUxL7BPUa8hpjbvY1+qvCl8k+8Tq34xJgg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"flat-cache": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"css/node_modules/flat-cache": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
-			"integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"flatted": "^3.3.1",
-				"keyv": "^4.5.4"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"css/node_modules/fs-extra": {
-			"version": "11.3.3",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-			"integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -167,120 +75,11 @@
 				"node": ">=14.14"
 			}
 		},
-		"css/node_modules/ignore": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-6.0.2.tgz",
-			"integrity": "sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
-		"css/node_modules/mdn-data": {
-			"version": "2.12.2",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-			"dev": true,
-			"license": "CC0-1.0"
-		},
-		"css/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"css/node_modules/stylelint": {
-			"version": "16.10.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.10.0.tgz",
-			"integrity": "sha512-z/8X2rZ52dt2c0stVwI9QL2AFJhLhbPkyfpDFcizs200V/g7v+UYY6SNcB9hKOLcDDX/yGLDsY/pX08sLkz9xQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/stylelint"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/stylelint"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.1",
-				"@csstools/css-tokenizer": "^3.0.1",
-				"@csstools/media-query-list-parser": "^3.0.1",
-				"@csstools/selector-specificity": "^4.0.0",
-				"@dual-bundle/import-meta-resolve": "^4.1.0",
-				"balanced-match": "^2.0.0",
-				"colord": "^2.9.3",
-				"cosmiconfig": "^9.0.0",
-				"css-functions-list": "^3.2.3",
-				"css-tree": "^3.0.0",
-				"debug": "^4.3.7",
-				"fast-glob": "^3.3.2",
-				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^9.1.0",
-				"global-modules": "^2.0.0",
-				"globby": "^11.1.0",
-				"globjoin": "^0.1.4",
-				"html-tags": "^3.3.1",
-				"ignore": "^6.0.2",
-				"imurmurhash": "^0.1.4",
-				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.34.0",
-				"mathml-tag-names": "^2.1.3",
-				"meow": "^13.2.0",
-				"micromatch": "^4.0.8",
-				"normalize-path": "^3.0.0",
-				"picocolors": "^1.0.1",
-				"postcss": "^8.4.47",
-				"postcss-resolve-nested-selector": "^0.1.6",
-				"postcss-safe-parser": "^7.0.1",
-				"postcss-selector-parser": "^6.1.2",
-				"postcss-value-parser": "^4.2.0",
-				"resolve-from": "^5.0.0",
-				"string-width": "^4.2.3",
-				"supports-hyperlinks": "^3.1.0",
-				"svg-tags": "^1.0.0",
-				"table": "^6.8.2",
-				"write-file-atomic": "^5.0.1"
-			},
-			"bin": {
-				"stylelint": "bin/stylelint.mjs"
-			},
-			"engines": {
-				"node": ">=18.12.0"
-			}
-		},
-		"css/node_modules/stylelint/node_modules/css-tree": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mdn-data": "2.12.2",
-				"source-map-js": "^1.0.1"
-			},
-			"engines": {
-				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-			}
-		},
 		"extension": {
 			"name": "atlas-design-system-tools",
 			"version": "0.0.10",
 			"dependencies": {
-				"@microsoft/atlas-css": "^6.0.0"
+				"@microsoft/atlas-css": "^6.6.1"
 			},
 			"devDependencies": {
 				"@types/glob": "^8.1.0",
@@ -304,9 +103,9 @@
 			}
 		},
 		"extension/node_modules/@types/node": {
-			"version": "24.10.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
-			"integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
+			"version": "24.12.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+			"integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -338,9 +137,9 @@
 			}
 		},
 		"integration/node_modules/fs-extra": {
-			"version": "11.3.3",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-			"integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -407,101 +206,6 @@
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-calc": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
-			"integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.19.0"
-			},
-			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-tokenizer": "^4.0.0"
-			}
-		},
-		"node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-color-parser": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
-			"integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@csstools/color-helpers": "^6.0.2",
-				"@csstools/css-calc": "^3.2.0"
-			},
-			"engines": {
-				"node": ">=20.19.0"
-			},
-			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-tokenizer": "^4.0.0"
-			}
-		},
-		"node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-parser-algorithms": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.19.0"
-			},
-			"peerDependencies": {
-				"@csstools/css-tokenizer": "^4.0.0"
-			}
-		},
-		"node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-tokenizer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.19.0"
-			}
-		},
 		"node_modules/@asamuzakjp/dom-selector": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
@@ -558,13 +262,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@axe-core/playwright": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.0.tgz",
-			"integrity": "sha512-70vBT/Ylqpm65RQz2iCG2o0JJCEG/WCNyefTr2xcOcr1CoSee60gNQYUMZZ7YukoKkFLv26I/jjlsvwwp532oQ==",
+			"version": "4.11.3",
+			"resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+			"integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
 			"dev": true,
 			"license": "MPL-2.0",
 			"dependencies": {
-				"axe-core": "~4.11.0"
+				"axe-core": "~4.11.4"
 			},
 			"peerDependencies": {
 				"playwright-core": ">= 1.0.0"
@@ -618,9 +322,9 @@
 			}
 		},
 		"node_modules/@azure/core-rest-pipeline": {
-			"version": "1.22.2",
-			"resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.2.tgz",
-			"integrity": "sha512-MzHym+wOi8CLUlKCQu12de0nwcq9k9Kuv43j4Wa++CsCpJwps2eeBQwD2Bu8snkxTtDKDx4GwjuR9E8yC8LNrg==",
+			"version": "1.23.0",
+			"resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+			"integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -629,7 +333,7 @@
 				"@azure/core-tracing": "^1.3.0",
 				"@azure/core-util": "^1.13.0",
 				"@azure/logger": "^1.3.0",
-				"@typespec/ts-http-runtime": "^0.3.0",
+				"@typespec/ts-http-runtime": "^0.3.4",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -665,9 +369,9 @@
 			}
 		},
 		"node_modules/@azure/identity": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.0.tgz",
-			"integrity": "sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+			"integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -678,8 +382,8 @@
 				"@azure/core-tracing": "^1.0.0",
 				"@azure/core-util": "^1.11.0",
 				"@azure/logger": "^1.0.0",
-				"@azure/msal-browser": "^4.2.0",
-				"@azure/msal-node": "^3.5.0",
+				"@azure/msal-browser": "^5.5.0",
+				"@azure/msal-node": "^5.1.0",
 				"open": "^10.1.0",
 				"tslib": "^2.2.0"
 			},
@@ -702,22 +406,22 @@
 			}
 		},
 		"node_modules/@azure/msal-browser": {
-			"version": "4.28.1",
-			"resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.28.1.tgz",
-			"integrity": "sha512-al2u2fTchbClq3L4C1NlqLm+vwKfhYCPtZN2LR/9xJVaQ4Mnrwf5vANvuyPSJHcGvw50UBmhuVmYUAhTEetTpA==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.10.1.tgz",
+			"integrity": "sha512-hTbvOi9Ko2Jvn+G/fSmjzHf9WbNcf/o3epMtbeGx/pMwMrVAbi6OgCJVeCfsAb8IybSRpaCSc4EDRlYAhgngUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@azure/msal-common": "15.14.1"
+				"@azure/msal-common": "16.6.1"
 			},
 			"engines": {
 				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/@azure/msal-common": {
-			"version": "15.14.1",
-			"resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.14.1.tgz",
-			"integrity": "sha512-IkzF7Pywt6QKTS0kwdCv/XV8x8JXknZDvSjj/IccooxnP373T5jaadO3FnOrbWo3S0UqkfIDyZNTaQ/oAgRdXw==",
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.1.tgz",
+			"integrity": "sha512-VxKdEtUwDuLD0F1hOQP7kye0YadZxFJfv37Em440geEf/w9uggKnHpRrqwZJOdxmPUOdhZ9kyRtKuAJW8wUcRg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -725,24 +429,23 @@
 			}
 		},
 		"node_modules/@azure/msal-node": {
-			"version": "3.8.6",
-			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.8.6.tgz",
-			"integrity": "sha512-XTmhdItcBckcVVTy65Xp+42xG4LX5GK+9AqAsXPXk4IqUNv+LyQo5TMwNjuFYBfAB2GTG9iSQGk+QLc03vhf3w==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.1.tgz",
+			"integrity": "sha512-tmQiQ2HvtzaeLqYGy3BemiPOSGPY4wCy1IW5zDWITKSs/s35WEd7Zij/hCxvUdAOzj6U3qnyaGbYXY91ortFEQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@azure/msal-common": "15.14.1",
-				"jsonwebtoken": "^9.0.0",
-				"uuid": "^8.3.0"
+				"@azure/msal-common": "16.6.1",
+				"jsonwebtoken": "^9.0.0"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
-			"integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.28.5",
@@ -752,6 +455,12 @@
 			"engines": {
 				"node": ">=6.9.0"
 			}
+		},
+		"node_modules/@babel/code-frame/node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"license": "MIT"
 		},
 		"node_modules/@babel/helper-string-parser": {
 			"version": "7.27.1",
@@ -789,9 +498,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -856,75 +565,14 @@
 			"dev": true,
 			"license": "CC0-1.0"
 		},
-		"node_modules/@cacheable/memory": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.7.tgz",
-			"integrity": "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@cacheable/utils": "^2.3.3",
-				"@keyv/bigmap": "^1.3.0",
-				"hookified": "^1.14.0",
-				"keyv": "^5.5.5"
-			}
-		},
-		"node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
-			"integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"hashery": "^1.4.0",
-				"hookified": "^1.15.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"peerDependencies": {
-				"keyv": "^5.6.0"
-			}
-		},
-		"node_modules/@cacheable/memory/node_modules/keyv": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
-			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@keyv/serialize": "^1.1.1"
-			}
-		},
-		"node_modules/@cacheable/utils": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.3.tgz",
-			"integrity": "sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"hashery": "^1.3.0",
-				"keyv": "^5.5.5"
-			}
-		},
-		"node_modules/@cacheable/utils/node_modules/keyv": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
-			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@keyv/serialize": "^1.1.1"
-			}
-		},
 		"node_modules/@changesets/apply-release-plan": {
-			"version": "7.0.14",
-			"resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.14.tgz",
-			"integrity": "sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.1.tgz",
+			"integrity": "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@changesets/config": "^3.1.2",
+				"@changesets/config": "^3.1.4",
 				"@changesets/get-version-range-type": "^0.4.0",
 				"@changesets/git": "^3.0.4",
 				"@changesets/should-skip-package": "^0.1.2",
@@ -940,14 +588,14 @@
 			}
 		},
 		"node_modules/@changesets/assemble-release-plan": {
-			"version": "6.0.9",
-			"resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.9.tgz",
-			"integrity": "sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==",
+			"version": "6.0.10",
+			"resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.10.tgz",
+			"integrity": "sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@changesets/errors": "^0.2.0",
-				"@changesets/get-dependents-graph": "^2.1.3",
+				"@changesets/get-dependents-graph": "^2.1.4",
 				"@changesets/should-skip-package": "^0.1.2",
 				"@changesets/types": "^6.1.0",
 				"@manypkg/get-packages": "^1.1.3",
@@ -965,34 +613,32 @@
 			}
 		},
 		"node_modules/@changesets/cli": {
-			"version": "2.29.8",
-			"resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.29.8.tgz",
-			"integrity": "sha512-1weuGZpP63YWUYjay/E84qqwcnt5yJMM0tep10Up7Q5cS/DGe2IZ0Uj3HNMxGhCINZuR7aO9WBMdKnPit5ZDPA==",
+			"version": "2.31.0",
+			"resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.31.0.tgz",
+			"integrity": "sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@changesets/apply-release-plan": "^7.0.14",
-				"@changesets/assemble-release-plan": "^6.0.9",
+				"@changesets/apply-release-plan": "^7.1.1",
+				"@changesets/assemble-release-plan": "^6.0.10",
 				"@changesets/changelog-git": "^0.2.1",
-				"@changesets/config": "^3.1.2",
+				"@changesets/config": "^3.1.4",
 				"@changesets/errors": "^0.2.0",
-				"@changesets/get-dependents-graph": "^2.1.3",
-				"@changesets/get-release-plan": "^4.0.14",
+				"@changesets/get-dependents-graph": "^2.1.4",
+				"@changesets/get-release-plan": "^4.0.16",
 				"@changesets/git": "^3.0.4",
 				"@changesets/logger": "^0.1.1",
 				"@changesets/pre": "^2.0.2",
-				"@changesets/read": "^0.6.6",
+				"@changesets/read": "^0.6.7",
 				"@changesets/should-skip-package": "^0.1.2",
 				"@changesets/types": "^6.1.0",
 				"@changesets/write": "^0.4.0",
 				"@inquirer/external-editor": "^1.0.2",
 				"@manypkg/get-packages": "^1.1.3",
 				"ansi-colors": "^4.1.3",
-				"ci-info": "^3.7.0",
 				"enquirer": "^2.4.1",
 				"fs-extra": "^7.0.1",
 				"mri": "^1.2.0",
-				"p-limit": "^2.2.0",
 				"package-manager-detector": "^0.2.0",
 				"picocolors": "^1.1.0",
 				"resolve-from": "^5.0.0",
@@ -1005,15 +651,16 @@
 			}
 		},
 		"node_modules/@changesets/config": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.2.tgz",
-			"integrity": "sha512-CYiRhA4bWKemdYi/uwImjPxqWNpqGPNbEBdX1BdONALFIDK7MCUj6FPkzD+z9gJcvDFUQJn9aDVf4UG7OT6Kog==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.4.tgz",
+			"integrity": "sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@changesets/errors": "^0.2.0",
-				"@changesets/get-dependents-graph": "^2.1.3",
+				"@changesets/get-dependents-graph": "^2.1.4",
 				"@changesets/logger": "^0.1.1",
+				"@changesets/should-skip-package": "^0.1.2",
 				"@changesets/types": "^6.1.0",
 				"@manypkg/get-packages": "^1.1.3",
 				"fs-extra": "^7.0.1",
@@ -1031,9 +678,9 @@
 			}
 		},
 		"node_modules/@changesets/get-dependents-graph": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.3.tgz",
-			"integrity": "sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.4.tgz",
+			"integrity": "sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1044,16 +691,16 @@
 			}
 		},
 		"node_modules/@changesets/get-release-plan": {
-			"version": "4.0.14",
-			"resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.14.tgz",
-			"integrity": "sha512-yjZMHpUHgl4Xl5gRlolVuxDkm4HgSJqT93Ri1Uz8kGrQb+5iJ8dkXJ20M2j/Y4iV5QzS2c5SeTxVSKX+2eMI0g==",
+			"version": "4.0.16",
+			"resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.16.tgz",
+			"integrity": "sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@changesets/assemble-release-plan": "^6.0.9",
-				"@changesets/config": "^3.1.2",
+				"@changesets/assemble-release-plan": "^6.0.10",
+				"@changesets/config": "^3.1.4",
 				"@changesets/pre": "^2.0.2",
-				"@changesets/read": "^0.6.6",
+				"@changesets/read": "^0.6.7",
 				"@changesets/types": "^6.1.0",
 				"@manypkg/get-packages": "^1.1.3"
 			}
@@ -1090,9 +737,9 @@
 			}
 		},
 		"node_modules/@changesets/parse": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.2.tgz",
-			"integrity": "sha512-Uo5MC5mfg4OM0jU3up66fmSn6/NE9INK+8/Vn/7sMVcdWg46zfbvvUSjD9EMonVqPi9fbrJH9SXHn48Tr1f2yA==",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.3.tgz",
+			"integrity": "sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1114,15 +761,15 @@
 			}
 		},
 		"node_modules/@changesets/read": {
-			"version": "0.6.6",
-			"resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.6.tgz",
-			"integrity": "sha512-P5QaN9hJSQQKJShzzpBT13FzOSPyHbqdoIBUd2DJdgvnECCyO6LmAOWSV+O8se2TaZJVwSXjL+v9yhb+a9JeJg==",
+			"version": "0.6.7",
+			"resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.7.tgz",
+			"integrity": "sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@changesets/git": "^3.0.4",
 				"@changesets/logger": "^0.1.1",
-				"@changesets/parse": "^0.4.2",
+				"@changesets/parse": "^0.4.3",
 				"@changesets/types": "^6.1.0",
 				"fs-extra": "^7.0.1",
 				"p-filter": "^2.1.0",
@@ -1180,10 +827,11 @@
 				"node": ">=20.19.0"
 			}
 		},
-		"node_modules/@csstools/css-parser-algorithms": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+		"node_modules/@csstools/css-calc": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+			"integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -1196,16 +844,69 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
-				"@csstools/css-tokenizer": "^3.0.4"
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+			"integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.2.1"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^4.0.0"
 			}
 		},
 		"node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.0.26",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
-			"integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+			"integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -1217,12 +918,20 @@
 				}
 			],
 			"license": "MIT-0",
-			"peer": true
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@csstools/css-tokenizer": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -1235,13 +944,13 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			}
 		},
 		"node_modules/@csstools/media-query-list-parser": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
-			"integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-3.0.1.tgz",
+			"integrity": "sha512-HNo8gGD02kHmcbX6PvCoUuOQvn4szyB9ca63vZHKX5A81QytgDG4oxG4IaEfHTlEZSZ6MjPEMWIVU+zF2PZcgw==",
 			"funding": [
 				{
 					"type": "github",
@@ -1253,13 +962,12 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-tokenizer": "^3.0.4"
+				"@csstools/css-parser-algorithms": "^3.0.1",
+				"@csstools/css-tokenizer": "^3.0.1"
 			}
 		},
 		"node_modules/@csstools/selector-specificity": {
@@ -1341,6 +1049,431 @@
 			},
 			"engines": {
 				"node": ">=16"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+			"integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+			"integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+			"integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+			"integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+			"integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+			"integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+			"integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+			"integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+			"integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+			"integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+			"integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+			"integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+			"integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+			"integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+			"integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+			"integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+			"integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+			"integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+			"integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+			"integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+			"integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+			"integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
@@ -1512,7 +1645,6 @@
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
 			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^5.1.2",
@@ -1530,7 +1662,6 @@
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
 			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -1540,13 +1671,12 @@
 			}
 		},
 		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-			"dev": true,
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^6.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
 				"node": ">=12"
@@ -1583,27 +1713,85 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
-		"node_modules/@keyv/serialize": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
-			"integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/@lezer/common": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.0.tgz",
-			"integrity": "sha512-PNGcolp9hr4PJdXR4ix7XtixDrClScvtSCYW3rQG106oVMOOI+jFb+0+J3mbeL/53g1Zd6s0kJzaw6Ri68GmAA==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+			"integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
 			"license": "MIT"
 		},
 		"node_modules/@lezer/lr": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
-			"integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+			"version": "1.4.10",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+			"integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
 			"license": "MIT",
 			"dependencies": {
 				"@lezer/common": "^1.0.0"
 			}
+		},
+		"node_modules/@lmdb/lmdb-darwin-arm64": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.8.5.tgz",
+			"integrity": "sha512-KPDeVScZgA1oq0CiPBcOa3kHIqU+pTOwRFDIhxvmf8CTNvqdZQYp5cCKW0bUk69VygB2PuTiINFWbY78aR2pQw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@lmdb/lmdb-darwin-x64": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.8.5.tgz",
+			"integrity": "sha512-w/sLhN4T7MW1nB3R/U8WK5BgQLz904wh+/SmA2jD8NnF7BLLoUgflCNxOeSPOWp8geP6nP/+VjWzZVip7rZ1ug==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@lmdb/lmdb-linux-arm": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.8.5.tgz",
+			"integrity": "sha512-c0TGMbm2M55pwTDIfkDLB6BpIsgxV4PjYck2HiOX+cy/JWiBXz32lYbarPqejKs9Flm7YVAKSILUducU9g2RVg==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@lmdb/lmdb-linux-arm64": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.8.5.tgz",
+			"integrity": "sha512-vtbZRHH5UDlL01TT5jB576Zox3+hdyogvpcbvVJlmU5PdL3c5V7cj1EODdh1CHPksRl+cws/58ugEHi8bcj4Ww==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@lmdb/lmdb-linux-x64": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.8.5.tgz",
+			"integrity": "sha512-Xkc8IUx9aEhP0zvgeKy7IQ3ReX2N8N1L0WPcQwnZweWmOuKfwpS3GRIYqLtK5za/w3E60zhFfNdS+3pBZPytqQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
 		},
 		"node_modules/@lmdb/lmdb-win32-x64": {
 			"version": "2.8.5",
@@ -1630,13 +1818,6 @@
 				"find-up": "^4.1.0",
 				"fs-extra": "^8.1.0"
 			}
-		},
-		"node_modules/@manypkg/find-root/node_modules/@types/node": {
-			"version": "12.20.55",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-			"integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@manypkg/find-root/node_modules/fs-extra": {
 			"version": "8.1.0",
@@ -1768,6 +1949,71 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+			"integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+			"integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+			"integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+			"integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+			"integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
@@ -1883,6 +2129,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/bundler-default/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/bundler-default/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/bundler-default/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -1899,42 +2175,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/types": {
+		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/bundler-default/node_modules/@parcel/utils": {
@@ -1958,30 +2399,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/cache": {
@@ -2022,6 +2439,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/cache/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/cache/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/cache/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -2032,6 +2479,209 @@
 			},
 			"engines": {
 				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/cache/node_modules/@parcel/rust": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@parcel/cache/node_modules/@parcel/rust-darwin-arm64": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/cache/node_modules/@parcel/rust-darwin-x64": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/cache/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/cache/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/cache/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/cache/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/cache/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/cache/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2092,123 +2742,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/compressor-raw/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/compressor-raw/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/compressor-raw/node_modules/@parcel/plugin": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/compressor-raw/node_modules/@parcel/types": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
-			}
-		},
-		"node_modules/@parcel/compressor-raw/node_modules/@parcel/types-internal": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
-			}
-		},
-		"node_modules/@parcel/compressor-raw/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/compressor-raw/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/config-default": {
@@ -2314,6 +2847,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/core/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/core/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/core/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -2330,42 +2893,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/core/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/core/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/core/node_modules/@parcel/types": {
+		"node_modules/@parcel/core/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/core/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/core/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/core/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/core/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/core/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/core/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/core/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/core/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/core/node_modules/@parcel/utils": {
@@ -2389,30 +3117,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/core/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/diagnostic": {
@@ -2446,9 +3150,9 @@
 			}
 		},
 		"node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.0.tgz",
+			"integrity": "sha512-PI7dryJLPYCe4jNzo7XWAzbUPUuD50Nd76GTdzaHhmcQfZnPrtWAu73UmP3yYqpbv97TtWSiCJyrJWPTDU/REA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 16.0.0"
@@ -2511,6 +3215,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/fs/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/fs/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/fs/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -2527,16 +3261,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/fs/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/fs/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@parcel/fs/node_modules/@parcel/rust-darwin-arm64": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/fs/node_modules/@parcel/rust-darwin-x64": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/fs/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/fs/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/fs/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/fs/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/fs/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/fs/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/fs/node_modules/@parcel/utils": {
@@ -2562,30 +3487,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/fs/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
-			}
-		},
 		"node_modules/@parcel/graph": {
 			"version": "3.6.3",
 			"resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.6.3.tgz",
@@ -2604,13 +3505,30 @@
 			}
 		},
 		"node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.0.tgz",
+			"integrity": "sha512-/K6UVVCtS1KOkH9xxuH9u2xV3348mb+Fb33K/OUs5wnpfmo0TtrzodjLyMpQG6KrofmYKSNzA5petp7+cf3aug==",
 			"license": "MIT",
 			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
+				"@parcel/diagnostic": "2.16.0",
+				"@parcel/events": "2.16.0"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/logger/node_modules/@parcel/diagnostic": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.16.0.tgz",
+			"integrity": "sha512-z5MeMwFegaA23wseltLykVV9OxsKkY3BiEje/Dt7ttVivwNWFKHDuXB8vbZTDArUooixUH3s/RJhTFI46VJc2A==",
+			"license": "MIT",
+			"dependencies": {
+				"@mischnic/json-sourcemap": "^0.1.1",
+				"nullthrows": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 16.0.0"
@@ -2655,123 +3573,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/namer-default/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/namer-default/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/namer-default/node_modules/@parcel/plugin": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/namer-default/node_modules/@parcel/types": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
-			}
-		},
-		"node_modules/@parcel/namer-default/node_modules/@parcel/types-internal": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
-			}
-		},
-		"node_modules/@parcel/namer-default/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/namer-default/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
-			}
-		},
 		"node_modules/@parcel/node-resolver-core": {
 			"version": "3.7.3",
 			"resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.7.3.tgz",
@@ -2810,6 +3611,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -2820,6 +3651,209 @@
 			},
 			"engines": {
 				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust-darwin-arm64": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust-darwin-x64": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2888,6 +3922,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/optimizer-css/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-css/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/optimizer-css/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -2904,42 +3968,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/types": {
+		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/optimizer-css/node_modules/@parcel/utils": {
@@ -2963,30 +4192,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/optimizer-html": {
@@ -3024,6 +4229,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/optimizer-html/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-html/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/optimizer-html/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -3040,42 +4275,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/types": {
+		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/optimizer-html/node_modules/@parcel/utils": {
@@ -3099,30 +4499,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/optimizer-image": {
@@ -3165,6 +4541,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/optimizer-image/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-image/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/optimizer-image/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -3181,42 +4587,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/types": {
+		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/optimizer-image/node_modules/@parcel/utils": {
@@ -3240,30 +4811,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/optimizer-svg": {
@@ -3301,6 +4848,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -3317,42 +4894,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/types": {
+		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/utils": {
@@ -3376,30 +5118,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/optimizer-swc": {
@@ -3440,6 +5158,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -3456,42 +5204,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/types": {
+		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/utils": {
@@ -3515,30 +5428,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/package-manager": {
@@ -3584,6 +5473,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/package-manager/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/package-manager/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/package-manager/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -3600,26 +5519,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/types": {
+		"node_modules/@parcel/package-manager/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/package-manager/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/package-manager/node_modules/@parcel/rust-darwin-x64": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/package-manager/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/package-manager/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/package-manager/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/package-manager/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/package-manager/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/package-manager/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/package-manager/node_modules/@parcel/utils": {
@@ -3643,30 +5743,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/packager-css": {
@@ -3707,6 +5783,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/packager-css/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-css/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/packager-css/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -3723,42 +5829,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/packager-css/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/types": {
+		"node_modules/@parcel/packager-css/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/packager-css/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-css/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-css/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-css/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-css/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-css/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-css/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/packager-css/node_modules/@parcel/utils": {
@@ -3782,30 +6053,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/packager-html": {
@@ -3844,6 +6091,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/packager-html/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-html/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/packager-html/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -3860,42 +6137,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/packager-html/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/types": {
+		"node_modules/@parcel/packager-html/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/packager-html/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-html/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-html/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-html/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-html/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-html/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-html/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/packager-html/node_modules/@parcel/utils": {
@@ -3919,30 +6361,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/packager-js": {
@@ -3985,6 +6403,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/packager-js/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-js/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/packager-js/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -4001,42 +6449,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/packager-js/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/types": {
+		"node_modules/@parcel/packager-js/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/packager-js/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-js/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-js/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-js/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-js/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-js/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-js/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/packager-js/node_modules/@parcel/utils": {
@@ -4062,30 +6675,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
-			}
-		},
 		"node_modules/@parcel/packager-raw": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.16.3.tgz",
@@ -4101,123 +6690,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-raw/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-raw/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-raw/node_modules/@parcel/plugin": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-raw/node_modules/@parcel/types": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
-			}
-		},
-		"node_modules/@parcel/packager-raw/node_modules/@parcel/types-internal": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
-			}
-		},
-		"node_modules/@parcel/packager-raw/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-raw/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/packager-svg": {
@@ -4256,6 +6728,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/packager-svg/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-svg/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/packager-svg/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -4272,42 +6774,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/types": {
+		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/packager-svg/node_modules/@parcel/utils": {
@@ -4333,30 +7000,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
-			}
-		},
 		"node_modules/@parcel/packager-wasm": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.16.3.tgz",
@@ -4374,130 +7017,13 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/packager-wasm/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-wasm/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-wasm/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/plugin": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
 			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
 			"license": "MIT",
 			"dependencies": {
 				"@parcel/types": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-wasm/node_modules/@parcel/types": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
-			}
-		},
-		"node_modules/@parcel/packager-wasm/node_modules/@parcel/types-internal": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
-			}
-		},
-		"node_modules/@parcel/packager-wasm/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-wasm/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
-			}
-		},
-		"node_modules/@parcel/plugin": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.0.tgz",
-			"integrity": "sha512-Rdk5e/VGmMp6s2DmC0AbjWYmea3Vv8Tx1SC5ln+lf+qRlhndrbFV9o5QKirTY9C8GWd20qH1ZqOxPDEzK/YSGA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.0"
 			},
 			"engines": {
 				"node": ">= 16.0.0"
@@ -4526,16 +7052,17 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/profiler/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/profiler/node_modules/@parcel/events": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/reporter-cli": {
@@ -4575,6 +7102,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/reporter-cli/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-cli/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/reporter-cli/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -4591,42 +7148,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/types": {
+		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/reporter-cli/node_modules/@parcel/utils": {
@@ -4650,30 +7372,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/reporter-dev-server": {
@@ -4712,6 +7410,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -4728,42 +7456,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/types": {
+		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/utils": {
@@ -4787,30 +7680,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/reporter-tracer": {
@@ -4849,6 +7718,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -4865,42 +7764,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/types": {
+		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/utils": {
@@ -4926,30 +7990,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
-			}
-		},
 		"node_modules/@parcel/resolver-default": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.16.3.tgz",
@@ -4966,123 +8006,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/resolver-default/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/resolver-default/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/resolver-default/node_modules/@parcel/plugin": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/resolver-default/node_modules/@parcel/types": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
-			}
-		},
-		"node_modules/@parcel/resolver-default/node_modules/@parcel/types-internal": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
-			}
-		},
-		"node_modules/@parcel/resolver-default/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/resolver-default/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/runtime-browser-hmr": {
@@ -5119,6 +8042,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -5135,42 +8088,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/types": {
+		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/utils": {
@@ -5194,30 +8312,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/runtime-js": {
@@ -5256,6 +8350,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/runtime-js/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-js/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/runtime-js/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -5272,42 +8396,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/types": {
+		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/runtime-js/node_modules/@parcel/utils": {
@@ -5331,30 +8620,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/runtime-rsc": {
@@ -5393,6 +8658,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -5409,42 +8704,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/types": {
+		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/utils": {
@@ -5468,30 +8928,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/runtime-service-worker": {
@@ -5529,6 +8965,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -5545,92 +9011,7 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/plugin": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/types": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
-			}
-		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/types-internal": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
-			}
-		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
-			}
-		},
-		"node_modules/@parcel/rust": {
+		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
 			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
@@ -5661,10 +9042,388 @@
 				}
 			}
 		},
-		"node_modules/@parcel/rust-win32-x64-msvc": {
+		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust-darwin-arm64": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust-darwin-x64": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust-win32-x64-msvc": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
 			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/utils": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
+			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/codeframe": "2.16.3",
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/logger": "2.16.3",
+				"@parcel/markdown-ansi": "2.16.3",
+				"@parcel/rust": "2.16.3",
+				"@parcel/source-map": "^2.1.1",
+				"chalk": "^4.1.2",
+				"nullthrows": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/rust": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.0.tgz",
+			"integrity": "sha512-9ZBiwCCm9OYa2f1rjkXtPUIa0qbKPmpdTqtNHC+5ieRxClvk+m/mxsO1Ag+GbNJrJ8qFYliL3Ha0ZK4d1BrVKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.0",
+				"@parcel/rust-darwin-x64": "2.16.0",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.0",
+				"@parcel/rust-linux-arm64-gnu": "2.16.0",
+				"@parcel/rust-linux-arm64-musl": "2.16.0",
+				"@parcel/rust-linux-x64-gnu": "2.16.0",
+				"@parcel/rust-linux-x64-musl": "2.16.0",
+				"@parcel/rust-win32-x64-msvc": "2.16.0"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@parcel/rust-darwin-arm64": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.0.tgz",
+			"integrity": "sha512-rdNl1jq34VflBzduQjcOH9SBJPW+Dy1w5XL7hQ5OEAOkRTP1/3mvh98iVYeB3e+RMjRNE/Ipn/rz2KXXku6e6g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/rust-darwin-x64": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.0.tgz",
+			"integrity": "sha512-tozUnjBPfnCjk6HVZCUKNdgFWw4WsLRTJdnsTYBIERrfj858VN0rdOGlVesLFYNSUquoAO+aHtRdT/JqYW7ozA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.0.tgz",
+			"integrity": "sha512-FX/XrQm5BkLfHHBsUA1t7tYGTkNN4vr/t9ZuADUQCWng+m8g7BB78zWxkjoqayn5zTJAfjjQp42lSZzahtT59A==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.0.tgz",
+			"integrity": "sha512-zmnWuclEQDQMhbB8jQw9f1VbnSs6EB2RApg16qs5Co/dhZVozMwJngdkZ6mq5aW8ut+PKYrxIPcVsm7WtVOOfg==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.0.tgz",
+			"integrity": "sha512-bL3PzFEg0azmdFaf34yHAXukk2MjNSuiITPVOj9Cq65qAk7lb4+9nuGIwrCMr1+R1yCamrL31GgG61qp0X97xg==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.0.tgz",
+			"integrity": "sha512-yvuDTyuhMtwZjB1xGFmCC/UsZjEpMTAanJHAVX9b+tJnn7ArG7Q75Az/JpZsru6KAXiTo1krI54vTE87zzwkIg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.0.tgz",
+			"integrity": "sha512-0q6ESCVe9uHVuQWuEGGDMJwjezliTsEWMcqn7oeQoKXaZJZQpW0UAuzNcNmpiHmeJdifYT9XuxVOo/a8IgOXhg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.0.tgz",
+			"integrity": "sha512-IVWpXF1VY+Xgi6ylXaZttAF5+WjazPyxRJUZlC31taYwpfZ4LzmsV8NYlj5ehjTL8d28SKDBoAnOQJwDRe8z8Q==",
 			"cpu": [
 				"x64"
 			],
@@ -5733,6 +9492,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/transformer-babel/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-babel/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/transformer-babel/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -5749,42 +9538,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/types": {
+		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/transformer-babel/node_modules/@parcel/utils": {
@@ -5808,30 +9762,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/transformer-css": {
@@ -5873,6 +9803,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/transformer-css/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-css/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/transformer-css/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -5889,42 +9849,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/types": {
+		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/transformer-css/node_modules/@parcel/utils": {
@@ -5950,30 +10075,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
-			}
-		},
 		"node_modules/@parcel/transformer-html": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.16.3.tgz",
@@ -5993,121 +10094,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-html/node_modules/@parcel/codeframe": {
+		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-html/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
 			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-html/node_modules/@parcel/plugin": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-html/node_modules/@parcel/types": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
-			}
-		},
-		"node_modules/@parcel/transformer-html/node_modules/@parcel/types-internal": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
-			}
-		},
-		"node_modules/@parcel/transformer-html/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-html/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
 			},
 			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust-darwin-arm64": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust-darwin-x64": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/transformer-image": {
@@ -6145,6 +10332,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/transformer-image/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-image/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/transformer-image/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -6161,42 +10378,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/types": {
+		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/transformer-image/node_modules/@parcel/utils": {
@@ -6220,30 +10602,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/transformer-js": {
@@ -6292,6 +10650,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/transformer-js/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-js/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/transformer-js/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -6308,42 +10696,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/types": {
+		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/transformer-js/node_modules/@parcel/utils": {
@@ -6369,30 +10922,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
-			}
-		},
 		"node_modules/@parcel/transformer-json": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.16.3.tgz",
@@ -6411,123 +10940,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-json/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-json/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-json/node_modules/@parcel/plugin": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-json/node_modules/@parcel/types": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
-			}
-		},
-		"node_modules/@parcel/transformer-json/node_modules/@parcel/types-internal": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
-			}
-		},
-		"node_modules/@parcel/transformer-json/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-json/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
-			}
-		},
 		"node_modules/@parcel/transformer-node": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/transformer-node/-/transformer-node-2.16.3.tgz",
@@ -6543,123 +10955,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-node/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-node/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-node/node_modules/@parcel/plugin": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-node/node_modules/@parcel/types": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
-			}
-		},
-		"node_modules/@parcel/transformer-node/node_modules/@parcel/types-internal": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
-			}
-		},
-		"node_modules/@parcel/transformer-node/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-node/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/transformer-postcss": {
@@ -6702,6 +10997,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -6718,42 +11043,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/types": {
+		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/utils": {
@@ -6777,30 +11267,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/transformer-posthtml": {
@@ -6837,6 +11303,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -6853,42 +11349,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/types": {
+		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/utils": {
@@ -6914,30 +11575,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
-			}
-		},
 		"node_modules/@parcel/transformer-raw": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.16.3.tgz",
@@ -6953,123 +11590,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-raw/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-raw/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-raw/node_modules/@parcel/plugin": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-raw/node_modules/@parcel/types": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
-			}
-		},
-		"node_modules/@parcel/transformer-raw/node_modules/@parcel/types-internal": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
-			}
-		},
-		"node_modules/@parcel/transformer-raw/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-raw/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/transformer-react-refresh-wrap": {
@@ -7108,6 +11628,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -7124,42 +11674,207 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/types": {
+		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/utils": {
@@ -7185,30 +11900,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
-			}
-		},
 		"node_modules/@parcel/transformer-sass": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/transformer-sass/-/transformer-sass-2.16.3.tgz",
@@ -7227,130 +11918,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-sass/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-sass/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-sass/node_modules/@parcel/plugin": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-sass/node_modules/@parcel/types": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
-			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/workers": "2.16.3"
-			}
-		},
-		"node_modules/@parcel/transformer-sass/node_modules/@parcel/types-internal": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
-			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/feature-flags": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
-			}
-		},
-		"node_modules/@parcel/transformer-sass/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-sass/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
 			}
 		},
 		"node_modules/@parcel/transformer-svg": {
@@ -7372,55 +11939,210 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-svg/node_modules/@parcel/codeframe": {
+		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
 			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@parcel/transformer-svg/node_modules/@parcel/markdown-ansi": {
+		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
+			"optional": true,
+			"os": [
+				"darwin"
+			],
 			"engines": {
-				"node": ">= 16.0.0"
+				"node": ">= 10"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-svg/node_modules/@parcel/plugin": {
+		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.3.tgz",
-			"integrity": "sha512-w4adN/E2MBbNzUwuGWcUkilrf7B6eQThPRdgiw2awIY0/t0C1gN/hhBfUeWt7vt0WcvWlXcyR/OGzU/r0nPteA==",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@parcel/types": "2.16.3"
-			},
+			"optional": true,
+			"os": [
+				"darwin"
+			],
 			"engines": {
-				"node": ">= 16.0.0"
+				"node": ">= 10"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-svg/node_modules/@parcel/types": {
+		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/types": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
 			"integrity": "sha512-aIJJFMif/A7u86UEt3sJPZ/F7suQW56ugiCp2Y2mYTPHpTJbI2Knk9yO4fkWHNO1BrH6a/VUWh7bWIOsQtzL1Q==",
@@ -7430,7 +12152,7 @@
 				"@parcel/workers": "2.16.3"
 			}
 		},
-		"node_modules/@parcel/transformer-svg/node_modules/@parcel/types-internal": {
+		"node_modules/@parcel/types-internal": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.3.tgz",
 			"integrity": "sha512-zi2GKdJHpNeW9sspTBfM68A9lekEztTWU8Dxs1ouPk90lfA0tfrMznAvkD5iJdKsM6usbgcqjjI8s+Ow8OrsBg==",
@@ -7440,105 +12162,6 @@
 				"@parcel/feature-flags": "2.16.3",
 				"@parcel/source-map": "^2.1.1",
 				"utility-types": "^3.11.0"
-			}
-		},
-		"node_modules/@parcel/transformer-svg/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-svg/node_modules/@parcel/workers": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
-			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/profiler": "2.16.3",
-				"@parcel/types-internal": "2.16.3",
-				"@parcel/utils": "2.16.3",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"peerDependencies": {
-				"@parcel/core": "^2.16.3"
-			}
-		},
-		"node_modules/@parcel/types": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.0.tgz",
-			"integrity": "sha512-EKsMTqqfiutQIiYKHEJHHeugIymPqM+D+CphhyewAIjxVLk6PTjEQW0ytIbbdOXGAgnK60OFiIKqZAxZ5Hf2dw==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/types-internal": "2.16.0",
-				"@parcel/workers": "2.16.0"
-			}
-		},
-		"node_modules/@parcel/types-internal": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.0.tgz",
-			"integrity": "sha512-tibAjOY8iyMDzFp5B9jEZPfHYlNvXpw7/msUVebAE6gZ7A8ymWXG8YzMvin6gvWIVTCsYoOkkRsZARvpRcSspQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.0",
-				"@parcel/feature-flags": "2.16.0",
-				"@parcel/source-map": "^2.1.1",
-				"utility-types": "^3.11.0"
-			}
-		},
-		"node_modules/@parcel/types-internal/node_modules/@parcel/diagnostic": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.16.0.tgz",
-			"integrity": "sha512-z5MeMwFegaA23wseltLykVV9OxsKkY3BiEje/Dt7ttVivwNWFKHDuXB8vbZTDArUooixUH3s/RJhTFI46VJc2A==",
-			"license": "MIT",
-			"dependencies": {
-				"@mischnic/json-sourcemap": "^0.1.1",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/types-internal/node_modules/@parcel/feature-flags": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.16.0.tgz",
-			"integrity": "sha512-GiRpLx0x8dZdWCpftk6OE0lp0Cc8oUyBssPiobigpSA8vgxrCz/zLbs83R/K70p+wPBb+ye4eEiR67+KCwcSXg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/utils": {
@@ -7575,87 +12198,6 @@
 			},
 			"engines": {
 				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/utils/node_modules/@parcel/events": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.0.tgz",
-			"integrity": "sha512-PI7dryJLPYCe4jNzo7XWAzbUPUuD50Nd76GTdzaHhmcQfZnPrtWAu73UmP3yYqpbv97TtWSiCJyrJWPTDU/REA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/utils/node_modules/@parcel/logger": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.0.tgz",
-			"integrity": "sha512-/K6UVVCtS1KOkH9xxuH9u2xV3348mb+Fb33K/OUs5wnpfmo0TtrzodjLyMpQG6KrofmYKSNzA5petp7+cf3aug==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.0",
-				"@parcel/events": "2.16.0"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/utils/node_modules/@parcel/rust": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.0.tgz",
-			"integrity": "sha512-9ZBiwCCm9OYa2f1rjkXtPUIa0qbKPmpdTqtNHC+5ieRxClvk+m/mxsO1Ag+GbNJrJ8qFYliL3Ha0ZK4d1BrVKw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.0",
-				"@parcel/rust-darwin-x64": "2.16.0",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.0",
-				"@parcel/rust-linux-arm64-gnu": "2.16.0",
-				"@parcel/rust-linux-arm64-musl": "2.16.0",
-				"@parcel/rust-linux-x64-gnu": "2.16.0",
-				"@parcel/rust-linux-x64-musl": "2.16.0",
-				"@parcel/rust-win32-x64-msvc": "2.16.0"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/utils/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.0.tgz",
-			"integrity": "sha512-IVWpXF1VY+Xgi6ylXaZttAF5+WjazPyxRJUZlC31taYwpfZ4LzmsV8NYlj5ehjTL8d28SKDBoAnOQJwDRe8z8Q==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -7784,6 +12326,9 @@
 			"cpu": [
 				"arm"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7803,6 +12348,9 @@
 			"integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
 			"cpu": [
 				"arm"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -7824,6 +12372,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7843,6 +12394,9 @@
 			"integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -7864,6 +12418,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7883,6 +12440,9 @@
 			"integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -7966,17 +12526,35 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@parcel/watcher/node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"license": "MIT"
+		},
+		"node_modules/@parcel/watcher/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/@parcel/workers": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.0.tgz",
-			"integrity": "sha512-JVdAtTWRONbP4X8Me1qRE5sMGIkSKAcUb8fZdjCUPJxsBwcJwzYicYFuahxVVGj2sYzjLi0TzlvmXMK7tVvffA==",
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.3.tgz",
+			"integrity": "sha512-SxIXRnrlQFhw377wxWC5WIl1FL1Y9IedhUtuc7j3uac3tlbCQJJ+3rFr5/BDUknJbTktvVsPakE98fH7TIJyyw==",
 			"license": "MIT",
 			"dependencies": {
-				"@parcel/diagnostic": "2.16.0",
-				"@parcel/logger": "2.16.0",
-				"@parcel/profiler": "2.16.0",
-				"@parcel/types-internal": "2.16.0",
-				"@parcel/utils": "2.16.0",
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/logger": "2.16.3",
+				"@parcel/profiler": "2.16.3",
+				"@parcel/types-internal": "2.16.3",
+				"@parcel/utils": "2.16.3",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
@@ -7987,17 +12565,16 @@
 				"url": "https://opencollective.com/parcel"
 			},
 			"peerDependencies": {
-				"@parcel/core": "^2.16.0"
+				"@parcel/core": "^2.16.3"
 			}
 		},
-		"node_modules/@parcel/workers/node_modules/@parcel/diagnostic": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.16.0.tgz",
-			"integrity": "sha512-z5MeMwFegaA23wseltLykVV9OxsKkY3BiEje/Dt7ttVivwNWFKHDuXB8vbZTDArUooixUH3s/RJhTFI46VJc2A==",
+		"node_modules/@parcel/workers/node_modules/@parcel/codeframe": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
+			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@mischnic/json-sourcemap": "^0.1.1",
-				"nullthrows": "^1.1.1"
+				"chalk": "^4.1.2"
 			},
 			"engines": {
 				"node": ">= 16.0.0"
@@ -8008,9 +12585,9 @@
 			}
 		},
 		"node_modules/@parcel/workers/node_modules/@parcel/events": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.0.tgz",
-			"integrity": "sha512-PI7dryJLPYCe4jNzo7XWAzbUPUuD50Nd76GTdzaHhmcQfZnPrtWAu73UmP3yYqpbv97TtWSiCJyrJWPTDU/REA==",
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 16.0.0"
@@ -8021,13 +12598,13 @@
 			}
 		},
 		"node_modules/@parcel/workers/node_modules/@parcel/logger": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.0.tgz",
-			"integrity": "sha512-/K6UVVCtS1KOkH9xxuH9u2xV3348mb+Fb33K/OUs5wnpfmo0TtrzodjLyMpQG6KrofmYKSNzA5petp7+cf3aug==",
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
 			"license": "MIT",
 			"dependencies": {
-				"@parcel/diagnostic": "2.16.0",
-				"@parcel/events": "2.16.0"
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
 			},
 			"engines": {
 				"node": ">= 16.0.0"
@@ -8037,16 +12614,239 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/workers/node_modules/@parcel/profiler": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.16.0.tgz",
-			"integrity": "sha512-xm6fVTA1V/Co7JuJfkNtZJsKsvq0RSpoE7JjiNtKLCMh+Lim6w7dxc6CEBqGImhR/9YbwteY6/gVFwkvCdLvLg==",
+		"node_modules/@parcel/workers/node_modules/@parcel/markdown-ansi": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
+			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
 			"license": "MIT",
 			"dependencies": {
-				"@parcel/diagnostic": "2.16.0",
-				"@parcel/events": "2.16.0",
-				"@parcel/types-internal": "2.16.0",
-				"chrome-trace-event": "^1.0.2"
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/workers/node_modules/@parcel/rust": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@parcel/workers/node_modules/@parcel/rust-darwin-arm64": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/workers/node_modules/@parcel/rust-darwin-x64": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/workers/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/workers/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/workers/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/workers/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/workers/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/workers/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/workers/node_modules/@parcel/utils": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
+			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/codeframe": "2.16.3",
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/logger": "2.16.3",
+				"@parcel/markdown-ansi": "2.16.3",
+				"@parcel/rust": "2.16.3",
+				"@parcel/source-map": "^2.1.1",
+				"chalk": "^4.1.2",
+				"nullthrows": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 16.0.0"
@@ -8060,7 +12860,6 @@
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
 			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"engines": {
@@ -8068,13 +12867,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.58.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
-			"integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.58.0"
+				"playwright": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -8380,14 +13179,14 @@
 			"license": "MIT"
 		},
 		"node_modules/@swc/core": {
-			"version": "1.15.10",
-			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.10.tgz",
-			"integrity": "sha512-udNofxftduMUEv7nqahl2nvodCiCDQ4Ge0ebzsEm6P8s0RC2tBM0Hqx0nNF5J/6t9uagFJyWIDjXy3IIWMHDJw==",
+			"version": "1.15.33",
+			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.33.tgz",
+			"integrity": "sha512-jOlwnFV2xhuuZeAUILGFULeR6vDPfijEJ57evfocwznQldLU3w2cZ9bSDryY9ip+AsM3r1NJKzf47V2NXebkeQ==",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@swc/counter": "^0.1.3",
-				"@swc/types": "^0.1.25"
+				"@swc/types": "^0.1.26"
 			},
 			"engines": {
 				"node": ">=10"
@@ -8397,16 +13196,18 @@
 				"url": "https://opencollective.com/swc"
 			},
 			"optionalDependencies": {
-				"@swc/core-darwin-arm64": "1.15.10",
-				"@swc/core-darwin-x64": "1.15.10",
-				"@swc/core-linux-arm-gnueabihf": "1.15.10",
-				"@swc/core-linux-arm64-gnu": "1.15.10",
-				"@swc/core-linux-arm64-musl": "1.15.10",
-				"@swc/core-linux-x64-gnu": "1.15.10",
-				"@swc/core-linux-x64-musl": "1.15.10",
-				"@swc/core-win32-arm64-msvc": "1.15.10",
-				"@swc/core-win32-ia32-msvc": "1.15.10",
-				"@swc/core-win32-x64-msvc": "1.15.10"
+				"@swc/core-darwin-arm64": "1.15.33",
+				"@swc/core-darwin-x64": "1.15.33",
+				"@swc/core-linux-arm-gnueabihf": "1.15.33",
+				"@swc/core-linux-arm64-gnu": "1.15.33",
+				"@swc/core-linux-arm64-musl": "1.15.33",
+				"@swc/core-linux-ppc64-gnu": "1.15.33",
+				"@swc/core-linux-s390x-gnu": "1.15.33",
+				"@swc/core-linux-x64-gnu": "1.15.33",
+				"@swc/core-linux-x64-musl": "1.15.33",
+				"@swc/core-win32-arm64-msvc": "1.15.33",
+				"@swc/core-win32-ia32-msvc": "1.15.33",
+				"@swc/core-win32-x64-msvc": "1.15.33"
 			},
 			"peerDependencies": {
 				"@swc/helpers": ">=0.5.17"
@@ -8417,10 +13218,204 @@
 				}
 			}
 		},
+		"node_modules/@swc/core-darwin-arm64": {
+			"version": "1.15.33",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.33.tgz",
+			"integrity": "sha512-N+L0uXhuO7FIfzqwgxmzv0zIpV0qEp8wPX3QQs2p4atjMoywup2JTeDlXPw+z9pWJGCae3JjM+tZ6myclI+2gA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-darwin-x64": {
+			"version": "1.15.33",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.33.tgz",
+			"integrity": "sha512-/Il4QHSOhV4FekbsDtkrNmKbsX26oSysvgrRswa/RYOHXAkwXDbB4jaeKq6PsJLSPkzJ2KzQ061gtBnk0vNHfA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-arm-gnueabihf": {
+			"version": "1.15.33",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.33.tgz",
+			"integrity": "sha512-C64hBnBxq4viOPQ8hlx+2lJ23bzZBGnjw7ryALmS+0Q3zHmwO8lw1/DArLENw4Q18/0w5wdEO1k3m1wWNtKGqQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-arm64-gnu": {
+			"version": "1.15.33",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.33.tgz",
+			"integrity": "sha512-TRJfnJbX3jqpxRDRoieMzRiCBS5jOmXNb3iQXmcgjFEHKLnAgK1RZRU8Cq1MsPqO4jAJp/ld1G4O3fXuxv85uw==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-arm64-musl": {
+			"version": "1.15.33",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.33.tgz",
+			"integrity": "sha512-il7tYM+CpUNzieQbwAjFT1P8zqAhmGWNAGhQZBnxurXZ0aNn+5nqYFTEUKNZl7QibtT0uQXzTZrNGHCIj6Y1Og==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-ppc64-gnu": {
+			"version": "1.15.33",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.33.tgz",
+			"integrity": "sha512-ZtNBwN0Z7CFj9Il0FcPaKdjgP7URyKu/3RfH46vq+0paOBqLj4NYldD6Qo//Duif/7IOtAraUfDOmp0PLAufog==",
+			"cpu": [
+				"ppc64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-s390x-gnu": {
+			"version": "1.15.33",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.33.tgz",
+			"integrity": "sha512-De1IyajoOmhOYYjw/lx66bKlyDpHZTueqwpDrWgf5O7T6d1ODeJJO9/OqMBmrBQc5C+dNnlmIufHsp4QVCWufA==",
+			"cpu": [
+				"s390x"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-x64-gnu": {
+			"version": "1.15.33",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.33.tgz",
+			"integrity": "sha512-mGTH0YxmUN+x6vRN/I6NOk5X0ogNktkwPnJ94IMvR7QjhRDwL0O8RXEDhyUM0YtwWrryBOqaJQBX4zruxEPRGw==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-x64-musl": {
+			"version": "1.15.33",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.33.tgz",
+			"integrity": "sha512-hj628ZkSEJf6zMf5VMbYrG2O6QqyTIp2qwY6VlCjvIa9lAEZ5c2lfPblCLVGYubTeLJDxadLB/CxqQYOQABeEQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-win32-arm64-msvc": {
+			"version": "1.15.33",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.33.tgz",
+			"integrity": "sha512-GV2oohtN2/5+KSccl86VULu3aT+LrISC8uzgSq0FRnikpD+Zwc+sBlXmoKQ+Db6jI57ITUOIB8jRkdGMABC29g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-win32-ia32-msvc": {
+			"version": "1.15.33",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.33.tgz",
+			"integrity": "sha512-gtyvzSNR8DHKfFEA2uqb8Ld1myqi6uEg2jyeUq3ikn5ytYs7H8RpZYC8mdy4NXr8hfcdJfCLXPlYaqqfBXpoEQ==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/@swc/core-win32-x64-msvc": {
-			"version": "1.15.10",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.10.tgz",
-			"integrity": "sha512-HvY8XUFuoTXn6lSccDLYFlXv1SU/PzYi4PyUqGT++WfTnbw/68N/7BdUZqglGRwiSqr0qhYt/EhmBpULj0J9rA==",
+			"version": "1.15.33",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.33.tgz",
+			"integrity": "sha512-d6fRqQSkJI+kmMEBWaDQ7TMl8+YjLYbwRUPZQ9DY0ORBJeTzOrG0twvfvlZ2xgw6jA0ScQKgfBm4vHLSLl5Hqg==",
 			"cpu": [
 				"x64"
 			],
@@ -8440,18 +13435,18 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@swc/helpers": {
-			"version": "0.5.18",
-			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
-			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+			"integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
 		},
 		"node_modules/@swc/types": {
-			"version": "0.1.25",
-			"resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
-			"integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
+			"version": "0.1.26",
+			"resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
+			"integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@swc/counter": "^0.1.3"
@@ -8533,14 +13528,11 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.1.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
-			"integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
+			"version": "12.20.55",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+			"integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"undici-types": "~7.16.0"
-			}
+			"license": "MIT"
 		},
 		"node_modules/@types/normalize-path": {
 			"version": "3.0.2",
@@ -8584,9 +13576,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.108.1",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.108.1.tgz",
-			"integrity": "sha512-DerV0BbSzt87TbrqmZ7lRDIYaMiqvP8tmJTzW2p49ZBVtGUnGAu2RGQd1Wv4XMzEVUpaHbsemVM5nfuQJj7H6w==",
+			"version": "1.118.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.118.0.tgz",
+			"integrity": "sha512-Ah6eTlqDcwIMELEVwQMO++rJAFBRz/oLluLD/vWdYrH1KuI9kfpaM+7pg0OvvascgcJy+ghLCERAYouM4QbzGw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -8787,9 +13779,9 @@
 			}
 		},
 		"node_modules/@typespec/ts-http-runtime": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.2.tgz",
-			"integrity": "sha512-IlqQ/Gv22xUC1r/WQm4StLkYQmaaTsXAhUVsNE0+xiyf0yRFiH5++q78U3bw6bLKDCTmh0uqKB9eG9+Bt75Dkg==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+			"integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8802,9 +13794,9 @@
 			}
 		},
 		"node_modules/@ungap/structured-clone": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+			"integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -8855,6 +13847,33 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+			"integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.6",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
@@ -9003,6 +14022,118 @@
 				"@vscode/vsce-sign-win32-x64": "2.0.6"
 			}
 		},
+		"node_modules/@vscode/vsce-sign-alpine-arm64": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
+			"integrity": "sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"optional": true,
+			"os": [
+				"alpine"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-alpine-x64": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
+			"integrity": "sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"optional": true,
+			"os": [
+				"alpine"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-darwin-arm64": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
+			"integrity": "sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-darwin-x64": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
+			"integrity": "sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-linux-arm": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
+			"integrity": "sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-linux-arm64": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
+			"integrity": "sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-linux-x64": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz",
+			"integrity": "sha512-/olerl1A4sOqdP+hjvJ1sbQjKN07Y3DVnxO4gnbn/ahtQvFrdhUi0G1VsZXDNjfqmXw57DmPi5ASnj/8PGZhAA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@vscode/vsce-sign-win32-arm64": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
+			"integrity": "sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.txt",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
 		"node_modules/@vscode/vsce-sign-win32-x64": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz",
@@ -9076,7 +14207,7 @@
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -9131,9 +14262,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -9226,19 +14357,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/anymatch/node_modules/picomatch": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/are-docs-informative": {
@@ -9410,13 +14528,6 @@
 				"js-tokens": "^10.0.0"
 			}
 		},
-		"node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/astral-regex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -9464,9 +14575,9 @@
 			}
 		},
 		"node_modules/axe-core": {
-			"version": "4.11.1",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
-			"integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+			"version": "4.11.4",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+			"integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
 			"dev": true,
 			"license": "MPL-2.0",
 			"engines": {
@@ -9488,7 +14599,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/base-x": {
@@ -9522,12 +14632,15 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.9.18",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.18.tgz",
-			"integrity": "sha512-e23vBV1ZLfjb9apvfPk4rHVu2ry6RIr2Wfs+O324okSidrX7pTAnEJPCh/O5BtRlr7QtZI7ktOP3vsqr7Z5XoA==",
+			"version": "2.10.29",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+			"integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
 			"license": "Apache-2.0",
 			"bin": {
-				"baseline-browser-mapping": "dist/cli.js"
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/better-path-resolve": {
@@ -9606,7 +14719,6 @@
 			"version": "1.1.14",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
 			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -9640,9 +14752,9 @@
 			"license": "ISC"
 		},
 		"node_modules/browserslist": {
-			"version": "4.28.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-			"integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -9659,11 +14771,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"baseline-browser-mapping": "^2.9.0",
-				"caniuse-lite": "^1.0.30001759",
-				"electron-to-chromium": "^1.5.263",
-				"node-releases": "^2.0.27",
-				"update-browserslist-db": "^1.2.0"
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -9744,40 +14856,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/cacheable": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.2.tgz",
-			"integrity": "sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@cacheable/memory": "^2.0.7",
-				"@cacheable/utils": "^2.3.3",
-				"hookified": "^1.15.0",
-				"keyv": "^5.5.5",
-				"qified": "^0.6.0"
-			}
-		},
-		"node_modules/cacheable/node_modules/keyv": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
-			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@keyv/serialize": "^1.1.1"
-			}
-		},
 		"node_modules/call-bind": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.0",
-				"es-define-property": "^1.0.0",
-				"get-intrinsic": "^1.2.4",
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"get-intrinsic": "^1.3.0",
 				"set-function-length": "^1.2.2"
 			},
 			"engines": {
@@ -9827,10 +14915,23 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001766",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
-			"integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
+			"version": "1.0.30001792",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+			"integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -9980,20 +15081,10 @@
 			}
 		},
 		"node_modules/ci-info": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/sibiraj-s"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"license": "MIT"
 		},
 		"node_modules/cli-cursor": {
 			"version": "5.0.0",
@@ -10170,7 +15261,6 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/convert-source-map": {
@@ -10237,7 +15327,6 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -10249,12 +15338,12 @@
 			}
 		},
 		"node_modules/css-functions-list": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
-			"integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+			"integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=12 || >=16"
+				"node": ">=12"
 			}
 		},
 		"node_modules/css-select": {
@@ -10327,29 +15416,6 @@
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
-		"node_modules/data-urls/node_modules/tr46": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"punycode": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"node_modules/data-urls/node_modules/webidl-conversions": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=20"
-			}
-		},
 		"node_modules/data-urls/node_modules/whatwg-mimetype": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
@@ -10358,21 +15424,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
-			}
-		},
-		"node_modules/data-urls/node_modules/whatwg-url": {
-			"version": "16.0.1",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@exodus/bytes": "^1.11.0",
-				"tr46": "^6.0.0",
-				"webidl-conversions": "^8.0.1"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/data-view-buffer": {
@@ -10446,6 +15497,19 @@
 				}
 			}
 		},
+		"node_modules/decamelize": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/decimal.js": {
 			"version": "10.6.0",
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -10489,9 +15553,9 @@
 			"license": "MIT"
 		},
 		"node_modules/default-browser": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.4.0.tgz",
-			"integrity": "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+			"integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10739,7 +15803,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/ecdsa-sig-formatter": {
@@ -10753,16 +15816,15 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.279",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.279.tgz",
-			"integrity": "sha512-0bblUU5UNdOt5G7XqGiJtpZMONma6WAfq9vsFmtn9x1+joAObr6x1chfqyxFSDCAFwFhCQDrqeAr6MYdpwJ9Hg==",
+			"version": "1.5.354",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.354.tgz",
+			"integrity": "sha512-JaBHwWcfIdmSAfWM5l3uwjGd431j8YEMikZ+K/2nXVuBqJKyZ0f+2h4n4JY5AyNiZmnY9qQr2RU3v9DxDmHMNg==",
 			"license": "ISC"
 		},
 		"node_modules/emoji-regex": {
 			"version": "9.2.2",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/encoding-sniffer": {
@@ -10848,9 +15910,9 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.24.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-			"integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+			"version": "1.24.2",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+			"integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11045,431 +16107,6 @@
 				"@esbuild/win32-x64": "0.25.12"
 			}
 		},
-		"node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-			"integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/android-arm": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-			"integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/android-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-			"integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/android-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-			"integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-			"integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-			"integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-			"integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-arm": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-			"integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-			"integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-			"integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-			"integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-			"integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-			"integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-			"integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-			"integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-			"integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-			"integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-			"integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-			"integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-			"integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-			"integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-			"integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -11563,15 +16200,15 @@
 			}
 		},
 		"node_modules/eslint-import-resolver-node": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
-			"integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+			"version": "0.3.10",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+			"integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^3.2.7",
-				"is-core-module": "^2.13.0",
-				"resolve": "^1.22.4"
+				"is-core-module": "^2.16.1",
+				"resolve": "^2.0.0-next.6"
 			}
 		},
 		"node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -12078,9 +16715,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -12245,7 +16882,6 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
 			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"cross-spawn": "^7.0.6",
@@ -12262,7 +16898,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
@@ -12370,9 +17005,9 @@
 			"license": "ISC"
 		},
 		"node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -12446,9 +17081,9 @@
 			}
 		},
 		"node_modules/get-east-asian-width": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-			"integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -12549,7 +17184,7 @@
 			"version": "10.5.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
 			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"dev": true,
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"license": "ISC",
 			"dependencies": {
 				"foreground-child": "^3.1.0",
@@ -12583,7 +17218,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
 			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
@@ -12593,7 +17227,6 @@
 			"version": "9.0.9",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
 			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.2"
@@ -12718,7 +17351,6 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/graphemer": {
@@ -12818,23 +17450,10 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/hashery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.4.0.tgz",
-			"integrity": "sha512-Wn2i1In6XFxl8Az55kkgnFRiAlIAushzh26PTjL2AKtQcEfXrcLa7Hn5QOWGZEf3LU057P9TwwZjFyxfS1VuvQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"hookified": "^1.14.0"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12863,18 +17482,10 @@
 				"node": ">=12.0.0"
 			}
 		},
-		"node_modules/hookified": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.0.tgz",
-			"integrity": "sha512-51w+ZZGt7Zw5q7rM3nC4t3aLn/xvKDETsXqMczndvwyVQhAHfUmUuFBRFcos8Iyebtk7OAE9dL26wFNzZVVOkw==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/hosted-git-info": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
 			"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -13026,13 +17637,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/husky"
 			}
-		},
-		"node_modules/husky/node_modules/ci-info": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/iconv-lite": {
 			"version": "0.7.2",
@@ -13289,13 +17893,13 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+			"version": "2.16.2",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+			"integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hasown": "^2.0.2"
+				"hasown": "^2.0.3"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -13509,6 +18113,16 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-plain-obj": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -13733,9 +18347,9 @@
 			}
 		},
 		"node_modules/is-wsl": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+			"integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13804,7 +18418,6 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
 			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/cliui": "^8.0.2"
@@ -13824,9 +18437,10 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
@@ -13892,31 +18506,6 @@
 				}
 			}
 		},
-		"node_modules/jsdom/node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
-			"integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT-0",
-			"peerDependencies": {
-				"css-tree": "^3.2.1"
-			},
-			"peerDependenciesMeta": {
-				"css-tree": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/jsdom/node_modules/css-tree": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -13974,29 +18563,6 @@
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
-		"node_modules/jsdom/node_modules/tr46": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"punycode": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"node_modules/jsdom/node_modules/webidl-conversions": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=20"
-			}
-		},
 		"node_modules/jsdom/node_modules/whatwg-mimetype": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
@@ -14005,21 +18571,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
-			}
-		},
-		"node_modules/jsdom/node_modules/whatwg-url": {
-			"version": "16.0.1",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@exodus/bytes": "^1.11.0",
-				"tr46": "^6.0.0",
-				"webidl-conversions": "^8.0.1"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/json-buffer": {
@@ -14068,9 +18619,9 @@
 			"license": "MIT"
 		},
 		"node_modules/jsonfile": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14151,14 +18702,6 @@
 				"node-addon-api": "^4.3.0",
 				"prebuild-install": "^7.0.1"
 			}
-		},
-		"node_modules/keytar/node_modules/node-addon-api": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-			"integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true
 		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
@@ -14645,7 +19188,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^4.0.0"
@@ -14806,18 +19348,6 @@
 				"node": ">=8.6"
 			}
 		},
-		"node_modules/micromatch/node_modules/picomatch": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/mime": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -14898,7 +19428,6 @@
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
 			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
@@ -14918,11 +19447,10 @@
 			}
 		},
 		"node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
@@ -15002,7 +19530,7 @@
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
 			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -15113,9 +19641,9 @@
 			"license": "MIT"
 		},
 		"node_modules/msgpackr": {
-			"version": "1.11.8",
-			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.8.tgz",
-			"integrity": "sha512-bC4UGzHhVvgDNS7kn9tV8fAucIYUBuGojcaLiz7v+P63Lmtm0Xeji8B/8tYKddALXxJLpwIeBmUN3u64C4YkRA==",
+			"version": "1.11.12",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.12.tgz",
+			"integrity": "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==",
 			"license": "MIT",
 			"optionalDependencies": {
 				"msgpackr-extract": "^3.0.2"
@@ -15181,13 +19709,12 @@
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.12",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -15225,9 +19752,9 @@
 			"license": "MIT"
 		},
 		"node_modules/node-abi": {
-			"version": "3.87.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
-			"integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+			"version": "3.92.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+			"integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -15239,10 +19766,41 @@
 			}
 		},
 		"node_modules/node-addon-api": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-			"license": "MIT"
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+			"integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/node-exports-info": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+			"integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array.prototype.flatmap": "^1.3.3",
+				"es-errors": "^1.3.0",
+				"object.entries": "^1.1.9",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/node-exports-info/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
 		},
 		"node_modules/node-fetch": {
 			"version": "2.7.0",
@@ -15263,6 +19821,31 @@
 				"encoding": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/node-fetch/node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/node-fetch/node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/node-fetch/node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/node-gyp-build-optional-packages": {
@@ -15289,9 +19872,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-			"integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+			"version": "2.0.44",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+			"integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
 			"license": "MIT"
 		},
 		"node_modules/normalize-path": {
@@ -15304,9 +19887,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "11.12.1",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-11.12.1.tgz",
-			"integrity": "sha512-zcoUuF1kezGSAo0CqtvoLXX3mkRqzuqYdL6Y5tdo8g69NVV3CkjQ6ZBhBgB4d7vGkPcV6TcvLi3GRKPDFX+xTA==",
+			"version": "11.14.1",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-11.14.1.tgz",
+			"integrity": "sha512-aopNZ0eEl6LbxoFcrXLmTEPzNBNxfiQnVgR9RmJBqzm+5h5pFoOmRljpRJbsXxocBeSl7GLcx3MoDf2UlEOjZw==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -15384,8 +19967,8 @@
 			],
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^9.4.2",
-				"@npmcli/config": "^10.8.1",
+				"@npmcli/arborist": "^9.5.0",
+				"@npmcli/config": "^10.9.0",
 				"@npmcli/fs": "^5.0.0",
 				"@npmcli/map-workspaces": "^5.0.3",
 				"@npmcli/metavuln-calculator": "^9.0.3",
@@ -15406,24 +19989,24 @@
 				"hosted-git-info": "^9.0.2",
 				"ini": "^6.0.0",
 				"init-package-json": "^8.2.5",
-				"is-cidr": "^6.0.3",
+				"is-cidr": "^6.0.4",
 				"json-parse-even-better-errors": "^5.0.0",
 				"libnpmaccess": "^10.0.3",
-				"libnpmdiff": "^8.1.5",
-				"libnpmexec": "^10.2.5",
-				"libnpmfund": "^7.0.19",
+				"libnpmdiff": "^8.1.7",
+				"libnpmexec": "^10.2.7",
+				"libnpmfund": "^7.0.21",
 				"libnpmorg": "^8.0.1",
-				"libnpmpack": "^9.1.5",
+				"libnpmpack": "^9.1.7",
 				"libnpmpublish": "^11.1.3",
 				"libnpmsearch": "^9.0.1",
 				"libnpmteam": "^8.0.2",
 				"libnpmversion": "^8.0.3",
 				"make-fetch-happen": "^15.0.5",
-				"minimatch": "^10.2.4",
+				"minimatch": "^10.2.5",
 				"minipass": "^7.1.3",
 				"minipass-pipeline": "^1.2.4",
 				"ms": "^2.1.2",
-				"node-gyp": "^12.2.0",
+				"node-gyp": "^12.3.0",
 				"nopt": "^9.0.0",
 				"npm-audit-report": "^7.0.0",
 				"npm-install-checks": "^8.0.0",
@@ -15442,7 +20025,7 @@
 				"spdx-expression-parse": "^4.0.0",
 				"ssri": "^13.0.1",
 				"supports-color": "^10.2.2",
-				"tar": "^7.5.11",
+				"tar": "^7.5.13",
 				"text-table": "~0.2.0",
 				"tiny-relative-date": "^2.0.2",
 				"treeverse": "^3.0.0",
@@ -15526,7 +20109,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "9.4.2",
+			"version": "9.5.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -15573,7 +20156,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/config": {
-			"version": "10.8.1",
+			"version": "10.9.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -15761,7 +20344,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-			"version": "0.5.0",
+			"version": "0.5.1",
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -15890,7 +20473,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/brace-expansion": {
-			"version": "5.0.4",
+			"version": "5.0.5",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -15954,7 +20537,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/cidr-regex": {
-			"version": "5.0.3",
+			"version": "5.0.5",
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"engines": {
@@ -16005,7 +20588,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/diff": {
-			"version": "8.0.3",
+			"version": "8.0.4",
 			"inBundle": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -16157,7 +20740,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/ip-address": {
-			"version": "10.1.0",
+			"version": "10.1.1",
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -16165,11 +20748,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/is-cidr": {
-			"version": "6.0.3",
+			"version": "6.0.4",
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"cidr-regex": "^5.0.1"
+				"cidr-regex": "^5.0.4"
 			},
 			"engines": {
 				"node": ">=20"
@@ -16230,11 +20813,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
-			"version": "8.1.5",
+			"version": "8.1.7",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^9.4.2",
+				"@npmcli/arborist": "^9.5.0",
 				"@npmcli/installed-package-contents": "^4.0.0",
 				"binary-extensions": "^3.0.0",
 				"diff": "^8.0.2",
@@ -16248,12 +20831,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "10.2.5",
+			"version": "10.2.7",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@gar/promise-retry": "^1.0.0",
-				"@npmcli/arborist": "^9.4.2",
+				"@npmcli/arborist": "^9.5.0",
 				"@npmcli/package-json": "^7.0.0",
 				"@npmcli/run-script": "^10.0.0",
 				"ci-info": "^4.0.0",
@@ -16270,11 +20853,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "7.0.19",
+			"version": "7.0.21",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^9.4.2"
+				"@npmcli/arborist": "^9.5.0"
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
@@ -16293,11 +20876,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
-			"version": "9.1.5",
+			"version": "9.1.7",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^9.4.2",
+				"@npmcli/arborist": "^9.5.0",
 				"@npmcli/run-script": "^10.0.0",
 				"npm-package-arg": "^13.0.0",
 				"pacote": "^21.0.2"
@@ -16363,7 +20946,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/lru-cache": {
-			"version": "11.2.7",
+			"version": "11.3.5",
 			"inBundle": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -16393,11 +20976,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/minimatch": {
-			"version": "10.2.4",
+			"version": "10.2.5",
 			"inBundle": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^5.0.2"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
 				"node": "18 || 20 || >=22"
@@ -16442,31 +21025,15 @@
 			}
 		},
 		"node_modules/npm/node_modules/minipass-flush": {
-			"version": "1.0.5",
+			"version": "1.0.6",
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"minipass": "^3.0.0"
+				"minipass": "^7.1.3"
 			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">=16 || 14 >=14.17"
 			}
-		},
-		"node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-			"version": "3.3.6",
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-			"version": "4.0.0",
-			"inBundle": true,
-			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/minipass-pipeline": {
 			"version": "1.2.4",
@@ -16539,19 +21106,19 @@
 			}
 		},
 		"node_modules/npm/node_modules/node-gyp": {
-			"version": "12.2.0",
+			"version": "12.3.0",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
 				"env-paths": "^2.2.0",
 				"exponential-backoff": "^3.1.1",
 				"graceful-fs": "^4.2.6",
-				"make-fetch-happen": "^15.0.0",
 				"nopt": "^9.0.0",
 				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
 				"tar": "^7.5.4",
 				"tinyglobby": "^0.2.12",
+				"undici": "^6.25.0",
 				"which": "^6.0.0"
 			},
 			"bin": {
@@ -16895,11 +21462,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/socks": {
-			"version": "2.8.7",
+			"version": "2.8.8",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"ip-address": "^10.0.1",
+				"ip-address": "^10.1.1",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
@@ -16962,7 +21529,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/tar": {
-			"version": "7.5.11",
+			"version": "7.5.13",
 			"inBundle": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -16987,12 +21554,12 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/tinyglobby": {
-			"version": "0.2.15",
+			"version": "0.2.16",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
 				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3"
+				"picomatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -17018,7 +21585,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.3",
+			"version": "4.0.4",
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -17047,6 +21614,14 @@
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/undici": {
+			"version": "6.25.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.17"
 			}
 		},
 		"node_modules/npm/node_modules/util-deprecate": {
@@ -17164,6 +21739,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object.entries": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+			"integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/object.fromentries": {
@@ -17422,13 +22013,13 @@
 			}
 		},
 		"node_modules/ora/node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^6.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
 				"node": ">=12"
@@ -17514,7 +22105,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
 			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -17534,7 +22124,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
 			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-			"dev": true,
 			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/package-manager-detector": {
@@ -17603,6 +22192,36 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/parcel/node_modules/@parcel/events": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/parcel/node_modules/@parcel/logger": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/parcel/node_modules/@parcel/markdown-ansi": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
@@ -17613,6 +22232,209 @@
 			},
 			"engines": {
 				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/parcel/node_modules/@parcel/rust": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
+			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.3",
+				"@parcel/rust-darwin-x64": "2.16.3",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
+				"@parcel/rust-linux-arm64-gnu": "2.16.3",
+				"@parcel/rust-linux-arm64-musl": "2.16.3",
+				"@parcel/rust-linux-x64-gnu": "2.16.3",
+				"@parcel/rust-linux-x64-musl": "2.16.3",
+				"@parcel/rust-win32-x64-msvc": "2.16.3"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/parcel/node_modules/@parcel/rust-darwin-arm64": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
+			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/parcel/node_modules/@parcel/rust-darwin-x64": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
+			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/parcel/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
+			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/parcel/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
+			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/parcel/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/parcel/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/parcel/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/parcel/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -17778,7 +22600,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -17795,7 +22616,6 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
 			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"lru-cache": "^10.2.0",
@@ -17812,7 +22632,6 @@
 			"version": "10.4.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
 			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/path-type": {
@@ -17845,12 +22664,12 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=12"
+				"node": ">=8.6"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
@@ -17968,13 +22787,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.58.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
-			"integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.58.0"
+				"playwright-core": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -17987,9 +22806,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.58.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
-			"integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -17997,6 +22816,21 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/please-upgrade-node": {
@@ -18163,6 +22997,7 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
 			"integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+			"deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -18417,9 +23252,9 @@
 			}
 		},
 		"node_modules/pump": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-			"integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -18435,19 +23270,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/qified": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
-			"integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"hookified": "^1.14.0"
-			},
-			"engines": {
-				"node": ">=20"
 			}
 		},
 		"node_modules/qs": {
@@ -18579,9 +23401,9 @@
 			}
 		},
 		"node_modules/quicktype-core/node_modules/yaml": {
-			"version": "2.8.4",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-			"integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -18645,7 +23467,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
 			"integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"mute-stream": "~0.0.4"
@@ -18730,19 +23551,6 @@
 				"node": ">=8.10.0"
 			}
 		},
-		"node_modules/readdirp/node_modules/picomatch": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -18823,13 +23631,16 @@
 			}
 		},
 		"node_modules/resolve": {
-			"version": "1.22.11",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-			"integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+			"version": "2.0.0-next.6",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+			"integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"es-errors": "^1.3.0",
 				"is-core-module": "^2.16.1",
+				"node-exports-info": "^1.6.0",
+				"object-keys": "^1.1.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -18939,7 +23750,7 @@
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -19028,15 +23839,15 @@
 			}
 		},
 		"node_modules/safe-array-concat": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-			"integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+			"integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.2",
-				"get-intrinsic": "^1.2.6",
+				"call-bind": "^1.0.9",
+				"call-bound": "^1.0.4",
+				"get-intrinsic": "^1.3.0",
 				"has-symbols": "^1.1.0",
 				"isarray": "^2.0.5"
 			},
@@ -19134,14 +23945,14 @@
 			"license": "MIT"
 		},
 		"node_modules/sass": {
-			"version": "1.97.3",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
-			"integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
+			"version": "1.99.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+			"integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^4.0.0",
-				"immutable": "^5.0.2",
+				"immutable": "^5.1.5",
 				"source-map-js": ">=0.6.2 <2.0.0"
 			},
 			"bin": {
@@ -19176,7 +23987,7 @@
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -19225,9 +24036,9 @@
 			}
 		},
 		"node_modules/sax": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-			"integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -19248,9 +24059,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -19349,7 +24160,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -19362,7 +24172,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -19389,14 +24198,14 @@
 			}
 		},
 		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
+				"object-inspect": "^1.13.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -19570,14 +24379,12 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
 			"integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
-			"dev": true,
 			"license": "CC-BY-3.0"
 		},
 		"node_modules/spdx-expression-parse": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
 			"integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"spdx-exceptions": "^2.1.0",
@@ -19585,10 +24392,9 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.22",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-			"integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
-			"dev": true,
+			"version": "3.0.23",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+			"integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
 			"license": "CC0-1.0"
 		},
 		"node_modules/sprintf-js": {
@@ -19659,7 +24465,6 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
 			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"eastasianwidth": "^0.2.0",
@@ -19678,7 +24483,6 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -19693,14 +24497,12 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/string-width/node_modules/ansi-regex": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
 			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -19710,13 +24512,12 @@
 			}
 		},
 		"node_modules/string-width/node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-			"dev": true,
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^6.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
 				"node": ">=12"
@@ -19801,7 +24602,6 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -19847,9 +24647,9 @@
 			}
 		},
 		"node_modules/stylelint": {
-			"version": "16.26.1",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
-			"integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
+			"version": "16.10.0",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.10.0.tgz",
+			"integrity": "sha512-z/8X2rZ52dt2c0stVwI9QL2AFJhLhbPkyfpDFcizs200V/g7v+UYY6SNcB9hKOLcDDX/yGLDsY/pX08sLkz9xQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -19861,46 +24661,44 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-syntax-patches-for-csstree": "^1.0.19",
-				"@csstools/css-tokenizer": "^3.0.4",
-				"@csstools/media-query-list-parser": "^4.0.3",
-				"@csstools/selector-specificity": "^5.0.0",
-				"@dual-bundle/import-meta-resolve": "^4.2.1",
+				"@csstools/css-parser-algorithms": "^3.0.1",
+				"@csstools/css-tokenizer": "^3.0.1",
+				"@csstools/media-query-list-parser": "^3.0.1",
+				"@csstools/selector-specificity": "^4.0.0",
+				"@dual-bundle/import-meta-resolve": "^4.1.0",
 				"balanced-match": "^2.0.0",
 				"colord": "^2.9.3",
 				"cosmiconfig": "^9.0.0",
 				"css-functions-list": "^3.2.3",
-				"css-tree": "^3.1.0",
-				"debug": "^4.4.3",
-				"fast-glob": "^3.3.3",
+				"css-tree": "^3.0.0",
+				"debug": "^4.3.7",
+				"fast-glob": "^3.3.2",
 				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^11.1.1",
+				"file-entry-cache": "^9.1.0",
 				"global-modules": "^2.0.0",
 				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
 				"html-tags": "^3.3.1",
-				"ignore": "^7.0.5",
+				"ignore": "^6.0.2",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.37.0",
+				"known-css-properties": "^0.34.0",
 				"mathml-tag-names": "^2.1.3",
 				"meow": "^13.2.0",
 				"micromatch": "^4.0.8",
 				"normalize-path": "^3.0.0",
-				"picocolors": "^1.1.1",
-				"postcss": "^8.5.6",
+				"picocolors": "^1.0.1",
+				"postcss": "^8.4.47",
 				"postcss-resolve-nested-selector": "^0.1.6",
 				"postcss-safe-parser": "^7.0.1",
-				"postcss-selector-parser": "^7.1.0",
+				"postcss-selector-parser": "^6.1.2",
 				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
 				"string-width": "^4.2.3",
-				"supports-hyperlinks": "^3.2.0",
+				"supports-hyperlinks": "^3.1.0",
 				"svg-tags": "^1.0.0",
-				"table": "^6.9.0",
+				"table": "^6.8.2",
 				"write-file-atomic": "^5.0.1"
 			},
 			"bin": {
@@ -20050,22 +24848,22 @@
 			}
 		},
 		"node_modules/stylelint-scss/node_modules/css-tree": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
 			"license": "MIT",
 			"dependencies": {
-				"mdn-data": "2.12.2",
-				"source-map-js": "^1.0.1"
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
 			},
 			"engines": {
 				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
 			}
 		},
 		"node_modules/stylelint-scss/node_modules/css-tree/node_modules/mdn-data": {
-			"version": "2.12.2",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
 			"license": "CC0-1.0"
 		},
 		"node_modules/stylelint-scss/node_modules/known-css-properties": {
@@ -20075,9 +24873,9 @@
 			"license": "MIT"
 		},
 		"node_modules/stylelint-scss/node_modules/mdn-data": {
-			"version": "2.26.0",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.26.0.tgz",
-			"integrity": "sha512-ZqI0qjKWHMPcGUfLmlr80NPNVHIOjPMHtIOe1qXYFGS0YBZ1YKAzo9yk8W+gGrLCN0Xdv/RKxqdIsqPakEfmow==",
+			"version": "2.28.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.28.1.tgz",
+			"integrity": "sha512-U9w+PzSZ00Z5m9rZ5ARVFL5xOfuCHdKYi/1RRwDCJsboFgJDNT3zT6PIPD7mZQYaQLhsZM3GfDRgSMRHhSmVng==",
 			"license": "CC0-1.0"
 		},
 		"node_modules/stylelint-scss/node_modules/postcss-selector-parser": {
@@ -20105,10 +24903,10 @@
 				"stylelint": ">= 11 < 17"
 			}
 		},
-		"node_modules/stylelint/node_modules/@csstools/selector-specificity": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
-			"integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+		"node_modules/stylelint/node_modules/@csstools/css-parser-algorithms": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -20119,28 +24917,44 @@
 					"url": "https://opencollective.com/csstools"
 				}
 			],
-			"license": "MIT-0",
-			"peer": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"postcss-selector-parser": "^7.0.0"
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/stylelint/node_modules/@csstools/css-tokenizer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/stylelint/node_modules/balanced-match": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
 			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/stylelint/node_modules/cosmiconfig": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+			"integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"env-paths": "^2.2.1",
 				"import-fresh": "^3.3.0",
@@ -20163,14 +24977,13 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/css-tree": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"mdn-data": "2.12.2",
-				"source-map-js": "^1.0.1"
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
 			},
 			"engines": {
 				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -20180,75 +24993,53 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/stylelint/node_modules/file-entry-cache": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
-			"integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-9.1.0.tgz",
+			"integrity": "sha512-/pqPFG+FdxWQj+/WSuzXSDaNzxgTLr/OrR1QuqfEZzDakpdYE70PwUxL7BPUa8hpjbvY1+qvCl8k+8Tq34xJgg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"flat-cache": "^6.1.20"
+				"flat-cache": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/stylelint/node_modules/flat-cache": {
-			"version": "6.1.20",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
-			"integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
+			"integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"cacheable": "^2.3.2",
-				"flatted": "^3.3.3",
-				"hookified": "^1.15.0"
+				"flatted": "^3.3.1",
+				"keyv": "^4.5.4"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/stylelint/node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-6.0.2.tgz",
+			"integrity": "sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
 		},
-		"node_modules/stylelint/node_modules/known-css-properties": {
-			"version": "0.37.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
-			"integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/stylelint/node_modules/mdn-data": {
-			"version": "2.12.2",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-			"license": "CC0-1.0",
-			"peer": true
-		},
-		"node_modules/stylelint/node_modules/postcss-selector-parser": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"license": "CC0-1.0"
 		},
 		"node_modules/stylelint/node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -20433,7 +25224,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/through": {
@@ -20482,6 +25272,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/tinyrainbow": {
@@ -20550,11 +25353,17 @@
 			}
 		},
 		"node_modules/tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=20"
+			}
 		},
 		"node_modules/tsconfig-paths": {
 			"version": "3.15.0",
@@ -20754,7 +25563,7 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
@@ -20922,14 +25731,95 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+		"node_modules/vite": {
+			"version": "8.0.12",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
+			"integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.4",
+				"postcss": "^8.5.14",
+				"rolldown": "1.0.0",
+				"tinyglobby": "^0.2.16"
+			},
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.1.18",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/vitest": {
@@ -21022,124 +25912,17 @@
 				}
 			}
 		},
-		"node_modules/vitest/node_modules/@vitest/mocker": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-			"integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+		"node_modules/vitest/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"@vitest/spy": "4.1.6",
-				"estree-walker": "^3.0.3",
-				"magic-string": "^0.30.21"
+			"engines": {
+				"node": ">=12"
 			},
 			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"msw": "^2.4.9",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"msw": {
-					"optional": true
-				},
-				"vite": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vitest/node_modules/fsevents": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
-		"node_modules/vitest/node_modules/vite": {
-			"version": "8.0.12",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
-			"integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"lightningcss": "^1.32.0",
-				"picomatch": "^4.0.4",
-				"postcss": "^8.5.14",
-				"rolldown": "1.0.0",
-				"tinyglobby": "^0.2.16"
-			},
-			"bin": {
-				"vite": "bin/vite.js"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			},
-			"funding": {
-				"url": "https://github.com/vitejs/vite?sponsor=1"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.3"
-			},
-			"peerDependencies": {
-				"@types/node": "^20.19.0 || >=22.12.0",
-				"@vitejs/devtools": "^0.1.18",
-				"esbuild": "^0.27.0 || ^0.28.0",
-				"jiti": ">=1.21.0",
-				"less": "^4.0.0",
-				"sass": "^1.70.0",
-				"sass-embedded": "^1.70.0",
-				"stylus": ">=0.54.8",
-				"sugarss": "^5.0.0",
-				"terser": "^5.16.0",
-				"tsx": "^4.8.1",
-				"yaml": "^2.4.2"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				},
-				"@vitejs/devtools": {
-					"optional": true
-				},
-				"esbuild": {
-					"optional": true
-				},
-				"jiti": {
-					"optional": true
-				},
-				"less": {
-					"optional": true
-				},
-				"sass": {
-					"optional": true
-				},
-				"sass-embedded": {
-					"optional": true
-				},
-				"stylus": {
-					"optional": true
-				},
-				"sugarss": {
-					"optional": true
-				},
-				"terser": {
-					"optional": true
-				},
-				"tsx": {
-					"optional": true
-				},
-				"yaml": {
-					"optional": true
-				}
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/w3c-xmlserializer": {
@@ -21162,11 +25945,14 @@
 			"license": "MIT"
 		},
 		"node_modules/webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
 			"dev": true,
-			"license": "BSD-2-Clause"
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20"
+			}
 		},
 		"node_modules/whatwg-encoding": {
 			"version": "3.1.1",
@@ -21206,21 +25992,24 @@
 			}
 		},
 		"node_modules/whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
+				"@exodus/bytes": "^1.11.0",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -21430,7 +26219,6 @@
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
 			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^6.1.0",
@@ -21449,7 +26237,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -21467,14 +26254,12 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -21489,7 +26274,6 @@
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
 			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -21502,7 +26286,6 @@
 			"version": "6.2.3",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
 			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -21512,13 +26295,12 @@
 			}
 		},
 		"node_modules/wrap-ansi/node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-			"dev": true,
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^6.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
 				"node": ">=12"
@@ -21630,7 +26412,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
@@ -21686,42 +26467,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/yargs-unparser/node_modules/camelcase": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/yargs-unparser/node_modules/decamelize": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/yargs-unparser/node_modules/is-plain-obj": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/yargs/node_modules/emoji-regex": {
@@ -21785,7 +26530,7 @@
 			"version": "2.7.2",
 			"license": "MIT",
 			"dependencies": {
-				"@microsoft/atlas-css": "4.0.0",
+				"@microsoft/atlas-css": "6.6.1",
 				"@parcel/plugin": "2.16.0",
 				"@parcel/utils": "2.16.0",
 				"front-matter": "4.0.2",
@@ -21800,11 +26545,116 @@
 				"parcel": "2.16.3"
 			}
 		},
-		"plugins/parcel-transformer-markdown-html/node_modules/@microsoft/atlas-css": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@microsoft/atlas-css/-/atlas-css-4.0.0.tgz",
-			"integrity": "sha512-loyyUqpAgx+UNDrL5JMLvnrDuyQBYATbRt0pk+D/0wlQuWTwqbl1wCVovfrEoOMDCnVvRfCNjOTsjPn0r2T/Og==",
-			"license": "MIT"
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/diagnostic": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.16.0.tgz",
+			"integrity": "sha512-z5MeMwFegaA23wseltLykVV9OxsKkY3BiEje/Dt7ttVivwNWFKHDuXB8vbZTDArUooixUH3s/RJhTFI46VJc2A==",
+			"license": "MIT",
+			"dependencies": {
+				"@mischnic/json-sourcemap": "^0.1.1",
+				"nullthrows": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/feature-flags": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.16.0.tgz",
+			"integrity": "sha512-GiRpLx0x8dZdWCpftk6OE0lp0Cc8oUyBssPiobigpSA8vgxrCz/zLbs83R/K70p+wPBb+ye4eEiR67+KCwcSXg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/plugin": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.0.tgz",
+			"integrity": "sha512-Rdk5e/VGmMp6s2DmC0AbjWYmea3Vv8Tx1SC5ln+lf+qRlhndrbFV9o5QKirTY9C8GWd20qH1ZqOxPDEzK/YSGA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/types": "2.16.0"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/profiler": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.16.0.tgz",
+			"integrity": "sha512-xm6fVTA1V/Co7JuJfkNtZJsKsvq0RSpoE7JjiNtKLCMh+Lim6w7dxc6CEBqGImhR/9YbwteY6/gVFwkvCdLvLg==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.0",
+				"@parcel/events": "2.16.0",
+				"@parcel/types-internal": "2.16.0",
+				"chrome-trace-event": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/types": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.0.tgz",
+			"integrity": "sha512-EKsMTqqfiutQIiYKHEJHHeugIymPqM+D+CphhyewAIjxVLk6PTjEQW0ytIbbdOXGAgnK60OFiIKqZAxZ5Hf2dw==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/types-internal": "2.16.0",
+				"@parcel/workers": "2.16.0"
+			}
+		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/types-internal": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.0.tgz",
+			"integrity": "sha512-tibAjOY8iyMDzFp5B9jEZPfHYlNvXpw7/msUVebAE6gZ7A8ymWXG8YzMvin6gvWIVTCsYoOkkRsZARvpRcSspQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.0",
+				"@parcel/feature-flags": "2.16.0",
+				"@parcel/source-map": "^2.1.1",
+				"utility-types": "^3.11.0"
+			}
+		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/workers": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.0.tgz",
+			"integrity": "sha512-JVdAtTWRONbP4X8Me1qRE5sMGIkSKAcUb8fZdjCUPJxsBwcJwzYicYFuahxVVGj2sYzjLi0TzlvmXMK7tVvffA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.0",
+				"@parcel/logger": "2.16.0",
+				"@parcel/profiler": "2.16.0",
+				"@parcel/types-internal": "2.16.0",
+				"@parcel/utils": "2.16.0",
+				"nullthrows": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"peerDependencies": {
+				"@parcel/core": "^2.16.0"
+			}
 		},
 		"plugins/stylelint-config-atlas": {
 			"name": "@microsoft/stylelint-config-atlas",
@@ -21822,196 +26672,6 @@
 			"engines": {
 				"node": "24.15.0",
 				"npm": "11.12.1"
-			}
-		},
-		"plugins/stylelint-config-atlas/node_modules/@csstools/media-query-list-parser": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-3.0.1.tgz",
-			"integrity": "sha512-HNo8gGD02kHmcbX6PvCoUuOQvn4szyB9ca63vZHKX5A81QytgDG4oxG4IaEfHTlEZSZ6MjPEMWIVU+zF2PZcgw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.1",
-				"@csstools/css-tokenizer": "^3.0.1"
-			}
-		},
-		"plugins/stylelint-config-atlas/node_modules/balanced-match": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
-			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-			"license": "MIT"
-		},
-		"plugins/stylelint-config-atlas/node_modules/cosmiconfig": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-			"license": "MIT",
-			"dependencies": {
-				"env-paths": "^2.2.1",
-				"import-fresh": "^3.3.0",
-				"js-yaml": "^4.1.0",
-				"parse-json": "^5.2.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/d-fischer"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.9.5"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"plugins/stylelint-config-atlas/node_modules/css-tree": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-			"license": "MIT",
-			"dependencies": {
-				"mdn-data": "2.12.2",
-				"source-map-js": "^1.0.1"
-			},
-			"engines": {
-				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-			}
-		},
-		"plugins/stylelint-config-atlas/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"license": "MIT"
-		},
-		"plugins/stylelint-config-atlas/node_modules/file-entry-cache": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-9.1.0.tgz",
-			"integrity": "sha512-/pqPFG+FdxWQj+/WSuzXSDaNzxgTLr/OrR1QuqfEZzDakpdYE70PwUxL7BPUa8hpjbvY1+qvCl8k+8Tq34xJgg==",
-			"license": "MIT",
-			"dependencies": {
-				"flat-cache": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"plugins/stylelint-config-atlas/node_modules/flat-cache": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
-			"integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
-			"license": "MIT",
-			"dependencies": {
-				"flatted": "^3.3.1",
-				"keyv": "^4.5.4"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"plugins/stylelint-config-atlas/node_modules/ignore": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-6.0.2.tgz",
-			"integrity": "sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
-		"plugins/stylelint-config-atlas/node_modules/mdn-data": {
-			"version": "2.12.2",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-			"license": "CC0-1.0"
-		},
-		"plugins/stylelint-config-atlas/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"plugins/stylelint-config-atlas/node_modules/stylelint": {
-			"version": "16.10.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.10.0.tgz",
-			"integrity": "sha512-z/8X2rZ52dt2c0stVwI9QL2AFJhLhbPkyfpDFcizs200V/g7v+UYY6SNcB9hKOLcDDX/yGLDsY/pX08sLkz9xQ==",
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/stylelint"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/stylelint"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.1",
-				"@csstools/css-tokenizer": "^3.0.1",
-				"@csstools/media-query-list-parser": "^3.0.1",
-				"@csstools/selector-specificity": "^4.0.0",
-				"@dual-bundle/import-meta-resolve": "^4.1.0",
-				"balanced-match": "^2.0.0",
-				"colord": "^2.9.3",
-				"cosmiconfig": "^9.0.0",
-				"css-functions-list": "^3.2.3",
-				"css-tree": "^3.0.0",
-				"debug": "^4.3.7",
-				"fast-glob": "^3.3.2",
-				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^9.1.0",
-				"global-modules": "^2.0.0",
-				"globby": "^11.1.0",
-				"globjoin": "^0.1.4",
-				"html-tags": "^3.3.1",
-				"ignore": "^6.0.2",
-				"imurmurhash": "^0.1.4",
-				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.34.0",
-				"mathml-tag-names": "^2.1.3",
-				"meow": "^13.2.0",
-				"micromatch": "^4.0.8",
-				"normalize-path": "^3.0.0",
-				"picocolors": "^1.0.1",
-				"postcss": "^8.4.47",
-				"postcss-resolve-nested-selector": "^0.1.6",
-				"postcss-safe-parser": "^7.0.1",
-				"postcss-selector-parser": "^6.1.2",
-				"postcss-value-parser": "^4.2.0",
-				"resolve-from": "^5.0.0",
-				"string-width": "^4.2.3",
-				"supports-hyperlinks": "^3.1.0",
-				"svg-tags": "^1.0.0",
-				"table": "^6.8.2",
-				"write-file-atomic": "^5.0.1"
-			},
-			"bin": {
-				"stylelint": "bin/stylelint.mjs"
-			},
-			"engines": {
-				"node": ">=18.12.0"
 			}
 		},
 		"site": {
@@ -22051,9 +26711,9 @@
 			}
 		},
 		"site/node_modules/fs-extra": {
-			"version": "11.3.3",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-			"integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"lint-fix": "npm run lint-fix:site && lint-fix:css",
 		"lint-fix:site": "npm run lint-fix --workspace=@microsoft/atlas-site",
 		"lint:js": "npm run lint --workspace=@microsoft/atlas-js",
+		"test": "npm run test --workspace=@microsoft/atlas-js",
 		"lint-fix:css": "npm run lint-fix --workspace=@microsoft/atlas-css",
 		"start": "npm run serve:site",
 		"serve:site": "npm run start --workspace=@microsoft/atlas-site",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"lint-fix:site": "npm run lint-fix --workspace=@microsoft/atlas-site",
 		"lint:js": "npm run lint --workspace=@microsoft/atlas-js",
 		"test": "npm run test --workspace=@microsoft/atlas-js",
-		"test:coverage": "npm run test:coverage --workspace=@microsoft/atlas-js",
+		"test:cov": "npm run test:cov --workspace=@microsoft/atlas-js",
 		"lint-fix:css": "npm run lint-fix --workspace=@microsoft/atlas-css",
 		"start": "npm run serve:site",
 		"serve:site": "npm run start --workspace=@microsoft/atlas-site",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"lint-fix:site": "npm run lint-fix --workspace=@microsoft/atlas-site",
 		"lint:js": "npm run lint --workspace=@microsoft/atlas-js",
 		"test": "npm run test --workspace=@microsoft/atlas-js",
+		"test:coverage": "npm run test:coverage --workspace=@microsoft/atlas-js",
 		"lint-fix:css": "npm run lint-fix --workspace=@microsoft/atlas-css",
 		"start": "npm run serve:site",
 		"serve:site": "npm run start --workspace=@microsoft/atlas-site",

--- a/plugins/parcel-transformer-markdown-html/package.json
+++ b/plugins/parcel-transformer-markdown-html/package.json
@@ -14,7 +14,7 @@
 		"parcel": "2.16.3"
 	},
 	"dependencies": {
-		"@microsoft/atlas-css": "4.0.0",
+		"@microsoft/atlas-css": "6.6.1",
 		"parcel": "2.16.3",
 		"@parcel/plugin": "2.16.0",
 		"@parcel/utils": "2.16.0",


### PR DESCRIPTION
- Install vitest and jsdom as dev dependencies in @microsoft/atlas-js
- Add vitest.config.ts with jsdom environment for DOM-dependent tests
- Update js package test script to run vitest
- Add root-level test script to run js workspace tests
- Add test step to main CI workflow
- Include sample utility tests to verify setup

Output: https://github.com/microsoft/atlas-design/actions/runs/25767534079/job/75683333312

Link: [preview](http://localhost:1111/)

`npm run test`, `npm run test:cov`
