### PR TITLE
Upgrade serialize-javascript to 7.0.3 via npm override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,8 +62,6 @@
 		},
 		"css/node_modules/fs-extra": {
 			"version": "11.3.5",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -73,6 +71,29 @@
 			},
 			"engines": {
 				"node": ">=14.14"
+			}
+		},
+		"css/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"css/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"extension": {
@@ -104,8 +125,6 @@
 		},
 		"extension/node_modules/@types/node": {
 			"version": "24.12.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-			"integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -136,10 +155,32 @@
 				"npm": "11.12.1"
 			}
 		},
+		"integration/node_modules/execa": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+			"integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.1",
+				"human-signals": "^4.3.0",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^3.0.7",
+				"strip-final-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
 		"integration/node_modules/fs-extra": {
 			"version": "11.3.5",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -149,6 +190,29 @@
 			},
 			"engines": {
 				"node": ">=14.14"
+			}
+		},
+		"integration/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"integration/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"js": {
@@ -175,8 +239,6 @@
 		},
 		"js/node_modules/rimraf": {
 			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-			"integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -455,12 +517,6 @@
 			"engines": {
 				"node": ">=6.9.0"
 			}
-		},
-		"node_modules/@babel/code-frame/node_modules/js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"license": "MIT"
 		},
 		"node_modules/@babel/helper-string-parser": {
 			"version": "7.27.1",
@@ -1546,6 +1602,30 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/@eslint/js": {
 			"version": "8.57.1",
 			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
@@ -1595,6 +1675,30 @@
 			},
 			"engines": {
 				"node": ">=10.10.0"
+			}
+		},
+		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/@humanwhocodes/module-importer": {
@@ -1834,26 +1938,6 @@
 				"node": ">=6 <7 || >=8"
 			}
 		},
-		"node_modules/@manypkg/find-root/node_modules/jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-			"dev": true,
-			"license": "MIT",
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/@manypkg/find-root/node_modules/universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4.0.0"
-			}
-		},
 		"node_modules/@manypkg/get-packages": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
@@ -1889,26 +1973,6 @@
 			},
 			"engines": {
 				"node": ">=6 <7 || >=8"
-			}
-		},
-		"node_modules/@manypkg/get-packages/node_modules/jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-			"dev": true,
-			"license": "MIT",
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/@manypkg/get-packages/node_modules/universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4.0.0"
 			}
 		},
 		"node_modules/@microsoft/atlas-css": {
@@ -2082,9 +2146,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.129.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
-			"integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+			"integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -2113,294 +2177,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/bundler-default/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/cache": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.16.3.tgz",
@@ -2423,298 +2199,10 @@
 				"@parcel/core": "^2.16.3"
 			}
 		},
-		"node_modules/@parcel/cache/node_modules/@parcel/codeframe": {
+		"node_modules/@parcel/codeframe": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
 			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/cache/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/cache/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/cache/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/cache/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/cache/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/cache/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/cache/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/cache/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/cache/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/cache/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/cache/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/cache/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/cache/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/codeframe": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.0.tgz",
-			"integrity": "sha512-wXpHOOE5o0c55AiUMCwkIrVCFeJzBfZpjhn07WQUUk57gGts5R67bMsoeoizvBhI748l6iSU7rPZSSrXc8NoRg==",
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.2"
@@ -2831,294 +2319,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/core/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/core/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/core/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/core/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/core/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/core/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/core/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/core/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/core/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/core/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/core/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/core/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/core/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/core/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/diagnostic": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.16.3.tgz",
@@ -3150,9 +2350,9 @@
 			}
 		},
 		"node_modules/@parcel/events": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.0.tgz",
-			"integrity": "sha512-PI7dryJLPYCe4jNzo7XWAzbUPUuD50Nd76GTdzaHhmcQfZnPrtWAu73UmP3yYqpbv97TtWSiCJyrJWPTDU/REA==",
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
+			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 16.0.0"
@@ -3199,294 +2399,6 @@
 				"@parcel/core": "^2.16.3"
 			}
 		},
-		"node_modules/@parcel/fs/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/fs/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/fs/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/fs/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/fs/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/fs/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/fs/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/fs/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/fs/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/fs/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/fs/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/fs/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/fs/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/fs/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/graph": {
 			"version": "3.6.3",
 			"resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.6.3.tgz",
@@ -3505,30 +2417,13 @@
 			}
 		},
 		"node_modules/@parcel/logger": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.0.tgz",
-			"integrity": "sha512-/K6UVVCtS1KOkH9xxuH9u2xV3348mb+Fb33K/OUs5wnpfmo0TtrzodjLyMpQG6KrofmYKSNzA5petp7+cf3aug==",
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
+			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
 			"license": "MIT",
 			"dependencies": {
-				"@parcel/diagnostic": "2.16.0",
-				"@parcel/events": "2.16.0"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/logger/node_modules/@parcel/diagnostic": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.16.0.tgz",
-			"integrity": "sha512-z5MeMwFegaA23wseltLykVV9OxsKkY3BiEje/Dt7ttVivwNWFKHDuXB8vbZTDArUooixUH3s/RJhTFI46VJc2A==",
-			"license": "MIT",
-			"dependencies": {
-				"@mischnic/json-sourcemap": "^0.1.1",
-				"nullthrows": "^1.1.1"
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/events": "2.16.3"
 			},
 			"engines": {
 				"node": ">= 16.0.0"
@@ -3539,9 +2434,9 @@
 			}
 		},
 		"node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.0.tgz",
-			"integrity": "sha512-NxlmF/JAmsq9Yf/8q2+WEHFkcQ/cDoVOUx6ETDM8icDaQ8kXJbZSKAMOWnsB1EF0757UST77kX9zw/V6tyXqnw==",
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
+			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.2"
@@ -3595,294 +2490,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/node-resolver-core/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/optimizer-css": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.16.3.tgz",
@@ -3906,294 +2513,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-css/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/optimizer-html": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/optimizer-html/-/optimizer-html-2.16.3.tgz",
@@ -4207,294 +2526,6 @@
 			"engines": {
 				"node": ">= 16.0.0",
 				"parcel": "^2.16.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-html/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4525,294 +2556,6 @@
 				"@parcel/core": "^2.16.3"
 			}
 		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-image/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/optimizer-svg": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/optimizer-svg/-/optimizer-svg-2.16.3.tgz",
@@ -4826,294 +2569,6 @@
 			"engines": {
 				"node": ">= 16.0.0",
 				"parcel": "^2.16.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-svg/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -5136,294 +2591,6 @@
 			"engines": {
 				"node": ">= 16.0.0",
 				"parcel": "^2.16.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/optimizer-swc/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -5457,294 +2624,6 @@
 				"@parcel/core": "^2.16.3"
 			}
 		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/package-manager/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/packager-css": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.16.3.tgz",
@@ -5761,294 +2640,6 @@
 			"engines": {
 				"node": ">= 16.0.0",
 				"parcel": "^2.16.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-css/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -6075,294 +2666,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-html/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/packager-js": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.16.3.tgz",
@@ -6381,294 +2684,6 @@
 			"engines": {
 				"node": ">= 16.0.0",
 				"parcel": "^2.16.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-js/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -6706,294 +2721,6 @@
 			"engines": {
 				"node": ">= 16.0.0",
 				"parcel": "^2.16.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/packager-svg/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -7052,19 +2779,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/profiler/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/reporter-cli": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.16.3.tgz",
@@ -7080,294 +2794,6 @@
 			"engines": {
 				"node": ">= 16.0.0",
 				"parcel": "^2.16.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-cli/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -7394,294 +2820,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-dev-server/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/reporter-tracer": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.16.3.tgz",
@@ -7696,294 +2834,6 @@
 			"engines": {
 				"node": ">= 16.0.0",
 				"parcel": "^2.16.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/reporter-tracer/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -8026,294 +2876,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-browser-hmr/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/runtime-js": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.16.3.tgz",
@@ -8328,294 +2890,6 @@
 			"engines": {
 				"node": ">= 16.0.0",
 				"parcel": "^2.16.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-js/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -8642,294 +2916,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-rsc/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/runtime-service-worker": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.16.3.tgz",
@@ -8949,69 +2935,7 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust": {
+		"node_modules/@parcel/rust": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
 			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
@@ -9042,7 +2966,7 @@
 				}
 			}
 		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust-darwin-arm64": {
+		"node_modules/@parcel/rust-darwin-arm64": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
 			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
@@ -9062,7 +2986,7 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust-darwin-x64": {
+		"node_modules/@parcel/rust-darwin-x64": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
 			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
@@ -9082,7 +3006,7 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+		"node_modules/@parcel/rust-linux-arm-gnueabihf": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
 			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
@@ -9102,241 +3026,12 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust-linux-arm64-gnu": {
+		"node_modules/@parcel/rust-linux-arm64-gnu": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
 			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/runtime-service-worker/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/rust": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.0.tgz",
-			"integrity": "sha512-9ZBiwCCm9OYa2f1rjkXtPUIa0qbKPmpdTqtNHC+5ieRxClvk+m/mxsO1Ag+GbNJrJ8qFYliL3Ha0ZK4d1BrVKw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.0",
-				"@parcel/rust-darwin-x64": "2.16.0",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.0",
-				"@parcel/rust-linux-arm64-gnu": "2.16.0",
-				"@parcel/rust-linux-arm64-musl": "2.16.0",
-				"@parcel/rust-linux-x64-gnu": "2.16.0",
-				"@parcel/rust-linux-x64-musl": "2.16.0",
-				"@parcel/rust-win32-x64-msvc": "2.16.0"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.0.tgz",
-			"integrity": "sha512-rdNl1jq34VflBzduQjcOH9SBJPW+Dy1w5XL7hQ5OEAOkRTP1/3mvh98iVYeB3e+RMjRNE/Ipn/rz2KXXku6e6g==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.0.tgz",
-			"integrity": "sha512-tozUnjBPfnCjk6HVZCUKNdgFWw4WsLRTJdnsTYBIERrfj858VN0rdOGlVesLFYNSUquoAO+aHtRdT/JqYW7ozA==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.0.tgz",
-			"integrity": "sha512-FX/XrQm5BkLfHHBsUA1t7tYGTkNN4vr/t9ZuADUQCWng+m8g7BB78zWxkjoqayn5zTJAfjjQp42lSZzahtT59A==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.0.tgz",
-			"integrity": "sha512-zmnWuclEQDQMhbB8jQw9f1VbnSs6EB2RApg16qs5Co/dhZVozMwJngdkZ6mq5aW8ut+PKYrxIPcVsm7WtVOOfg==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -9352,14 +3047,11 @@
 			}
 		},
 		"node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.0.tgz",
-			"integrity": "sha512-bL3PzFEg0azmdFaf34yHAXukk2MjNSuiITPVOj9Cq65qAk7lb4+9nuGIwrCMr1+R1yCamrL31GgG61qp0X97xg==",
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
+			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -9375,14 +3067,11 @@
 			}
 		},
 		"node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.0.tgz",
-			"integrity": "sha512-yvuDTyuhMtwZjB1xGFmCC/UsZjEpMTAanJHAVX9b+tJnn7ArG7Q75Az/JpZsru6KAXiTo1krI54vTE87zzwkIg==",
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
+			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -9398,14 +3087,11 @@
 			}
 		},
 		"node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.0.tgz",
-			"integrity": "sha512-0q6ESCVe9uHVuQWuEGGDMJwjezliTsEWMcqn7oeQoKXaZJZQpW0UAuzNcNmpiHmeJdifYT9XuxVOo/a8IgOXhg==",
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
+			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -9421,9 +3107,9 @@
 			}
 		},
 		"node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.0.tgz",
-			"integrity": "sha512-IVWpXF1VY+Xgi6ylXaZttAF5+WjazPyxRJUZlC31taYwpfZ4LzmsV8NYlj5ehjTL8d28SKDBoAnOQJwDRe8z8Q==",
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
+			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
 			"cpu": [
 				"x64"
 			],
@@ -9476,294 +3162,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-babel/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/transformer-css": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.16.3.tgz",
@@ -9781,294 +3179,6 @@
 			"engines": {
 				"node": ">= 16.0.0",
 				"parcel": "^2.16.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-css/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -10094,209 +3204,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-html/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/transformer-image": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.16.3.tgz",
@@ -10314,294 +3221,6 @@
 			},
 			"peerDependencies": {
 				"@parcel/core": "^2.16.3"
-			}
-		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-image/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/transformer-js": {
@@ -10632,294 +3251,6 @@
 			},
 			"peerDependencies": {
 				"@parcel/core": "^2.16.3"
-			}
-		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-js/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/@parcel/transformer-json": {
@@ -10981,294 +3312,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-postcss/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/transformer-posthtml": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.16.3.tgz",
@@ -11281,294 +3324,6 @@
 			"engines": {
 				"node": ">= 16.0.0",
 				"parcel": "^2.16.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -11606,294 +3361,6 @@
 			"engines": {
 				"node": ">= 16.0.0",
 				"parcel": "^2.16.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-react-refresh-wrap/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -11939,209 +3406,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-svg/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/types": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.3.tgz",
@@ -12165,35 +3429,18 @@
 			}
 		},
 		"node_modules/@parcel/utils": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.0.tgz",
-			"integrity": "sha512-Jc5npvJ5T45goEIbDwsQKX3AtfhLIF2t6G496XhbjcH3aeFLrnIbg1iaitQWvgxdjrt73h8PPNphDkREZ/H7WA==",
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
+			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
 			"license": "MIT",
 			"dependencies": {
-				"@parcel/codeframe": "2.16.0",
-				"@parcel/diagnostic": "2.16.0",
-				"@parcel/logger": "2.16.0",
-				"@parcel/markdown-ansi": "2.16.0",
-				"@parcel/rust": "2.16.0",
+				"@parcel/codeframe": "2.16.3",
+				"@parcel/diagnostic": "2.16.3",
+				"@parcel/logger": "2.16.3",
+				"@parcel/markdown-ansi": "2.16.3",
+				"@parcel/rust": "2.16.3",
 				"@parcel/source-map": "^2.1.1",
 				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/utils/node_modules/@parcel/diagnostic": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.16.0.tgz",
-			"integrity": "sha512-z5MeMwFegaA23wseltLykVV9OxsKkY3BiEje/Dt7ttVivwNWFKHDuXB8vbZTDArUooixUH3s/RJhTFI46VJc2A==",
-			"license": "MIT",
-			"dependencies": {
-				"@mischnic/json-sourcemap": "^0.1.1",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
@@ -12326,9 +3573,6 @@
 			"cpu": [
 				"arm"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -12348,9 +3592,6 @@
 			"integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
 			"cpu": [
 				"arm"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -12372,9 +3613,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -12394,9 +3632,6 @@
 			"integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -12418,9 +3653,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -12440,9 +3672,6 @@
 			"integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -12526,12 +3755,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@parcel/watcher/node_modules/node-addon-api": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-			"license": "MIT"
-		},
 		"node_modules/@parcel/watcher/node_modules/picomatch": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -12568,294 +3791,6 @@
 				"@parcel/core": "^2.16.3"
 			}
 		},
-		"node_modules/@parcel/workers/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/workers/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/workers/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/workers/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/workers/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@parcel/workers/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/workers/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/workers/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/workers/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/workers/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/workers/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/workers/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/workers/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/workers/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -12883,9 +3818,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
-			"integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+			"integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
 			"cpu": [
 				"arm64"
 			],
@@ -12900,9 +3835,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
-			"integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+			"integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
 			"cpu": [
 				"arm64"
 			],
@@ -12917,9 +3852,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
-			"integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+			"integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
 			"cpu": [
 				"x64"
 			],
@@ -12934,9 +3869,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
-			"integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+			"integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
 			"cpu": [
 				"x64"
 			],
@@ -12951,9 +3886,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
-			"integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+			"integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
 			"cpu": [
 				"arm"
 			],
@@ -12968,16 +3903,13 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
-			"integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+			"integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -12988,16 +3920,13 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
-			"integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+			"integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -13008,16 +3937,13 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
-			"integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+			"integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -13028,16 +3954,13 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
-			"integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+			"integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -13048,16 +3971,13 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
-			"integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+			"integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -13068,16 +3988,13 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
-			"integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+			"integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -13088,9 +4005,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
-			"integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+			"integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -13105,9 +4022,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
-			"integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+			"integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
 			"cpu": [
 				"wasm32"
 			],
@@ -13124,9 +4041,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
-			"integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+			"integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
 			"cpu": [
 				"arm64"
 			],
@@ -13141,9 +4058,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
-			"integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+			"integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
 			"cpu": [
 				"x64"
 			],
@@ -13158,9 +4075,9 @@
 			}
 		},
 		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
-			"integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -13273,9 +4190,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -13291,9 +4205,6 @@
 			"integrity": "sha512-il7tYM+CpUNzieQbwAjFT1P8zqAhmGWNAGhQZBnxurXZ0aNn+5nqYFTEUKNZl7QibtT0uQXzTZrNGHCIj6Y1Og==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
@@ -13311,9 +4222,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -13329,9 +4237,6 @@
 			"integrity": "sha512-De1IyajoOmhOYYjw/lx66bKlyDpHZTueqwpDrWgf5O7T6d1ODeJJO9/OqMBmrBQc5C+dNnlmIufHsp4QVCWufA==",
 			"cpu": [
 				"s390x"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
@@ -13349,9 +4254,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -13367,9 +4269,6 @@
 			"integrity": "sha512-hj628ZkSEJf6zMf5VMbYrG2O6QqyTIp2qwY6VlCjvIa9lAEZ5c2lfPblCLVGYubTeLJDxadLB/CxqQYOQABeEQ==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
@@ -13576,9 +4475,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.118.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.118.0.tgz",
-			"integrity": "sha512-Ah6eTlqDcwIMELEVwQMO++rJAFBRz/oLluLD/vWdYrH1KuI9kfpaM+7pg0OvvascgcJy+ghLCERAYouM4QbzGw==",
+			"version": "1.120.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+			"integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -14161,6 +5060,17 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/@vscode/vsce/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/@vscode/vsce/node_modules/chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -14192,6 +5102,16 @@
 			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@vscode/vsce/node_modules/commander": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/@vscode/vsce/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
@@ -14233,6 +5153,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/@vscode/vsce/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/@vscode/vsce/node_modules/supports-color": {
@@ -14528,6 +5461,13 @@
 				"js-tokens": "^10.0.0"
 			}
 		},
+		"node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/astral-regex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -14632,9 +5572,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.29",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-			"integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+			"version": "2.10.30",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.30.tgz",
+			"integrity": "sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==",
 			"license": "Apache-2.0",
 			"bin": {
 				"baseline-browser-mapping": "dist/cli.cjs"
@@ -14716,13 +5656,12 @@
 			"license": "ISC"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/braces": {
@@ -14929,9 +5868,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001792",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-			"integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+			"version": "1.0.30001793",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+			"integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -15048,19 +5987,6 @@
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
-			}
-		},
-		"node_modules/chokidar/node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/chownr": {
@@ -15231,13 +6157,12 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-			"dev": true,
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
 			"license": "MIT",
 			"engines": {
-				"node": ">= 6"
+				"node": ">=18"
 			}
 		},
 		"node_modules/comment-parser": {
@@ -15261,6 +6186,7 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/convert-source-map": {
@@ -15816,9 +6742,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.354",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.354.tgz",
-			"integrity": "sha512-JaBHwWcfIdmSAfWM5l3uwjGd431j8YEMikZ+K/2nXVuBqJKyZ0f+2h4n4JY5AyNiZmnY9qQr2RU3v9DxDmHMNg==",
+			"version": "1.5.357",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
+			"integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
 			"license": "ISC"
 		},
 		"node_modules/emoji-regex": {
@@ -16283,6 +7209,17 @@
 				"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
 			}
 		},
+		"node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/eslint-plugin-import/node_modules/debug": {
 			"version": "3.2.7",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -16304,6 +7241,19 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/eslint-plugin-import/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/eslint-plugin-import/node_modules/semver": {
@@ -16388,6 +7338,17 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/eslint/node_modules/eslint-scope": {
 			"version": "7.2.2",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -16432,6 +7393,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/eslint/node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
 		"node_modules/eslint/node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -16446,6 +7420,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/eslint/node_modules/p-limit": {
@@ -16608,27 +7595,115 @@
 			}
 		},
 		"node_modules/execa": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
-			"integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+			"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cross-spawn": "^7.0.3",
-				"get-stream": "^6.0.1",
-				"human-signals": "^4.3.0",
-				"is-stream": "^3.0.0",
+				"cross-spawn": "^7.0.0",
+				"get-stream": "^5.0.0",
+				"human-signals": "^1.1.1",
+				"is-stream": "^2.0.0",
 				"merge-stream": "^2.0.0",
-				"npm-run-path": "^5.1.0",
-				"onetime": "^6.0.0",
-				"signal-exit": "^3.0.7",
-				"strip-final-newline": "^3.0.0"
+				"npm-run-path": "^4.0.0",
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2",
+				"strip-final-newline": "^2.0.0"
 			},
 			"engines": {
-				"node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/execa/node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/execa/node_modules/human-signals": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+			"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.12.0"
+			}
+		},
+		"node_modules/execa/node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/execa/node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/execa/node_modules/npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/execa/node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/execa/node_modules/strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/expand-template": {
@@ -16686,18 +7761,6 @@
 			},
 			"engines": {
 				"node": ">=8.6.0"
-			}
-		},
-		"node_modules/fast-glob/node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/fast-json-stable-stringify": {
@@ -16977,26 +8040,6 @@
 				"node": ">=6 <7 || >=8"
 			}
 		},
-		"node_modules/fs-extra/node_modules/jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-			"dev": true,
-			"license": "MIT",
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/fs-extra/node_modules/universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4.0.0"
-			}
-		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -17005,9 +8048,9 @@
 			"license": "ISC"
 		},
 		"node_modules/fsevents": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -17202,40 +8245,15 @@
 			}
 		},
 		"node_modules/glob-parent": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-			"dev": true,
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
 			"license": "ISC",
 			"dependencies": {
-				"is-glob": "^4.0.3"
+				"is-glob": "^4.0.1"
 			},
 			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/glob/node_modules/minimatch": {
-			"version": "9.0.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"node": ">= 6"
 			}
 		},
 		"node_modules/global-modules": {
@@ -17489,6 +8507,18 @@
 			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/hosted-git-info/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=10"
@@ -18437,10 +9467,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/js-tokens": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-			"dev": true,
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
@@ -18619,14 +9648,11 @@
 			"license": "MIT"
 		},
 		"node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -18702,6 +9728,14 @@
 				"node-addon-api": "^4.3.0",
 				"prebuild-install": "^7.0.1"
 			}
+		},
+		"node_modules/keytar/node_modules/node-addon-api": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+			"integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
@@ -18897,9 +9931,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -18919,9 +9950,6 @@
 			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MPL-2.0",
 			"optional": true,
@@ -18943,9 +9971,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -18965,9 +9990,6 @@
 			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MPL-2.0",
 			"optional": true,
@@ -19185,16 +10207,10 @@
 			}
 		},
 		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"license": "ISC"
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
@@ -19207,13 +10223,13 @@
 			}
 		},
 		"node_modules/magicast": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
-			"integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+			"integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.29.0",
+				"@babel/parser": "^7.29.3",
 				"@babel/types": "^7.29.0",
 				"source-map-js": "^1.2.1"
 			}
@@ -19425,15 +10441,18 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/minimist": {
@@ -19497,16 +10516,6 @@
 			},
 			"engines": {
 				"node": ">= 14.0.0"
-			}
-		},
-		"node_modules/mocha/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/mocha/node_modules/find-up": {
@@ -19766,12 +10775,10 @@
 			}
 		},
 		"node_modules/node-addon-api": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-			"integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"license": "MIT"
 		},
 		"node_modules/node-exports-info": {
 			"version": "1.6.0",
@@ -22176,303 +13183,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/parcel/node_modules/@parcel/codeframe": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.3.tgz",
-			"integrity": "sha512-oXZx8PUqExnXnAHCLhxulTDeFvTBqPAwJU4AVZwnYFToaQ6nltXWWYaDGUu2f/V3Z17LObWiOROHT7HYXAe62Q==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/parcel/node_modules/@parcel/events": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.3.tgz",
-			"integrity": "sha512-rAh/yXwtHYcKWmi9Tjjf5t95UdBVhhlyJkIYN25/PYKdSRBcQ9c1rd8/fvOeZKy1/fSiOcEXqm6dK7bhLSCaww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/parcel/node_modules/@parcel/logger": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.3.tgz",
-			"integrity": "sha512-dHUJk8dvo2wOg3dIqSjNGqlVqsRn4hTZVbgTShaImaLTWdueaKfMojxo79P7T3em49y0dQb0m+xl2SunDhtwsA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/events": "2.16.3"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/parcel/node_modules/@parcel/markdown-ansi": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.3.tgz",
-			"integrity": "sha512-r0QQpS44jNueY8lcZcSoUua3kJfI5kDZrJvFgi1jrkyxwDUfq3L0xWQjxHrXzv8K6uFAeU+teoq8JcWLVLXa1w==",
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/parcel/node_modules/@parcel/rust": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.3.tgz",
-			"integrity": "sha512-pUsgURnDdlHA9AqvEcm124/9+DB7GM7Mk0qQ9XDNiznl09n8XZ67lf/IIvaMW7y0vQ7FpTzRIrRzAJhGyMRbMw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/rust-darwin-arm64": "2.16.3",
-				"@parcel/rust-darwin-x64": "2.16.3",
-				"@parcel/rust-linux-arm-gnueabihf": "2.16.3",
-				"@parcel/rust-linux-arm64-gnu": "2.16.3",
-				"@parcel/rust-linux-arm64-musl": "2.16.3",
-				"@parcel/rust-linux-x64-gnu": "2.16.3",
-				"@parcel/rust-linux-x64-musl": "2.16.3",
-				"@parcel/rust-win32-x64-msvc": "2.16.3"
-			},
-			"peerDependencies": {
-				"napi-wasm": "^1.1.2"
-			},
-			"peerDependenciesMeta": {
-				"napi-wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/parcel/node_modules/@parcel/rust-darwin-arm64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.3.tgz",
-			"integrity": "sha512-9JG19DDNjIpvlI1b8VYIjvCaulftd6/J09/Rj2A8KgREv6EtCDkus8jCsNw7Jacj2HIWg23kxJY3XKcJ9pkiug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/parcel/node_modules/@parcel/rust-darwin-x64": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.3.tgz",
-			"integrity": "sha512-9mG6M6SGYiCO9IfD85Bixg5udXoy2IQHCRdBoQmpNej5+FrDW1a3FeDwDzqOFtl9b7axpzPEVb7zp+WK36Rn4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/parcel/node_modules/@parcel/rust-linux-arm-gnueabihf": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.3.tgz",
-			"integrity": "sha512-zSA1Dz5JWS28DkEMjEQNmf8qk55dR6rcKtwrw5CMg3Ndt30ugrGtRechsqEpXSYYxcDY1kmZ779LwiTUdkdCrQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/parcel/node_modules/@parcel/rust-linux-arm64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.3.tgz",
-			"integrity": "sha512-PvjO0U6qM0JjRCH2eKi3JNKgBVWDBP3VrMEUXJJM8K37ylfLTozK0f7oK2M03voCS1WjKrduRGjJNk8EZrBPow==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/parcel/node_modules/@parcel/rust-linux-arm64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.3.tgz",
-			"integrity": "sha512-a4TZB9/Y/y8DQ55XZXh9bNb5yIC9CAoK2YK8g3OytauC8OrHGtIIVlF+E1UCn/FPBFr2dobYOeih/InvLKITpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/parcel/node_modules/@parcel/rust-linux-x64-gnu": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.3.tgz",
-			"integrity": "sha512-6/a/5jDcVwE0xpLSLGI9T2pclgnad0jVFRH/4Gm9yQ5fl2gpYghjg3fcCNeSjJ/aBNFKlOeKLlp/oBSlTtlkoQ==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/parcel/node_modules/@parcel/rust-linux-x64-musl": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.3.tgz",
-			"integrity": "sha512-gTUlFvJBLR3UxNjGs076wVuFZyx+X6G6opJzBFaSG9XqLhLo+VrpqHpjCx+SCwSufDLTVq8rWJbwpvbe2EhRJg==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/parcel/node_modules/@parcel/rust-win32-x64-msvc": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.3.tgz",
-			"integrity": "sha512-/kyr5CL4XFJpMj9CvW8K1NNNqkzyOhxc7ibXhykiPyPiGOwO/ZbqnfDhqVx3JMSjOASeW1e6UlGNjnfTPvFkGQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/parcel/node_modules/@parcel/utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.3.tgz",
-			"integrity": "sha512-g/yqVWSdZqPvTiS96dEK9MEl7q6w31u+luD5VGt6f9w6PQCpuVajhhDNuXf9uzDU/dL4sSZPKUhLteVZDqryHA==",
-			"license": "MIT",
-			"dependencies": {
-				"@parcel/codeframe": "2.16.3",
-				"@parcel/diagnostic": "2.16.3",
-				"@parcel/logger": "2.16.3",
-				"@parcel/markdown-ansi": "2.16.3",
-				"@parcel/rust": "2.16.3",
-				"@parcel/source-map": "^2.1.1",
-				"chalk": "^4.1.2",
-				"nullthrows": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/parcel/node_modules/commander": {
-			"version": "12.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -22627,12 +13337,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
-		},
-		"node_modules/path-scurry/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"license": "ISC"
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
@@ -22816,21 +13520,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/playwright/node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/please-upgrade-node": {
@@ -23097,108 +13786,6 @@
 				"prettier": "^2.0.0"
 			}
 		},
-		"node_modules/pretty-quick/node_modules/execa": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-			"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cross-spawn": "^7.0.0",
-				"get-stream": "^5.0.0",
-				"human-signals": "^1.1.1",
-				"is-stream": "^2.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^4.0.0",
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2",
-				"strip-final-newline": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/execa?sponsor=1"
-			}
-		},
-		"node_modules/pretty-quick/node_modules/get-stream": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"pump": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/pretty-quick/node_modules/human-signals": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-			"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=8.12.0"
-			}
-		},
-		"node_modules/pretty-quick/node_modules/is-stream": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/pretty-quick/node_modules/mimic-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/pretty-quick/node_modules/npm-run-path": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-key": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/pretty-quick/node_modules/onetime": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mimic-fn": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/pretty-quick/node_modules/picomatch": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.2.tgz",
@@ -23210,16 +13797,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/pretty-quick/node_modules/strip-final-newline": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/process": {
@@ -23273,9 +13850,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.15.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-			"integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+			"version": "6.15.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -23414,16 +13991,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/eemeli"
-			}
-		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
 			}
 		},
 		"node_modules/rc": {
@@ -23631,14 +14198,14 @@
 			}
 		},
 		"node_modules/resolve": {
-			"version": "2.0.0-next.6",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-			"integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+			"version": "2.0.0-next.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+			"integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"is-core-module": "^2.16.1",
+				"is-core-module": "^2.16.2",
 				"node-exports-info": "^1.6.0",
 				"object-keys": "^1.1.1",
 				"path-parse": "^1.0.7",
@@ -23746,6 +14313,17 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/rimraf/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/rimraf/node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -23768,15 +14346,28 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/rimraf/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/rolldown": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
-			"integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+			"integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.129.0",
-				"@rolldown/pluginutils": "1.0.0"
+				"@oxc-project/types": "=0.130.0",
+				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
 				"rolldown": "bin/cli.mjs"
@@ -23785,21 +14376,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.0",
-				"@rolldown/binding-darwin-arm64": "1.0.0",
-				"@rolldown/binding-darwin-x64": "1.0.0",
-				"@rolldown/binding-freebsd-x64": "1.0.0",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.0",
-				"@rolldown/binding-linux-arm64-musl": "1.0.0",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.0",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.0",
-				"@rolldown/binding-linux-x64-gnu": "1.0.0",
-				"@rolldown/binding-linux-x64-musl": "1.0.0",
-				"@rolldown/binding-openharmony-arm64": "1.0.0",
-				"@rolldown/binding-wasm32-wasi": "1.0.0",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.0",
-				"@rolldown/binding-win32-x64-msvc": "1.0.0"
+				"@rolldown/binding-android-arm64": "1.0.1",
+				"@rolldown/binding-darwin-arm64": "1.0.1",
+				"@rolldown/binding-darwin-x64": "1.0.1",
+				"@rolldown/binding-freebsd-x64": "1.0.1",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.1",
+				"@rolldown/binding-linux-arm64-musl": "1.0.1",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.1",
+				"@rolldown/binding-linux-x64-gnu": "1.0.1",
+				"@rolldown/binding-linux-x64-musl": "1.0.1",
+				"@rolldown/binding-openharmony-arm64": "1.0.1",
+				"@rolldown/binding-wasm32-wasi": "1.0.1",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.1",
+				"@rolldown/binding-win32-x64-msvc": "1.0.1"
 			}
 		},
 		"node_modules/run-applescript": {
@@ -23983,6 +14574,17 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/sass-export/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/sass-export/node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -24003,6 +14605,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/sass-export/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/sass/node_modules/chokidar": {
@@ -24091,13 +14706,13 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+			"integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"dependencies": {
-				"randombytes": "^2.1.0"
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/set-function-length": {
@@ -25616,13 +16231,6 @@
 				"node": ">=20.18.1"
 			}
 		},
-		"node_modules/undici-types": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/unicode-properties": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
@@ -25653,13 +16261,13 @@
 			"license": "MIT"
 		},
 		"node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">= 10.0.0"
+				"node": ">= 4.0.0"
 			}
 		},
 		"node_modules/update-browserslist-db": {
@@ -25732,16 +16340,16 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "8.0.12",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
-			"integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
+			"version": "8.0.13",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+			"integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
 				"postcss": "^8.5.14",
-				"rolldown": "1.0.0",
+				"rolldown": "1.0.1",
 				"tinyglobby": "^0.2.16"
 			},
 			"bin": {
@@ -25807,6 +16415,21 @@
 				"yaml": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vite/node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/vite/node_modules/picomatch": {
@@ -26545,10 +17168,24 @@
 				"parcel": "2.16.3"
 			}
 		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/codeframe": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.0.tgz",
+			"integrity": "sha512-wXpHOOE5o0c55AiUMCwkIrVCFeJzBfZpjhn07WQUUk57gGts5R67bMsoeoizvBhI748l6iSU7rPZSSrXc8NoRg==",
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/diagnostic": {
 			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.16.0.tgz",
-			"integrity": "sha512-z5MeMwFegaA23wseltLykVV9OxsKkY3BiEje/Dt7ttVivwNWFKHDuXB8vbZTDArUooixUH3s/RJhTFI46VJc2A==",
 			"license": "MIT",
 			"dependencies": {
 				"@mischnic/json-sourcemap": "^0.1.1",
@@ -26562,11 +17199,55 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/events": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.0.tgz",
+			"integrity": "sha512-PI7dryJLPYCe4jNzo7XWAzbUPUuD50Nd76GTdzaHhmcQfZnPrtWAu73UmP3yYqpbv97TtWSiCJyrJWPTDU/REA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/feature-flags": {
 			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.16.0.tgz",
-			"integrity": "sha512-GiRpLx0x8dZdWCpftk6OE0lp0Cc8oUyBssPiobigpSA8vgxrCz/zLbs83R/K70p+wPBb+ye4eEiR67+KCwcSXg==",
 			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/logger": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.0.tgz",
+			"integrity": "sha512-/K6UVVCtS1KOkH9xxuH9u2xV3348mb+Fb33K/OUs5wnpfmo0TtrzodjLyMpQG6KrofmYKSNzA5petp7+cf3aug==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.0",
+				"@parcel/events": "2.16.0"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/markdown-ansi": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.0.tgz",
+			"integrity": "sha512-NxlmF/JAmsq9Yf/8q2+WEHFkcQ/cDoVOUx6ETDM8icDaQ8kXJbZSKAMOWnsB1EF0757UST77kX9zw/V6tyXqnw==",
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^4.1.2"
+			},
 			"engines": {
 				"node": ">= 16.0.0"
 			},
@@ -26577,8 +17258,6 @@
 		},
 		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/plugin": {
 			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.0.tgz",
-			"integrity": "sha512-Rdk5e/VGmMp6s2DmC0AbjWYmea3Vv8Tx1SC5ln+lf+qRlhndrbFV9o5QKirTY9C8GWd20qH1ZqOxPDEzK/YSGA==",
 			"license": "MIT",
 			"dependencies": {
 				"@parcel/types": "2.16.0"
@@ -26593,8 +17272,6 @@
 		},
 		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/profiler": {
 			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.16.0.tgz",
-			"integrity": "sha512-xm6fVTA1V/Co7JuJfkNtZJsKsvq0RSpoE7JjiNtKLCMh+Lim6w7dxc6CEBqGImhR/9YbwteY6/gVFwkvCdLvLg==",
 			"license": "MIT",
 			"dependencies": {
 				"@parcel/diagnostic": "2.16.0",
@@ -26610,10 +17287,199 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/rust": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.0.tgz",
+			"integrity": "sha512-9ZBiwCCm9OYa2f1rjkXtPUIa0qbKPmpdTqtNHC+5ieRxClvk+m/mxsO1Ag+GbNJrJ8qFYliL3Ha0ZK4d1BrVKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/rust-darwin-arm64": "2.16.0",
+				"@parcel/rust-darwin-x64": "2.16.0",
+				"@parcel/rust-linux-arm-gnueabihf": "2.16.0",
+				"@parcel/rust-linux-arm64-gnu": "2.16.0",
+				"@parcel/rust-linux-arm64-musl": "2.16.0",
+				"@parcel/rust-linux-x64-gnu": "2.16.0",
+				"@parcel/rust-linux-x64-musl": "2.16.0",
+				"@parcel/rust-win32-x64-msvc": "2.16.0"
+			},
+			"peerDependencies": {
+				"napi-wasm": "^1.1.2"
+			},
+			"peerDependenciesMeta": {
+				"napi-wasm": {
+					"optional": true
+				}
+			}
+		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/rust-darwin-arm64": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.0.tgz",
+			"integrity": "sha512-rdNl1jq34VflBzduQjcOH9SBJPW+Dy1w5XL7hQ5OEAOkRTP1/3mvh98iVYeB3e+RMjRNE/Ipn/rz2KXXku6e6g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/rust-darwin-x64": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.0.tgz",
+			"integrity": "sha512-tozUnjBPfnCjk6HVZCUKNdgFWw4WsLRTJdnsTYBIERrfj858VN0rdOGlVesLFYNSUquoAO+aHtRdT/JqYW7ozA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/rust-linux-arm-gnueabihf": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.0.tgz",
+			"integrity": "sha512-FX/XrQm5BkLfHHBsUA1t7tYGTkNN4vr/t9ZuADUQCWng+m8g7BB78zWxkjoqayn5zTJAfjjQp42lSZzahtT59A==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/rust-linux-arm64-gnu": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.0.tgz",
+			"integrity": "sha512-zmnWuclEQDQMhbB8jQw9f1VbnSs6EB2RApg16qs5Co/dhZVozMwJngdkZ6mq5aW8ut+PKYrxIPcVsm7WtVOOfg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/rust-linux-arm64-musl": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.0.tgz",
+			"integrity": "sha512-bL3PzFEg0azmdFaf34yHAXukk2MjNSuiITPVOj9Cq65qAk7lb4+9nuGIwrCMr1+R1yCamrL31GgG61qp0X97xg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/rust-linux-x64-gnu": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.0.tgz",
+			"integrity": "sha512-yvuDTyuhMtwZjB1xGFmCC/UsZjEpMTAanJHAVX9b+tJnn7ArG7Q75Az/JpZsru6KAXiTo1krI54vTE87zzwkIg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/rust-linux-x64-musl": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.0.tgz",
+			"integrity": "sha512-0q6ESCVe9uHVuQWuEGGDMJwjezliTsEWMcqn7oeQoKXaZJZQpW0UAuzNcNmpiHmeJdifYT9XuxVOo/a8IgOXhg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/rust-win32-x64-msvc": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.0.tgz",
+			"integrity": "sha512-IVWpXF1VY+Xgi6ylXaZttAF5+WjazPyxRJUZlC31taYwpfZ4LzmsV8NYlj5ehjTL8d28SKDBoAnOQJwDRe8z8Q==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/types": {
 			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.0.tgz",
-			"integrity": "sha512-EKsMTqqfiutQIiYKHEJHHeugIymPqM+D+CphhyewAIjxVLk6PTjEQW0ytIbbdOXGAgnK60OFiIKqZAxZ5Hf2dw==",
 			"license": "MIT",
 			"dependencies": {
 				"@parcel/types-internal": "2.16.0",
@@ -26622,8 +17488,6 @@
 		},
 		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/types-internal": {
 			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.0.tgz",
-			"integrity": "sha512-tibAjOY8iyMDzFp5B9jEZPfHYlNvXpw7/msUVebAE6gZ7A8ymWXG8YzMvin6gvWIVTCsYoOkkRsZARvpRcSspQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@parcel/diagnostic": "2.16.0",
@@ -26632,10 +17496,31 @@
 				"utility-types": "^3.11.0"
 			}
 		},
+		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/utils": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.0.tgz",
+			"integrity": "sha512-Jc5npvJ5T45goEIbDwsQKX3AtfhLIF2t6G496XhbjcH3aeFLrnIbg1iaitQWvgxdjrt73h8PPNphDkREZ/H7WA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/codeframe": "2.16.0",
+				"@parcel/diagnostic": "2.16.0",
+				"@parcel/logger": "2.16.0",
+				"@parcel/markdown-ansi": "2.16.0",
+				"@parcel/rust": "2.16.0",
+				"@parcel/source-map": "^2.1.1",
+				"chalk": "^4.1.2",
+				"nullthrows": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"plugins/parcel-transformer-markdown-html/node_modules/@parcel/workers": {
 			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.0.tgz",
-			"integrity": "sha512-JVdAtTWRONbP4X8Me1qRE5sMGIkSKAcUb8fZdjCUPJxsBwcJwzYicYFuahxVVGj2sYzjLi0TzlvmXMK7tVvffA==",
 			"license": "MIT",
 			"dependencies": {
 				"@parcel/diagnostic": "2.16.0",
@@ -26702,8 +17587,6 @@
 		},
 		"site/node_modules/detect-libc": {
 			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -26712,8 +17595,6 @@
 		},
 		"site/node_modules/fs-extra": {
 			"version": "11.3.5",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -26725,10 +17606,21 @@
 				"node": ">=14.14"
 			}
 		},
+		"site/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
 		"site/node_modules/lightningcss": {
 			"version": "1.30.2",
-			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
-			"integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
 			"dev": true,
 			"license": "MPL-2.0",
 			"dependencies": {
@@ -26868,9 +17760,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -26892,9 +17781,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -26916,9 +17802,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -26940,9 +17823,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -26979,8 +17859,6 @@
 		},
 		"site/node_modules/lightningcss-win32-x64-msvc": {
 			"version": "1.30.2",
-			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
-			"integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
 			"cpu": [
 				"x64"
 			],
@@ -26996,6 +17874,16 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"site/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -97,5 +97,8 @@
 	"license": "MIT",
 	"dependencies": {
 		"npm": "^11.12.1"
+	},
+	"overrides": {
+		"serialize-javascript": "7.0.3"
 	}
 }


### PR DESCRIPTION
## Summary
Add npm override to force serialize-javascript from 6.0.2 to 7.0.3 to fix Component Governance security vulnerability.

The package is a transitive dependency of mocha (via atlas-design-system-tools extension).

## Changes
- Added `overrides` section to root package.json
- Regenerated package-lock.json

## Testing
- Unit tests (vitest): passed
- CSS build: passed
- Lint (css + site + js): passed