### PR TITLE
Add JavaScript functionality for restoring layouts

### DIFF
--- a/.changeset/busy-planets-like.md
+++ b/.changeset/busy-planets-like.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': minor
+---
+
+Add a `contentLoaded` utility that resolves after `DOMContentLoaded`.

--- a/.changeset/large-snakes-share.md
+++ b/.changeset/large-snakes-share.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': major
+---
+
+Restructure the output folder to fix a prior issue where `src` was being copied into `dist`.

--- a/.changeset/layout-state-subscriptions.md
+++ b/.changeset/layout-state-subscriptions.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': minor
+---
+
+Add `createLayoutState` to `behaviors/layout` for persisting and restoring `layout-*` classes on `<html>` across page loads, scoped per `viewName` and backed by a configurable storage (defaults to `localStorage`). Restoration and a `MutationObserver` start synchronously inside the factory, and subscribers receive the current matching state on registration with optional `document.startViewTransition` support for the initial restore and subsequent dispatches. After the initial callback flush — or if setup or a queued callback throws — `createLayoutState` sets `data-layout-restored="true"` on `<html>` so CSS hooks (e.g. the new `display-*-until-layout-restored` helpers) don't permanently hide content on failure.

--- a/.changeset/legal-dancers-wonder.md
+++ b/.changeset/legal-dancers-wonder.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/parcel-optimizer-inline-script-restore': patch
+---
+
+Create new package to help site process inline scripts correctly, mitigates parcel bug.

--- a/.changeset/restored-display-helpers.md
+++ b/.changeset/restored-display-helpers.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': minor
+---
+
+Add `display-{value}-until-layout-restored` helpers in `components/layout`. These apply the given `display` value while the `data-layout-restored` attribute is absent from `<html>`, letting you hide (or show) elements until `createLayoutState` (from `@microsoft/atlas-js`) has flushed its initial subscriber callbacks.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Atlas Design System - Copilot Instructions
 
-The Atlas Design System is a CSS-first framework powering Microsoft Learn. It's a monorepo with seven workspaces: `css`, `js`, `site`, `integration`, `extension`, and two plugins.
+The Atlas Design System is a CSS-first framework powering Microsoft Learn. It's a monorepo with eight workspaces: `css`, `js`, `site`, `integration`, `extension`, and three plugins.
 
 ## Commands
 
@@ -49,7 +49,8 @@ npm run screenshots:all    # All themes
 - `integration/` - Playwright tests for visual regression and accessibility
 - `extension/` - VS Code extension for class IntelliSense
 - `plugins/stylelint-config-atlas/` - Shared Stylelint configuration
-- `plugins/parcel-transformer-markdown-html/` - Markdown-to-HTML transformer
+- `plugins/parcel-transformer-markdown-html/` - Markdown-to-HTML transformer (also hides inline `<script>` tags as HTML comments to dodge a Parcel cold-cache race)
+- `plugins/parcel-optimizer-inline-script-restore/` - Parcel optimizer that restores those hidden inline `<script>` tags after transformers run; see the package README for the full story
 
 **Token flow**: CSS variables are defined in `css/src/tokens/`, exported to JSON/TS via `npm run build:tokens`, and consumed by other packages.
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ playwright-report/
 coverage/
 .wireit
 .netrc
+js/coverage

--- a/css/src/components/layout.scss
+++ b/css/src/components/layout.scss
@@ -416,7 +416,7 @@ $layout-aside-width-wide: 450px !default;
 /*
  * For certain classes that toggle the width of layout containers, it is useful to have the ability to toggle the display of elements inside these containers based on the state.
  */
-$layout-collapse-states: 'layout-menu-collapsed', 'layout-aside-collapsed';
+$layout-collapse-states: 'layout-menu-collapsed', 'layout-aside-collapsed', 'layout-flyout-active';
 
 @each $state in $layout-collapse-states {
 	.layout.#{$state} {
@@ -424,6 +424,17 @@ $layout-collapse-states: 'layout-menu-collapsed', 'layout-aside-collapsed';
 			.display-#{$item}-#{$state} {
 				display: #{$item} !important;
 			}
+		}
+	}
+}
+
+/*
+ * Prevent in-flux elements from showing before the layout state from atlas-js has resolved.
+ */
+html:not([data-layout-restored]) {
+	@each $item in tokens.$displays {
+		.display-#{$item}-until-layout-restored {
+			display: #{$item} !important;
 		}
 	}
 }

--- a/integration/tests/layout.spec.ts
+++ b/integration/tests/layout.spec.ts
@@ -622,3 +622,48 @@ test('aside-collapsed modifier collapses aside on sidecar-right layout at widesc
 		expect(boxRestored!.width).toBeGreaterThan(boxAfter!.width);
 	}).toPass();
 });
+
+test('layout-menu-collapsed state persists across a page reload @desktop', async ({
+	page
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'Widescreen Chromium',
+		'Skip test if display screen is not widescreen'
+	);
+
+	await page.goto('/components/layout.html');
+	await page.waitForLoadState('domcontentloaded');
+
+	const html = page.locator('html');
+
+	// Default holy-grail layout starts with the menu expanded.
+	await expect(html).not.toHaveClass(/\blayout-menu-collapsed\b/);
+
+	// Collapse the menu. createLayoutState should persist this to
+	// localStorage under the 'atlas-layout-page' view name.
+	await page.locator(toggleMenuCollapsedSelector).click();
+	await expect(html).toHaveClass(/\blayout-menu-collapsed\b/);
+
+	// Wait for the persisted state to land in localStorage so we know the
+	// inline restore script in <head> will pick it up on reload.
+	await expect
+		.poll(() =>
+			page.evaluate(() => {
+				try {
+					const stored = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
+					return Boolean(stored['atlas-layout-page']?.['layout-menu-collapsed']);
+				} catch {
+					return false;
+				}
+			})
+		)
+		.toBe(true);
+
+	// After reload, the inline restore script should re-apply
+	// layout-menu-collapsed to <html> before first paint, so the collapsed
+	// menu state survives across navigations without a layout flash.
+	await page.reload();
+	await page.waitForLoadState('domcontentloaded');
+
+	await expect(html).toHaveClass(/\blayout-menu-collapsed\b/);
+});

--- a/js/.eslintrc.js
+++ b/js/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
 	parser: '@typescript-eslint/parser',
 	parserOptions: {
 		tsconfigRootDir: __dirname,
-		project: ['./tsconfig.json']
+		project: ['./tsconfig.eslint.json']
 	},
 	plugins: ['@typescript-eslint', 'jsdoc', 'import', 'eslint-plugin-jasmine', 'security'],
 	settings: {

--- a/js/README.md
+++ b/js/README.md
@@ -1,34 +1,23 @@
 # Atlas JS
 
-Welcome to TypeScript/JavaScript code backing the Atlas Design system. While Atlas endeavors to find CSS-only strategies for creating modern UI patterns, there are times when writing behavior code is necessary. These cases tend to fall into a one of several categories.
+JavaScript behaviors and lightweight web components for the [Atlas Design System](https://github.com/microsoft/atlas-design). Atlas prefers CSS-first patterns; this package exists for cases where CSS alone cannot meet accessibility requirements or where a lightweight web component is the right fit.
 
-- A component's markup / attributes require changing upon interaction for compatibility with screen readers or other assistive technology.
-- A particular pattern is a good candidate for a re-usable web component. That is, its behavior is relatively straightforward and lightweight.
+## Install
 
-## Installing this package
-
-Install the `@microsoft/atlas-js` package in your project's dependencies.
-
-```
-npm i @microsoft/atlas-js;
+```sh
+npm i @microsoft/atlas-js
 ```
 
-## Accesssing its Typescript through the `src` folder
+## Import
 
-Include the index file directly to add behaviors to your scripts.
-
-```ts
-import '@microsoft/atlas-js/src/index';
-```
-
-## Accessing the built JS through the `dist` folder
+Built JS (default entry, from `dist/`):
 
 ```js
-import '@microsoft/atlas-js/dist/index';
+import '@microsoft/atlas-js';
 ```
 
-Or include a script tag to pull the built JavaScript from UNPKG.
+TypeScript source (for tree-shakeable named imports from `src/`): `import { createLayoutState } from '@microsoft/atlas-js/src/index'`
 
-```html
-<script src="https://unpkg.com/@microsoft/atlas-js@0.0.1/dist/index.js" type="module" defer>
-```
+## Notable behaviors
+
+- **`createLayoutState`** (in `behaviors/layout`) — persists and restores `layout-*` classes on `<html>` across page loads, with optional `document.startViewTransition` support. See the [Layout component docs](https://github.com/microsoft/atlas-design/blob/main/site/src/components/layout.md#persisting-layout-state-across-page-loads) for the inline-script pattern that restores classes **before first paint**, and the JSDoc in [`src/`](https://github.com/microsoft/atlas-design/tree/main/js/src) for full API details.

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -51,3 +51,453 @@ export function initLayout() {
 		passive: true
 	});
 }
+
+/* -------------------------------------------------------------------------- */
+/* Layout state                                                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Observes `layout-*` class changes on a root element (default: `<html>`) and
+ * persists them via a Storage backend, scoped per `viewName`. Consumers
+ * `subscribe()` to specific class transitions; a new subscription replays
+ * immediately if the current state already matches.
+ *
+ * Restoration and the `MutationObserver` are wired synchronously inside the
+ * factory — by return time the instance is live. Subscriber callbacks are
+ * queued until `deferCallbacksUntil` resolves (default: a resolved promise,
+ * so they fire on the next microtask) so they can safely touch the DOM.
+ *
+ * After the initial flush, sets `data-layout-restored="true"` on the root.
+ * The attribute is set even if setup throws, `deferCallbacksUntil` rejects,
+ * or a queued subscriber throws — CSS rules gated on it (e.g.
+ * `display-*-until-layout-restored`) won't permanently hide content. Setup
+ * errors are re-thrown.
+ *
+ * View-transition coordination: requests to wrap restoration or a
+ * subscriber callback in `document.startViewTransition` are coordinated per
+ * instance to avoid `InvalidStateError` aborts. Subscriber callbacks queued
+ * in the same microtask coalesce into a single transition; any request made
+ * while a transition is already animating runs synchronously instead of
+ * starting (and aborting) another one.
+ */
+
+export type LayoutClassWhen = 'added' | 'removed' | 'always';
+
+export interface LayoutCallbackEvent {
+	className: string;
+	isApplied: boolean;
+	viewName: string;
+}
+
+export type LayoutCallback = (event: LayoutCallbackEvent) => void;
+
+export interface LayoutStateView {
+	[className: string]: boolean;
+}
+
+export interface LayoutStatePersisted {
+	[viewName: string]: LayoutStateView;
+}
+
+export interface LayoutStateOptions {
+	/** Element whose classList is observed and toggled. Defaults to `<html>`. */
+	root?: HTMLElement;
+	/** Storage backend matching `getItem`/`setItem`. Defaults to `localStorage`. */
+	storage?: Pick<Storage, 'getItem' | 'setItem'>;
+	/**
+	 * Scope for stored state, e.g. per page template. May be a static string
+	 * or a getter function that is called every time a view name is needed —
+	 * the function variant lets a single instance follow a dynamically
+	 * changing "current view" without being recreated.
+	 */
+	viewName?: string | (() => string);
+	/**
+	 * Subscriber callbacks are queued until this resolves. Defaults to a
+	 * resolved promise (fires on next microtask). Pass `contentLoaded` to
+	 * wait for `DOMContentLoaded`.
+	 */
+	deferCallbacksUntil?: Promise<unknown>;
+	/** Wrap initial restoration in `document.startViewTransition` if available. */
+	useViewTransitionOnRestore?: boolean;
+}
+
+export interface LayoutSubscribeOptions {
+	/**
+	 * Wrap this callback's invocation in `document.startViewTransition` if
+	 * available. Multiple subscriptions firing in the same microtask coalesce
+	 * into a single transition, and the wrap is skipped (callback runs
+	 * synchronously) when another transition is already animating, so
+	 * subscribers can opt in without worrying about aborting each other.
+	 */
+	useViewTransition?: boolean;
+}
+
+export interface LayoutStateInstance {
+	/**
+	 * Register a callback for transitions of `className`. Fires immediately
+	 * if the current state already matches (queued behind
+	 * `deferCallbacksUntil`). Returns an unsubscribe function.
+	 */
+	subscribe(
+		className: string,
+		when: LayoutClassWhen,
+		callback: LayoutCallback,
+		options?: LayoutSubscribeOptions
+	): () => void;
+	/** Persisted view state for this view name. */
+	getViewState(): LayoutStateView;
+	/** Persisted state across all view names. */
+	getState(): LayoutStatePersisted;
+	/** Stop observing. Subscriptions remain registered. */
+	stop(): void;
+}
+
+export interface LayoutSubscription {
+	className: string;
+	when: LayoutClassWhen;
+	callback: LayoutCallback;
+	useViewTransition: boolean;
+}
+
+type DocumentWithViewTransition = Document & {
+	startViewTransition?: (updateCallback: () => void) => unknown;
+};
+
+export function createLayoutState(options: LayoutStateOptions = {}): LayoutStateInstance {
+	const {
+		root: targetRoot = document.documentElement,
+		storage = window.localStorage,
+		viewName: viewNameOption = 'default',
+		deferCallbacksUntil = Promise.resolve(),
+		useViewTransitionOnRestore = false
+	} = options;
+
+	const CLASS_PREFIX = 'layout-';
+	const STORAGE_KEY = 'atlas-layout-preferences';
+	const RESTORED_ATTRIBUTE = 'data-layout-restored';
+
+	// Resolve the view name on demand so consumers can pass a getter and have
+	// each persistence / dispatch call see the current value. Unsafe object
+	// keys are coerced to 'default' to keep storage writes prototype-safe.
+	function getViewName(): string {
+		const raw = typeof viewNameOption === 'function' ? viewNameOption() : viewNameOption;
+		return raw === '__proto__' || raw === 'prototype' || raw === 'constructor' ? 'default' : raw;
+	}
+
+	const subscriptions = new Set<LayoutSubscription>();
+	let observer: MutationObserver | null = null;
+	let callbacksReady = false;
+	const pendingCallbacks: (() => void)[] = [];
+
+	// View-transition coordination (per instance). `activeTransitionCount`
+	// gates new transitions so callbacks fired while one is animating run
+	// synchronously instead of aborting it with InvalidStateError.
+	// `pendingTransitionFns` lets subscriber callbacks queued in the same
+	// microtask coalesce into a single transition.
+	let activeTransitionCount = 0;
+	const pendingTransitionFns: (() => void)[] = [];
+	let transitionMicrotaskQueued = false;
+
+	function dispatch(invoke: () => void): void {
+		if (callbacksReady) {
+			invoke();
+		} else {
+			pendingCallbacks.push(invoke);
+		}
+	}
+
+	// Sentinel attribute (not a class, to stay out of the layout-* persistence path).
+	function markRestored(): void {
+		targetRoot.setAttribute(RESTORED_ATTRIBUTE, 'true');
+	}
+
+	function flushPendingCallbacks(): void {
+		callbacksReady = true;
+		const queued = pendingCallbacks.splice(0);
+		try {
+			for (const invoke of queued) {
+				try {
+					invoke();
+				} catch (err) {
+					// Isolate one bad subscriber; keep draining.
+					// eslint-disable-next-line no-console
+					console.error('createLayoutState: a subscriber callback threw during initial flush', err);
+				}
+			}
+		} finally {
+			markRestored();
+		}
+	}
+
+	function startOptionalViewTransition(
+		useViewTransition: boolean,
+		fn: () => void,
+		viewTransitionOptions: { sync?: boolean } = {}
+	): void {
+		if (!useViewTransition) {
+			fn();
+			return;
+		}
+		if (viewTransitionOptions.sync) {
+			startSyncViewTransition(fn);
+		} else {
+			startBatchedViewTransition(fn);
+		}
+	}
+
+	function startSyncViewTransition(fn: () => void): void {
+		const docWithVT = document as DocumentWithViewTransition;
+		if (typeof docWithVT.startViewTransition !== 'function') {
+			fn();
+			return;
+		}
+		// A transition is already animating — starting another now would abort
+		// it with InvalidStateError. Apply the change without a transition.
+		if (activeTransitionCount > 0) {
+			fn();
+			return;
+		}
+		startTrackedViewTransition(docWithVT, fn);
+	}
+
+	function startBatchedViewTransition(fn: () => void): void {
+		const docWithVT = document as DocumentWithViewTransition;
+		if (typeof docWithVT.startViewTransition !== 'function' || activeTransitionCount > 0) {
+			fn();
+			return;
+		}
+		pendingTransitionFns.push(fn);
+		if (transitionMicrotaskQueued) {
+			return;
+		}
+		transitionMicrotaskQueued = true;
+		queueMicrotask(() => {
+			transitionMicrotaskQueued = false;
+			const batch = pendingTransitionFns.splice(0);
+			if (batch.length === 0) {
+				return;
+			}
+			// Something else (e.g. a sync restore in another instance) started
+			// a transition between scheduling and now. Apply the batched
+			// changes without a transition so we don't abort it.
+			if (activeTransitionCount > 0) {
+				invokeTransitionCallbacks(batch);
+				return;
+			}
+			startTrackedViewTransition(docWithVT, () => {
+				invokeTransitionCallbacks(batch);
+			});
+		});
+	}
+
+	function startTrackedViewTransition(docWithVT: DocumentWithViewTransition, fn: () => void): void {
+		let transition: { finished?: Promise<unknown> } | undefined;
+		try {
+			transition = docWithVT.startViewTransition!(fn) as unknown as {
+				finished?: Promise<unknown>;
+			};
+		} catch (err) {
+			// eslint-disable-next-line no-console
+			console.error('createLayoutState: startViewTransition threw', err);
+			fn();
+			return;
+		}
+		activeTransitionCount++;
+		const settle = (): void => {
+			activeTransitionCount = Math.max(0, activeTransitionCount - 1);
+		};
+		const finished = transition?.finished;
+		if (finished && typeof finished.then === 'function') {
+			finished.then(settle, settle);
+		} else {
+			// No .finished (e.g. a test stub). Treat the transition as
+			// complete immediately so subsequent calls can either batch or
+			// start a fresh transition cleanly.
+			settle();
+		}
+	}
+
+	function invokeTransitionCallbacks(callbacks: (() => void)[]): void {
+		for (const cb of callbacks) {
+			try {
+				cb();
+			} catch (err) {
+				// eslint-disable-next-line no-console
+				console.error('createLayoutState: view-transition callback threw', err);
+			}
+		}
+	}
+
+	function loadState(): LayoutStatePersisted {
+		const raw = storage.getItem(STORAGE_KEY);
+		if (!raw) {
+			return {};
+		}
+		try {
+			return JSON.parse(raw) as LayoutStatePersisted;
+		} catch {
+			return {};
+		}
+	}
+
+	function saveState(state: LayoutStatePersisted): void {
+		storage.setItem(STORAGE_KEY, JSON.stringify(state));
+	}
+
+	function getViewState(): LayoutStateView {
+		return loadState()[getViewName()] ?? {};
+	}
+
+	function isClassApplied(className: string): boolean {
+		return targetRoot.classList.contains(className);
+	}
+
+	function matches(sub: LayoutSubscription, applied: boolean): boolean {
+		if (sub.when === 'always') {
+			return true;
+		}
+		if (sub.when === 'added') {
+			return applied === true;
+		}
+		return applied === false;
+	}
+
+	function fireMatching(className: string, applied: boolean): void {
+		// Resolve once per fire so every event in this batch carries the same
+		// viewName as the storage write that just happened.
+		const eventViewName = getViewName();
+		for (const sub of subscriptions) {
+			if (sub.className === className && matches(sub, applied)) {
+				const { callback, useViewTransition } = sub;
+				dispatch(() => {
+					startOptionalViewTransition(useViewTransition, () => {
+						callback({ className, isApplied: applied, viewName: eventViewName });
+					});
+				});
+			}
+		}
+	}
+
+	function subscribe(
+		className: string,
+		when: LayoutClassWhen,
+		callback: LayoutCallback,
+		subscribeOptions: LayoutSubscribeOptions = {}
+	): () => void {
+		const sub: LayoutSubscription = {
+			className,
+			when,
+			callback,
+			useViewTransition: !!subscribeOptions.useViewTransition
+		};
+		subscriptions.add(sub);
+
+		const applied = isClassApplied(className);
+		if (matches(sub, applied)) {
+			const eventViewName = getViewName();
+			const { useViewTransition } = sub;
+			dispatch(() => {
+				startOptionalViewTransition(useViewTransition, () => {
+					callback({ className, isApplied: applied, viewName: eventViewName });
+				});
+			});
+		}
+
+		return () => {
+			subscriptions.delete(sub);
+		};
+	}
+
+	function restoreInitialState(): void {
+		const viewState = getViewState();
+		for (const className of Object.keys(viewState)) {
+			targetRoot.classList.toggle(className, viewState[className]);
+		}
+	}
+
+	function matchesPrefix(className: string): boolean {
+		return className.startsWith(CLASS_PREFIX);
+	}
+
+	function diffClasses(newList: string[], oldList: string[]) {
+		const filteredNew = newList.filter(matchesPrefix);
+		const filteredOld = oldList.filter(matchesPrefix);
+		const added = filteredNew.filter(c => !filteredOld.includes(c));
+		const removed = filteredOld.filter(c => !filteredNew.includes(c));
+		return { added, removed };
+	}
+
+	function persistChanges(added: string[], removed: string[]): void {
+		if (added.length + removed.length === 0) {
+			return;
+		}
+		const currentViewName = getViewName();
+		const state = loadState();
+		const viewState = state[currentViewName] ?? {};
+		for (const c of added) {
+			viewState[c] = true;
+		}
+		for (const c of removed) {
+			viewState[c] = false;
+		}
+		state[currentViewName] = viewState;
+		saveState(state);
+	}
+
+	function stop(): void {
+		observer?.disconnect();
+		observer = null;
+	}
+
+	// Wired synchronously so the instance is live on return. Wrapped so a
+	// failure can't strand CSS rules keyed on `data-layout-restored`.
+	try {
+		startOptionalViewTransition(useViewTransitionOnRestore, restoreInitialState, {
+			sync: true
+		});
+
+		observer = new MutationObserver(mutations => {
+			for (const mutation of mutations) {
+				const oldClasses = (mutation.oldValue ?? '').split(/\s+/);
+				const newClasses = Array.from((mutation.target as Element).classList);
+				const { added, removed } = diffClasses(newClasses, oldClasses);
+
+				persistChanges(added, removed);
+
+				for (const c of added) {
+					fireMatching(c, true);
+				}
+				for (const c of removed) {
+					fireMatching(c, false);
+				}
+			}
+		});
+
+		observer.observe(targetRoot, {
+			attributes: true,
+			attributeFilter: ['class'],
+			attributeOldValue: true
+		});
+
+		deferCallbacksUntil.then(flushPendingCallbacks, err => {
+			// eslint-disable-next-line no-console
+			console.error(
+				'createLayoutState: deferCallbacksUntil rejected; flushing pending callbacks anyway',
+				err
+			);
+			flushPendingCallbacks();
+		});
+	} catch (err) {
+		// eslint-disable-next-line no-console
+		console.error('createLayoutState: setup failed; marking layout as restored anyway', err);
+		markRestored();
+		throw err;
+	}
+
+	return {
+		subscribe,
+		getViewState,
+		getState: loadState,
+		stop
+	};
+}

--- a/js/src/utilities/util.ts
+++ b/js/src/utilities/util.ts
@@ -7,3 +7,11 @@ export function generateElementId() {
 export function kebabToCamelCase(str: string) {
 	return str.replace(/-./g, x => x[1].toUpperCase());
 }
+
+export const contentLoaded = new Promise<void>(resolve => {
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', () => resolve());
+	} else {
+		resolve();
+	}
+});

--- a/js/test/behaviors/layout.test.ts
+++ b/js/test/behaviors/layout.test.ts
@@ -1,0 +1,1192 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createLayoutState, LayoutStateInstance } from '../../src/behaviors/layout';
+
+const STORAGE_KEY = 'atlas-layout-preferences';
+
+/* -------------------------------------------------------------------------- */
+/* Test helpers                                                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Every `LayoutStateInstance` created in a test should be passed through
+ * `track()` so `afterEach` can `stop()` it. Forgetting to stop an instance
+ * would leave its MutationObserver watching `document.documentElement` and
+ * leak class-change callbacks into subsequent tests.
+ */
+const liveInstances: LayoutStateInstance[] = [];
+
+function track<T extends LayoutStateInstance | null>(instance: T): T {
+	if (instance) {
+		liveInstances.push(instance);
+	}
+	return instance;
+}
+
+function createFakeStorage(seed: Record<string, string> = {}) {
+	const data: Record<string, string> = { ...seed };
+	const storage = {
+		getItem(key: string): string | null {
+			return Object.prototype.hasOwnProperty.call(data, key) ? data[key] : null;
+		},
+		setItem(key: string, value: string): void {
+			data[key] = String(value);
+		}
+	};
+	return { storage, data };
+}
+
+function createRoot(): HTMLElement {
+	const el = document.createElement('div');
+	document.body.appendChild(el);
+	return el;
+}
+
+/**
+ * Flush microtasks and a macrotask so MutationObserver delivery,
+ * `deferCallbacksUntil.then()` continuations, and any subsequent dispatches
+ * have all run before we assert.
+ */
+async function flush(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await new Promise<void>(resolve => setTimeout(resolve, 0));
+}
+
+interface DocWithViewTransition {
+	startViewTransition?: (cb: () => void) => unknown;
+}
+
+/** Removes any stubbed `document.startViewTransition` so jsdom returns to
+ *  its native (absent) state. Idempotent. */
+function clearViewTransitionStub(): void {
+	delete (document as unknown as DocWithViewTransition).startViewTransition;
+}
+
+/**
+ * Removes every `layout-*` class from `<html>`. We scan by prefix rather than
+ * iterating a hardcoded list so a new class introduced by a test or by
+ * `initLayoutPageDemo` can't survive into the next test.
+ */
+function clearLayoutClassesFromDocumentElement(): void {
+	const layoutClasses = Array.from(document.documentElement.classList).filter(c =>
+		c.startsWith('layout-')
+	);
+	for (const c of layoutClasses) {
+		document.documentElement.classList.remove(c);
+	}
+}
+
+function resetDom(): void {
+	document.body.innerHTML = '';
+	clearLayoutClassesFromDocumentElement();
+	document.documentElement.removeAttribute('data-layout-restored');
+}
+
+function resetStorage(): void {
+	window.localStorage.clear();
+}
+
+/**
+ * Stubs `document.startViewTransition` with a synchronous spy and returns a
+ * handle for assertions plus a `restore()` for tests that want explicit
+ * teardown. The outer `afterEach` clears the stub unconditionally as a
+ * safety net even if a test throws before it gets to its `restore()`.
+ */
+function stubViewTransition(impl?: (cb: () => void) => void) {
+	const doc = document as unknown as DocWithViewTransition;
+	const original = doc.startViewTransition;
+	const spy = vi.fn(impl ?? ((cb: () => void) => cb()));
+	doc.startViewTransition = spy as unknown as (cb: () => void) => unknown;
+	return {
+		spy,
+		restore() {
+			if (original === undefined) {
+				delete doc.startViewTransition;
+			} else {
+				doc.startViewTransition = original;
+			}
+		}
+	};
+}
+
+/* -------------------------------------------------------------------------- */
+/* Lifecycle                                                                  */
+/*                                                                            */
+/* jsdom is shared across tests in this file, so every observable side        */
+/* effect (DOM, storage, view-transition stub, live observers) is reset on    */
+/* both sides of each test. Anything a test forgets to clean up is still      */
+/* guaranteed to be wiped before the next test runs.                          */
+/* -------------------------------------------------------------------------- */
+
+beforeAll(() => {
+	resetDom();
+	resetStorage();
+	clearViewTransitionStub();
+});
+
+beforeEach(() => {
+	resetDom();
+	resetStorage();
+	clearViewTransitionStub();
+});
+
+afterEach(() => {
+	// Disconnect any LayoutStateInstance MutationObservers before the next
+	// test starts mutating the DOM. `stop()` is idempotent.
+	while (liveInstances.length) {
+		try {
+			liveInstances.pop()?.stop();
+		} catch {
+			// Best-effort: never let teardown failures mask the real assertion.
+		}
+	}
+	resetDom();
+	resetStorage();
+	clearViewTransitionStub();
+});
+
+afterAll(() => {
+	resetDom();
+	resetStorage();
+	clearViewTransitionStub();
+});
+
+describe('createLayoutState', () => {
+	describe('getState / getViewState', () => {
+		it('returns {} when storage is empty [ai generated]', () => {
+			const { storage } = createFakeStorage();
+			const state = track(createLayoutState({ storage }));
+			expect(state.getState()).toEqual({});
+			expect(state.getViewState()).toEqual({});
+		});
+
+		it('returns {} when storage value is malformed JSON [ai generated]', () => {
+			const { storage } = createFakeStorage({ [STORAGE_KEY]: 'not-json' });
+			const state = track(createLayoutState({ storage }));
+			expect(state.getState()).toEqual({});
+			expect(state.getViewState()).toEqual({});
+		});
+
+		it('returns parsed full state and the view-scoped slice [ai generated]', () => {
+			const persisted = {
+				viewA: { 'layout-twin': true },
+				viewB: { 'layout-single': false }
+			};
+			const { storage } = createFakeStorage({
+				[STORAGE_KEY]: JSON.stringify(persisted)
+			});
+			const state = track(createLayoutState({ storage, viewName: 'viewA' }));
+			expect(state.getState()).toEqual(persisted);
+			expect(state.getViewState()).toEqual({ 'layout-twin': true });
+		});
+
+		it('returns empty view state when this view name has no stored entry [ai generated]', () => {
+			const { storage } = createFakeStorage({
+				[STORAGE_KEY]: JSON.stringify({ other: { 'layout-twin': true } })
+			});
+			const state = track(createLayoutState({ storage, viewName: 'mine' }));
+			expect(state.getViewState()).toEqual({});
+		});
+
+		it('falls back to "default" view name when none is provided [ai generated]', () => {
+			const { storage } = createFakeStorage({
+				[STORAGE_KEY]: JSON.stringify({ default: { 'layout-twin': true } })
+			});
+			const state = track(createLayoutState({ storage }));
+			expect(state.getViewState()).toEqual({ 'layout-twin': true });
+		});
+	});
+
+	describe('initial restoration', () => {
+		it('adds classes whose stored value is true [ai generated]', () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage({
+				[STORAGE_KEY]: JSON.stringify({ v: { 'layout-twin': true } })
+			});
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			expect(root.classList.contains('layout-twin')).toBe(true);
+		});
+
+		it('removes classes whose stored value is false [ai generated]', () => {
+			const root = createRoot();
+			root.classList.add('layout-holy-grail');
+			const { storage } = createFakeStorage({
+				[STORAGE_KEY]: JSON.stringify({ v: { 'layout-holy-grail': false } })
+			});
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			expect(root.classList.contains('layout-holy-grail')).toBe(false);
+		});
+
+		it('leaves classes that are not in the stored view state untouched [ai generated]', () => {
+			const root = createRoot();
+			root.classList.add('layout-single', 'unrelated');
+			const { storage } = createFakeStorage({
+				[STORAGE_KEY]: JSON.stringify({ v: {} })
+			});
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			expect(root.classList.contains('layout-single')).toBe(true);
+			expect(root.classList.contains('unrelated')).toBe(true);
+		});
+
+		it('wraps restoration in startViewTransition when opted in and supported [ai generated]', () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage({
+				[STORAGE_KEY]: JSON.stringify({ v: { 'layout-twin': true } })
+			});
+			const vt = stubViewTransition();
+			try {
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						viewName: 'v',
+						useViewTransitionOnRestore: true,
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				expect(vt.spy).toHaveBeenCalledTimes(1);
+				expect(root.classList.contains('layout-twin')).toBe(true);
+			} finally {
+				vt.restore();
+			}
+		});
+
+		it('does not call startViewTransition when not opted in [ai generated]', () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const vt = stubViewTransition();
+			try {
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				expect(vt.spy).not.toHaveBeenCalled();
+			} finally {
+				vt.restore();
+			}
+		});
+
+		it('falls back to a plain mutation when startViewTransition is unavailable [ai generated]', () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage({
+				[STORAGE_KEY]: JSON.stringify({ v: { 'layout-twin': true } })
+			});
+			const doc = document as unknown as DocWithViewTransition;
+			const original = doc.startViewTransition;
+			delete doc.startViewTransition;
+			try {
+				expect(() =>
+					track(
+						createLayoutState({
+							root,
+							storage,
+							viewName: 'v',
+							useViewTransitionOnRestore: true,
+							deferCallbacksUntil: Promise.resolve()
+						})
+					)
+				).not.toThrow();
+				expect(root.classList.contains('layout-twin')).toBe(true);
+			} finally {
+				if (original) {
+					doc.startViewTransition = original;
+				}
+			}
+		});
+
+		it('defaults the root to document.documentElement [ai generated]', () => {
+			const { storage } = createFakeStorage({
+				[STORAGE_KEY]: JSON.stringify({ default: { 'layout-test-marker': true } })
+			});
+			const state = track(createLayoutState({ storage, deferCallbacksUntil: Promise.resolve() }));
+			expect(document.documentElement.classList.contains('layout-test-marker')).toBe(true);
+		});
+	});
+
+	describe('mutation observation', () => {
+		it('persists added layout-* classes as true [ai generated]', async () => {
+			const root = createRoot();
+			const { storage, data } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			root.classList.add('layout-twin');
+			await flush();
+			expect(state.getViewState()).toEqual({ 'layout-twin': true });
+			expect(JSON.parse(data[STORAGE_KEY])).toEqual({ v: { 'layout-twin': true } });
+		});
+
+		it('persists removed layout-* classes as false [ai generated]', async () => {
+			const root = createRoot();
+			root.classList.add('layout-twin');
+			const { storage } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			root.classList.remove('layout-twin');
+			await flush();
+			expect(state.getViewState()).toEqual({ 'layout-twin': false });
+		});
+
+		it('ignores classes that do not start with the layout- prefix [ai generated]', async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			root.classList.add('not-a-layout-class');
+			root.classList.add('theme-dark');
+			await flush();
+			expect(state.getViewState()).toEqual({});
+		});
+
+		it('persists multiple layout-* classes from a single attribute change [ai generated]', async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			root.className = 'layout-twin layout-menu-collapsed unrelated';
+			await flush();
+			expect(state.getViewState()).toEqual({
+				'layout-twin': true,
+				'layout-menu-collapsed': true
+			});
+		});
+
+		it('preserves persisted state across multiple sequential mutations [ai generated]', async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			root.classList.add('layout-twin');
+			await flush();
+			root.classList.add('layout-menu-collapsed');
+			await flush();
+			root.classList.remove('layout-twin');
+			await flush();
+			expect(state.getViewState()).toEqual({
+				'layout-twin': false,
+				'layout-menu-collapsed': true
+			});
+		});
+
+		it('keeps other views in storage intact when persisting this view [ai generated]', async () => {
+			const root = createRoot();
+			const { storage, data } = createFakeStorage({
+				[STORAGE_KEY]: JSON.stringify({ other: { 'layout-single': true } })
+			});
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'mine',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			root.classList.add('layout-twin');
+			await flush();
+			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
+				other: { 'layout-single': true },
+				mine: { 'layout-twin': true }
+			});
+		});
+	});
+
+	describe('subscriptions', () => {
+		it("fires 'added' callbacks only when the class is added [ai generated]", async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			const cb = vi.fn();
+			state.subscribe('layout-twin', 'added', cb);
+			root.classList.add('layout-twin');
+			await flush();
+			root.classList.remove('layout-twin');
+			await flush();
+			expect(cb).toHaveBeenCalledTimes(1);
+			expect(cb).toHaveBeenCalledWith({
+				className: 'layout-twin',
+				isApplied: true,
+				viewName: 'v'
+			});
+		});
+
+		it("fires 'removed' callbacks only when the class is removed [ai generated]", async () => {
+			const root = createRoot();
+			root.classList.add('layout-twin');
+			const { storage } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			const cb = vi.fn();
+			state.subscribe('layout-twin', 'removed', cb);
+			root.classList.remove('layout-twin');
+			await flush();
+			root.classList.add('layout-twin');
+			await flush();
+			expect(cb).toHaveBeenCalledTimes(1);
+			expect(cb).toHaveBeenCalledWith({
+				className: 'layout-twin',
+				isApplied: false,
+				viewName: 'v'
+			});
+		});
+
+		it("fires 'always' callbacks on both add and remove [ai generated]", async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			const cb = vi.fn();
+			state.subscribe('layout-twin', 'always', cb);
+			await flush();
+			// Subscribing 'always' triggers an immediate replay with the current
+			// (absent) state. Clear that so we only count mutations.
+			cb.mockClear();
+			root.classList.add('layout-twin');
+			await flush();
+			root.classList.remove('layout-twin');
+			await flush();
+			expect(cb).toHaveBeenCalledTimes(2);
+		});
+
+		it('replays current state when subscribing after the class is already applied [ai generated]', async () => {
+			const root = createRoot();
+			root.classList.add('layout-twin');
+			const { storage } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			await flush();
+			const cb = vi.fn();
+			state.subscribe('layout-twin', 'added', cb);
+			await flush();
+			expect(cb).toHaveBeenCalledTimes(1);
+			expect(cb).toHaveBeenCalledWith({
+				className: 'layout-twin',
+				isApplied: true,
+				viewName: 'v'
+			});
+		});
+
+		it("does not replay an 'added' subscription when the class is absent [ai generated]", async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			await flush();
+			const cb = vi.fn();
+			state.subscribe('layout-twin', 'added', cb);
+			await flush();
+			expect(cb).not.toHaveBeenCalled();
+		});
+
+		it('queues immediate replay until deferCallbacksUntil resolves on the next microtask [ai generated]', async () => {
+			const root = createRoot();
+			root.classList.add('layout-twin');
+			const { storage } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			const cb = vi.fn();
+			state.subscribe('layout-twin', 'always', cb);
+			expect(cb).not.toHaveBeenCalled();
+			await flush();
+			expect(cb).toHaveBeenCalledWith({
+				className: 'layout-twin',
+				isApplied: true,
+				viewName: 'v'
+			});
+		});
+
+		it('unsubscribe prevents future invocations [ai generated]', async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			const cb = vi.fn();
+			const unsubscribe = state.subscribe('layout-twin', 'added', cb);
+			await flush();
+			expect(cb).not.toHaveBeenCalled();
+			root.classList.add('layout-twin');
+			await flush();
+			expect(cb).toHaveBeenCalledTimes(1);
+			unsubscribe();
+			root.classList.remove('layout-twin');
+			await flush();
+			root.classList.add('layout-twin');
+			await flush();
+			expect(cb).toHaveBeenCalledTimes(1);
+		});
+
+		it('defers callback execution until deferCallbacksUntil resolves [ai generated]', async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			let resolveDefer: () => void = () => undefined;
+			const deferPromise = new Promise<void>(resolve => {
+				resolveDefer = resolve;
+			});
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: deferPromise
+				})
+			);
+			const cb = vi.fn();
+			state.subscribe('layout-twin', 'always', cb);
+			root.classList.add('layout-twin');
+			await flush();
+			expect(cb).not.toHaveBeenCalled();
+			resolveDefer();
+			await flush();
+			expect(cb).toHaveBeenCalled();
+		});
+
+		it('wraps subscription callbacks in a view transition when opted in [ai generated]', async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const vt = stubViewTransition();
+			try {
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						viewName: 'v',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				const cb = vi.fn();
+				state.subscribe('layout-twin', 'always', cb, { useViewTransition: true });
+				root.classList.add('layout-twin');
+				await flush();
+				expect(vt.spy).toHaveBeenCalled();
+				expect(cb).toHaveBeenCalled();
+			} finally {
+				vt.restore();
+			}
+		});
+
+		it('does not wrap subscription callbacks in a view transition by default [ai generated]', async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const vt = stubViewTransition();
+			try {
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						viewName: 'v',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				const cb = vi.fn();
+				state.subscribe('layout-twin', 'always', cb);
+				root.classList.add('layout-twin');
+				await flush();
+				expect(vt.spy).not.toHaveBeenCalled();
+				expect(cb).toHaveBeenCalled();
+			} finally {
+				vt.restore();
+			}
+		});
+
+		it('fires multiple subscriptions for the same class independently [ai generated]', async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			const cbA = vi.fn();
+			const cbB = vi.fn();
+			state.subscribe('layout-twin', 'always', cbA);
+			state.subscribe('layout-twin', 'added', cbB);
+			await flush();
+			cbA.mockClear();
+			cbB.mockClear();
+			root.classList.add('layout-twin');
+			await flush();
+			expect(cbA).toHaveBeenCalledTimes(1);
+			expect(cbB).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('view transition coordination', () => {
+		it('coalesces same-microtask subscription callbacks into a single transition [ai generated]', async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const vt = stubViewTransition();
+			try {
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						viewName: 'v',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				const cbA = vi.fn();
+				const cbB = vi.fn();
+				const cbC = vi.fn();
+				state.subscribe('layout-twin', 'always', cbA, { useViewTransition: true });
+				state.subscribe('layout-twin', 'added', cbB, { useViewTransition: true });
+				state.subscribe('layout-twin', 'always', cbC, { useViewTransition: true });
+				await flush();
+				vt.spy.mockClear();
+				cbA.mockClear();
+				cbB.mockClear();
+				cbC.mockClear();
+				root.classList.add('layout-twin');
+				await flush();
+				expect(vt.spy).toHaveBeenCalledTimes(1);
+				expect(cbA).toHaveBeenCalledTimes(1);
+				expect(cbB).toHaveBeenCalledTimes(1);
+				expect(cbC).toHaveBeenCalledTimes(1);
+			} finally {
+				vt.restore();
+			}
+		});
+
+		it('skips wrap when a transition is already animating [ai generated]', async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage({
+				[STORAGE_KEY]: JSON.stringify({ v: { 'layout-twin': true } })
+			});
+			const doc = document as unknown as DocWithViewTransition;
+			const original = doc.startViewTransition;
+			let resolveFinished: () => void = () => undefined;
+			const finishedPromise = new Promise<void>(resolve => {
+				resolveFinished = resolve;
+			});
+			const spy = vi.fn((cb: () => void) => {
+				cb();
+				return { finished: finishedPromise };
+			});
+			doc.startViewTransition = spy as unknown as (cb: () => void) => unknown;
+			try {
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						viewName: 'v',
+						useViewTransitionOnRestore: true,
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				expect(spy).toHaveBeenCalledTimes(1);
+				const cb = vi.fn();
+				state.subscribe('layout-twin', 'always', cb, { useViewTransition: true });
+				await flush();
+				// Replay fired while restoration's .finished is still pending —
+				// must not start a second transition (would abort the first).
+				expect(spy).toHaveBeenCalledTimes(1);
+				expect(cb).toHaveBeenCalled();
+				resolveFinished();
+				await finishedPromise;
+				await flush();
+				cb.mockClear();
+				root.classList.remove('layout-twin');
+				await flush();
+				expect(spy).toHaveBeenCalledTimes(2);
+				expect(cb).toHaveBeenCalledTimes(1);
+			} finally {
+				if (original === undefined) {
+					delete doc.startViewTransition;
+				} else {
+					doc.startViewTransition = original;
+				}
+			}
+		});
+
+		it('starts a fresh transition after the previous one settles [ai generated]', async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const vt = stubViewTransition();
+			try {
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						viewName: 'v',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				const cb = vi.fn();
+				state.subscribe('layout-twin', 'always', cb, { useViewTransition: true });
+				await flush();
+				vt.spy.mockClear();
+				cb.mockClear();
+				root.classList.add('layout-twin');
+				await flush();
+				expect(vt.spy).toHaveBeenCalledTimes(1);
+				root.classList.remove('layout-twin');
+				await flush();
+				expect(vt.spy).toHaveBeenCalledTimes(2);
+				expect(cb).toHaveBeenCalledTimes(2);
+			} finally {
+				vt.restore();
+			}
+		});
+
+		it('continues firing remaining batched callbacks when one throws [ai generated]', async () => {
+			const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const vt = stubViewTransition();
+			try {
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						viewName: 'v',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				const cbA = vi.fn(() => {
+					throw new Error('boom');
+				});
+				const cbB = vi.fn();
+				state.subscribe('layout-twin', 'always', cbA, { useViewTransition: true });
+				state.subscribe('layout-twin', 'always', cbB, { useViewTransition: true });
+				await flush();
+				vt.spy.mockClear();
+				cbA.mockClear();
+				cbB.mockClear();
+				errSpy.mockClear();
+				root.classList.add('layout-twin');
+				await flush();
+				expect(vt.spy).toHaveBeenCalledTimes(1);
+				expect(cbA).toHaveBeenCalledTimes(1);
+				expect(cbB).toHaveBeenCalledTimes(1);
+				expect(errSpy).toHaveBeenCalled();
+			} finally {
+				vt.restore();
+				errSpy.mockRestore();
+			}
+		});
+	});
+
+	describe('stop()', () => {
+		it('stops processing further mutations [ai generated]', async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			const cb = vi.fn();
+			// 'added' avoids the immediate replay (class is absent).
+			state.subscribe('layout-twin', 'added', cb);
+			await flush();
+			state.stop();
+			root.classList.add('layout-twin');
+			await flush();
+			expect(cb).not.toHaveBeenCalled();
+			expect(state.getViewState()).toEqual({});
+		});
+
+		it('is safe to call multiple times [ai generated]', () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			expect(() => {
+				state.stop();
+				state.stop();
+			}).not.toThrow();
+		});
+	});
+
+	describe('data-layout-restored sentinel', () => {
+		it('is absent on the root before deferCallbacksUntil resolves [ai generated]', () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			let resolveDefer: () => void = () => undefined;
+			const deferPromise = new Promise<void>(resolve => {
+				resolveDefer = resolve;
+			});
+			track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: deferPromise
+				})
+			);
+			expect(root.hasAttribute('data-layout-restored')).toBe(false);
+			// Settle the promise so the outer teardown can run cleanly.
+			resolveDefer();
+		});
+
+		it('is set to "true" on the root after deferCallbacksUntil resolves [ai generated]', async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			await flush();
+			expect(root.getAttribute('data-layout-restored')).toBe('true');
+		});
+
+		it('is not persisted to storage [ai generated]', async () => {
+			const root = createRoot();
+			const { storage, data } = createFakeStorage();
+			track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			await flush();
+			// Attribute change is not a class change, so storage is untouched.
+			expect(data[STORAGE_KEY]).toBeUndefined();
+		});
+
+		it('does not appear as a layout-* class on the root [ai generated]', async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			await flush();
+			const layoutClasses = Array.from(root.classList).filter(c => c.startsWith('layout-'));
+			expect(layoutClasses).toEqual([]);
+		});
+
+		it('fires queued subscriber callbacks before setting the attribute [ai generated]', async () => {
+			const root = createRoot();
+			root.classList.add('layout-twin');
+			const { storage } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'v',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			let attributeWhenCbRan: string | null = 'sentinel-not-checked';
+			state.subscribe('layout-twin', 'always', () => {
+				attributeWhenCbRan = root.getAttribute('data-layout-restored');
+			});
+			await flush();
+			expect(attributeWhenCbRan).toBeNull();
+			expect(root.getAttribute('data-layout-restored')).toBe('true');
+		});
+	});
+
+	describe('failure fallback', () => {
+		it('sets the sentinel and re-throws when synchronous setup fails [ai generated]', () => {
+			const root = createRoot();
+			const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+			const throwingStorage = {
+				getItem(): string | null {
+					throw new Error('storage exploded');
+				},
+				setItem(): void {
+					/* no-op */
+				}
+			};
+			try {
+				expect(() =>
+					createLayoutState({
+						root,
+						storage: throwingStorage,
+						viewName: 'v',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				).toThrow('storage exploded');
+				expect(root.getAttribute('data-layout-restored')).toBe('true');
+				expect(errorSpy).toHaveBeenCalled();
+			} finally {
+				errorSpy.mockRestore();
+			}
+		});
+
+		it('sets the sentinel and keeps draining when a queued subscriber throws [ai generated]', async () => {
+			const root = createRoot();
+			root.classList.add('layout-twin');
+			const { storage } = createFakeStorage();
+			const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+			try {
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						viewName: 'v',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				const goodCb = vi.fn();
+				state.subscribe('layout-twin', 'always', () => {
+					throw new Error('subscriber exploded');
+				});
+				state.subscribe('layout-twin', 'always', goodCb);
+				await flush();
+				expect(goodCb).toHaveBeenCalledTimes(1);
+				expect(root.getAttribute('data-layout-restored')).toBe('true');
+				expect(errorSpy).toHaveBeenCalled();
+			} finally {
+				errorSpy.mockRestore();
+			}
+		});
+
+		it('sets the sentinel and flushes callbacks when deferCallbacksUntil rejects [ai generated]', async () => {
+			const root = createRoot();
+			root.classList.add('layout-twin');
+			const { storage } = createFakeStorage();
+			const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+			try {
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						viewName: 'v',
+						deferCallbacksUntil: Promise.reject(new Error('defer rejected'))
+					})
+				);
+				const cb = vi.fn();
+				state.subscribe('layout-twin', 'always', cb);
+				await flush();
+				expect(cb).toHaveBeenCalledTimes(1);
+				expect(root.getAttribute('data-layout-restored')).toBe('true');
+				expect(errorSpy).toHaveBeenCalled();
+			} finally {
+				errorSpy.mockRestore();
+			}
+		});
+	});
+
+	describe('viewName accessor', () => {
+		it('accepts a function that returns the view name [ai generated]', () => {
+			const { storage } = createFakeStorage({
+				[STORAGE_KEY]: JSON.stringify({
+					alpha: { 'layout-twin': true },
+					beta: { 'layout-single': true }
+				})
+			});
+			const state = track(createLayoutState({ storage, viewName: () => 'alpha' }));
+			expect(state.getViewState()).toEqual({ 'layout-twin': true });
+		});
+
+		it('calls the function each time the view name is needed [ai generated]', async () => {
+			const root = createRoot();
+			const { storage, data } = createFakeStorage();
+			let currentView = 'alpha';
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: () => currentView,
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+
+			root.classList.add('layout-twin');
+			await flush();
+			expect(state.getViewState()).toEqual({ 'layout-twin': true });
+
+			currentView = 'beta';
+			root.classList.add('layout-single');
+			await flush();
+
+			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
+				alpha: { 'layout-twin': true },
+				beta: { 'layout-single': true }
+			});
+			expect(state.getViewState()).toEqual({ 'layout-single': true });
+		});
+
+		it('passes the resolved viewName at fire time to subscriber events [ai generated]', async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			let currentView = 'alpha';
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: () => currentView,
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			const cb = vi.fn();
+			state.subscribe('layout-twin', 'added', cb);
+
+			root.classList.add('layout-twin');
+			await flush();
+			expect(cb).toHaveBeenLastCalledWith({
+				className: 'layout-twin',
+				isApplied: true,
+				viewName: 'alpha'
+			});
+
+			currentView = 'beta';
+			root.classList.remove('layout-twin');
+			state.subscribe('layout-twin', 'removed', cb);
+			root.classList.add('layout-twin');
+			root.classList.remove('layout-twin');
+			await flush();
+			expect(cb).toHaveBeenLastCalledWith({
+				className: 'layout-twin',
+				isApplied: false,
+				viewName: 'beta'
+			});
+		});
+
+		it('coerces unsafe keys returned by the function to "default" [ai generated]', async () => {
+			const root = createRoot();
+			const { storage, data } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: () => '__proto__',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			root.classList.add('layout-twin');
+			await flush();
+			expect(state.getViewState()).toEqual({ 'layout-twin': true });
+			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
+				default: { 'layout-twin': true }
+			});
+		});
+
+		it('still coerces unsafe static viewName strings to "default" [ai generated]', async () => {
+			const root = createRoot();
+			const { storage, data } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'prototype',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			root.classList.add('layout-twin');
+			await flush();
+			expect(state.getViewState()).toEqual({ 'layout-twin': true });
+			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
+				default: { 'layout-twin': true }
+			});
+		});
+	});
+});

--- a/js/tsconfig.eslint.json
+++ b/js/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"rootDir": ".",
+		"noEmit": true
+	},
+	"include": ["src", "test"]
+}

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		/*NOTE: This file is used only for linting. */
+		/* NOTE: This file is used for both linting and building. */
 		/* Basic Options */
 		"target": "esnext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
 		"module": "esnext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
@@ -13,7 +13,7 @@
 		// "sourceMap": true,                     /* Generates corresponding '.map' file. */
 		// "outFile": "./",                       /* Concatenate and emit output to single file. */
 		// "outDir": "./",                        /* Redirect output structure to the directory. */
-		// "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+		"rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
 		// "removeComments": true,                /* Do not emit comments to output. */
 		// "noEmit": true,                        /* Do not emit outputs. */
 		// "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
@@ -36,7 +36,7 @@
 		"noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
 
 		/* Module Resolution Options */
-		"moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+		"moduleResolution": "bundler" /* Specify module resolution strategy: 'bundler' for libraries consumed via bundlers. */
 		// "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
 		// "paths": {
 		// 	"@microsoft/atlas-js/*": ["../node_modules/@microsoft/atlas-js/*"]
@@ -57,5 +57,6 @@
 		/* Experimental Options */
 		// "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
 		// "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-	}
+	},
+	"include": ["src"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
 				"packages": [
 					"css",
 					"plugins/parcel-transformer-markdown-html",
+					"plugins/parcel-optimizer-inline-script-restore",
 					"plugins/stylelint-config-atlas",
 					"site",
 					"js",
@@ -883,7 +884,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
 			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -931,7 +931,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
 			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -1645,6 +1644,7 @@
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
 			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^5.1.2",
@@ -1662,6 +1662,7 @@
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
 			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -1674,6 +1675,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
 			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^6.2.2"
@@ -1819,6 +1821,13 @@
 				"fs-extra": "^8.1.0"
 			}
 		},
+		"node_modules/@manypkg/find-root/node_modules/@types/node": {
+			"version": "12.20.55",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+			"integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@manypkg/find-root/node_modules/fs-extra": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -1925,6 +1934,10 @@
 		},
 		"node_modules/@microsoft/atlas-site": {
 			"resolved": "site",
+			"link": true
+		},
+		"node_modules/@microsoft/parcel-optimizer-inline-script-restore": {
+			"resolved": "plugins/parcel-optimizer-inline-script-restore",
 			"link": true
 		},
 		"node_modules/@microsoft/parcel-transformer-markdown-html": {
@@ -12860,6 +12873,7 @@
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
 			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"engines": {
@@ -13528,9 +13542,19 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "12.20.55",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-			"integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+			"version": "25.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": ">=7.24.0 <7.24.7"
+			}
+		},
+		"node_modules/@types/node/node_modules/undici-types": {
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -14599,6 +14623,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/base-x": {
@@ -14719,6 +14744,7 @@
 			"version": "1.1.14",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
 			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -15084,6 +15110,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
 			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/cli-cursor": {
@@ -15261,6 +15288,7 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/convert-source-map": {
@@ -15327,6 +15355,7 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -15803,6 +15832,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/ecdsa-sig-formatter": {
@@ -15825,6 +15855,7 @@
 			"version": "9.2.2",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/encoding-sniffer": {
@@ -16882,6 +16913,7 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
 			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"cross-spawn": "^7.0.6",
@@ -16898,6 +16930,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
@@ -17185,6 +17218,7 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
 			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
 			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"foreground-child": "^3.1.0",
@@ -17218,6 +17252,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
 			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
@@ -17227,6 +17262,7 @@
 			"version": "9.0.9",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
 			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.2"
@@ -17351,6 +17387,7 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/graphemer": {
@@ -17486,6 +17523,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
 			"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -18418,6 +18456,7 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
 			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/cliui": "^8.0.2"
@@ -19188,6 +19227,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^4.0.0"
@@ -19428,6 +19468,7 @@
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
 			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
@@ -19450,6 +19491,7 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
 			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -19709,6 +19751,7 @@
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/nanoid": {
@@ -22108,6 +22151,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
 			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -22127,6 +22171,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
 			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true,
 			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/package-manager-detector": {
@@ -22603,6 +22648,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -22619,6 +22665,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
 			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"lru-cache": "^10.2.0",
@@ -22635,6 +22682,7 @@
 			"version": "10.4.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
 			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/path-type": {
@@ -23460,6 +23508,7 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
 			"integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"mute-stream": "~0.0.4"
@@ -24153,6 +24202,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -24165,6 +24215,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -24372,12 +24423,14 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
 			"integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+			"dev": true,
 			"license": "CC-BY-3.0"
 		},
 		"node_modules/spdx-expression-parse": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
 			"integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"spdx-exceptions": "^2.1.0",
@@ -24388,6 +24441,7 @@
 			"version": "3.0.23",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
 			"integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+			"dev": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/sprintf-js": {
@@ -24458,6 +24512,7 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
 			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"eastasianwidth": "^0.2.0",
@@ -24476,6 +24531,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -24490,12 +24546,14 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/string-width/node_modules/ansi-regex": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
 			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -24508,6 +24566,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
 			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^6.2.2"
@@ -24595,6 +24654,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -25217,6 +25277,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/through": {
@@ -25311,9 +25372,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tmp": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+			"integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -25556,7 +25617,7 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
@@ -26003,6 +26064,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -26212,6 +26274,7 @@
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
 			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^6.1.0",
@@ -26230,6 +26293,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -26247,12 +26311,14 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -26267,6 +26333,7 @@
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
 			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -26279,6 +26346,7 @@
 			"version": "6.2.3",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
 			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -26291,6 +26359,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
 			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^6.2.2"
@@ -26405,6 +26474,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
@@ -26516,6 +26586,132 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"plugins/parcel-optimizer-inline-script-restore": {
+			"name": "@microsoft/parcel-optimizer-inline-script-restore",
+			"version": "1.0.0",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/plugin": "2.16.0",
+				"@parcel/utils": "2.16.0",
+				"parcel": "2.16.3"
+			},
+			"engines": {
+				"node": "24.15.0",
+				"npm": "11.12.1",
+				"parcel": "2.16.3"
+			}
+		},
+		"plugins/parcel-optimizer-inline-script-restore/node_modules/@parcel/diagnostic": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.16.0.tgz",
+			"integrity": "sha512-z5MeMwFegaA23wseltLykVV9OxsKkY3BiEje/Dt7ttVivwNWFKHDuXB8vbZTDArUooixUH3s/RJhTFI46VJc2A==",
+			"license": "MIT",
+			"dependencies": {
+				"@mischnic/json-sourcemap": "^0.1.1",
+				"nullthrows": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-optimizer-inline-script-restore/node_modules/@parcel/feature-flags": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.16.0.tgz",
+			"integrity": "sha512-GiRpLx0x8dZdWCpftk6OE0lp0Cc8oUyBssPiobigpSA8vgxrCz/zLbs83R/K70p+wPBb+ye4eEiR67+KCwcSXg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-optimizer-inline-script-restore/node_modules/@parcel/plugin": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.0.tgz",
+			"integrity": "sha512-Rdk5e/VGmMp6s2DmC0AbjWYmea3Vv8Tx1SC5ln+lf+qRlhndrbFV9o5QKirTY9C8GWd20qH1ZqOxPDEzK/YSGA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/types": "2.16.0"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-optimizer-inline-script-restore/node_modules/@parcel/profiler": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.16.0.tgz",
+			"integrity": "sha512-xm6fVTA1V/Co7JuJfkNtZJsKsvq0RSpoE7JjiNtKLCMh+Lim6w7dxc6CEBqGImhR/9YbwteY6/gVFwkvCdLvLg==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.0",
+				"@parcel/events": "2.16.0",
+				"@parcel/types-internal": "2.16.0",
+				"chrome-trace-event": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"plugins/parcel-optimizer-inline-script-restore/node_modules/@parcel/types": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.0.tgz",
+			"integrity": "sha512-EKsMTqqfiutQIiYKHEJHHeugIymPqM+D+CphhyewAIjxVLk6PTjEQW0ytIbbdOXGAgnK60OFiIKqZAxZ5Hf2dw==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/types-internal": "2.16.0",
+				"@parcel/workers": "2.16.0"
+			}
+		},
+		"plugins/parcel-optimizer-inline-script-restore/node_modules/@parcel/types-internal": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.0.tgz",
+			"integrity": "sha512-tibAjOY8iyMDzFp5B9jEZPfHYlNvXpw7/msUVebAE6gZ7A8ymWXG8YzMvin6gvWIVTCsYoOkkRsZARvpRcSspQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.0",
+				"@parcel/feature-flags": "2.16.0",
+				"@parcel/source-map": "^2.1.1",
+				"utility-types": "^3.11.0"
+			}
+		},
+		"plugins/parcel-optimizer-inline-script-restore/node_modules/@parcel/workers": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.0.tgz",
+			"integrity": "sha512-JVdAtTWRONbP4X8Me1qRE5sMGIkSKAcUb8fZdjCUPJxsBwcJwzYicYFuahxVVGj2sYzjLi0TzlvmXMK7tVvffA==",
+			"license": "MIT",
+			"dependencies": {
+				"@parcel/diagnostic": "2.16.0",
+				"@parcel/logger": "2.16.0",
+				"@parcel/profiler": "2.16.0",
+				"@parcel/types-internal": "2.16.0",
+				"@parcel/utils": "2.16.0",
+				"nullthrows": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"peerDependencies": {
+				"@parcel/core": "^2.16.0"
 			}
 		},
 		"plugins/parcel-transformer-markdown-html": {
@@ -26674,6 +26870,7 @@
 			"devDependencies": {
 				"@microsoft/atlas-css": "6.7.0",
 				"@microsoft/atlas-js": "^1.15.0",
+				"@microsoft/parcel-optimizer-inline-script-restore": "1.0.0",
 				"@microsoft/parcel-transformer-markdown-html": "2.7.3",
 				"@parcel/transformer-sass": "2.16.3",
 				"@typescript-eslint/eslint-plugin": "^5.60.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22575,7 +22575,6 @@
 			"version": "7.3.0",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
 			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"entities": "^6.0.0"
@@ -22615,7 +22614,6 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
 			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.12"
@@ -26726,7 +26724,8 @@
 				"highlight.js": "11.11.1",
 				"marked": "^5.1.0",
 				"mustache": "4.2.0",
-				"parcel": "2.16.3"
+				"parcel": "2.16.3",
+				"parse5": "7.3.0"
 			},
 			"engines": {
 				"node": "24.15.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 		"packages": [
 			"css",
 			"plugins/parcel-transformer-markdown-html",
+			"plugins/parcel-optimizer-inline-script-restore",
 			"plugins/stylelint-config-atlas",
 			"site",
 			"js",

--- a/plugins/parcel-optimizer-inline-script-restore/README.md
+++ b/plugins/parcel-optimizer-inline-script-restore/README.md
@@ -1,0 +1,45 @@
+# parcel-optimizer-inline-script-restore
+
+A Parcel optimizer that restores inline `<script>` tags previously hidden by [`@microsoft/parcel-transformer-markdown-html`](../parcel-transformer-markdown-html). It only exists to work around a Parcel cold-cache bug; nothing in the design system depends on it at runtime.
+
+## Why this exists
+
+When `@parcel/transformer-html` encounters an inline `<script>` (one without a `src` attribute) it extracts the body as a child JS asset and registers `@parcel/transformer-js`, `-babel`, and `-react-refresh-wrap` as new dev dependencies. On a cold (no `.parcel-cache`) build this newly-registered transformer chain races with Parcel's worker dev-dep machinery and fails with:
+
+```
+Error: Worker send back a reference to a missing dev dep request.
+This might happen due to internal in-memory build caches not being
+cleared between builds or due a race condition. This is a bug in Parcel.
+```
+
+The race only fires on the first build of a worker; subsequent builds succeed because the dev-dep entry is now warm in cache.
+
+## How the workaround works
+
+The fix is split across two plugins:
+
+1. **`@microsoft/parcel-transformer-markdown-html`** rewrites every inline `<script>` in the markdown → html pass into an HTML comment of the form `<!--ATLAS_INLINE_SCRIPT_V1::<attrs_b64>::<body_b64>-->`. `@parcel/transformer-html` sees a comment, not a script, and never registers the dev-dep chain.
+2. **`@microsoft/parcel-optimizer-inline-script-restore`** (this package) decodes those markers back into the original `<script>` tags after all transformers run but before `@parcel/optimizer-html` minifies the document — so htmlnano sees real inline JS and minifies it in place.
+
+A separate plugin is required because Parcel dedupes transformers by name per asset (`asset.transformers.has(transformerName)` in `@parcel/core/lib/Transformation.js`), so re-registering the markdown transformer for the `*.html` pipeline silently becomes a no-op. Optimizers run on the final bundle and have no such dedup.
+
+## Configuration
+
+Register first in the `*.html` optimizers list in `.parcelrc`:
+
+```json
+{
+	"optimizers": {
+		"*.html": [
+			"@microsoft/parcel-optimizer-inline-script-restore",
+			"..."
+		]
+	}
+}
+```
+
+Order matters — restoring must happen before `@parcel/optimizer-html` runs, otherwise the comments may be stripped or the inline JS won't be minified.
+
+## When this can be removed
+
+This package can be deleted once the upstream Parcel race condition is fixed (see [parcel-bundler/parcel](https://github.com/parcel-bundler/parcel)). At that point, drop the marker rewriting from `@microsoft/parcel-transformer-markdown-html` and remove the `optimizers` entry from `site/.parcelrc`.

--- a/plugins/parcel-optimizer-inline-script-restore/lib/index.js
+++ b/plugins/parcel-optimizer-inline-script-restore/lib/index.js
@@ -1,0 +1,42 @@
+// @ts-nocheck
+const { Optimizer } = require('@parcel/plugin');
+const { blobToString } = require('@parcel/utils');
+
+// Restores inline `<script>` tags that
+// `@microsoft/parcel-transformer-markdown-html` hid as HTML comments to dodge
+// a Parcel cold-cache race condition.
+//
+// See `plugins/parcel-transformer-markdown-html/lib/index.js` for the
+// background on why scripts are hidden in the first place and the marker
+// format. This optimizer is a separate plugin (rather than a second pass
+// of the markdown transformer) because Parcel dedupes transformers by name
+// per asset — running the same transformer on both the `*.md` and `*.html`
+// pipelines is a no-op. Optimizers run on the final bundle output and have
+// no such dedup.
+//
+// We register this optimizer FIRST in the `*.html` pipeline so the markers
+// are restored before `@parcel/optimizer-html` minifies the document — that
+// way htmlnano sees real `<script>` content and minifies the JS in place.
+const ATLAS_INLINE_SCRIPT_MARKER = 'ATLAS_INLINE_SCRIPT_V1';
+const INLINE_SCRIPT_MARKER_REGEX = new RegExp(
+	`<!--${ATLAS_INLINE_SCRIPT_MARKER}::([A-Za-z0-9+/=]*)::([A-Za-z0-9+/=]*)-->`,
+	'g'
+);
+
+function restoreInlineScripts(html) {
+	return html.replace(INLINE_SCRIPT_MARKER_REGEX, (_, attrsB64, contentB64) => {
+		const attrs = Buffer.from(attrsB64, 'base64').toString('utf8');
+		const content = Buffer.from(contentB64, 'base64').toString('utf8');
+		return `<script${attrs}>${content}</script>`;
+	});
+}
+
+module.exports = new Optimizer({
+	async optimize({ contents, map }) {
+		const code = await blobToString(contents);
+		if (!code.includes(ATLAS_INLINE_SCRIPT_MARKER)) {
+			return { contents, map };
+		}
+		return { contents: restoreInlineScripts(code), map };
+	}
+});

--- a/plugins/parcel-optimizer-inline-script-restore/package.json
+++ b/plugins/parcel-optimizer-inline-script-restore/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@microsoft/parcel-optimizer-inline-script-restore",
+	"version": "1.0.0",
+	"license": "MIT",
+	"private": true,
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/atlas-design"
+	},
+	"main": "lib/index.js",
+	"engines": {
+		"node": "24.15.0",
+		"npm": "11.12.1",
+		"parcel": "2.16.3"
+	},
+	"dependencies": {
+		"parcel": "2.16.3",
+		"@parcel/plugin": "2.16.0",
+		"@parcel/utils": "2.16.0"
+	}
+}

--- a/plugins/parcel-transformer-markdown-html/lib/index.js
+++ b/plugins/parcel-transformer-markdown-html/lib/index.js
@@ -9,6 +9,50 @@ const allTokens = require('@microsoft/atlas-css/dist/tokens.json');
 const { renderBreadcrumbsMarkup } = require('./breadcrumbs');
 const { buildGithubLink } = require('./github-link');
 
+// Inline-script hide helper.
+//
+// Background: when @parcel/transformer-html sees a `<script>` tag without a
+// `src` attribute it extracts the body as a separate inline-JS child asset
+// and pulls in @parcel/transformer-js, @parcel/transformer-babel, and
+// @parcel/transformer-react-refresh-wrap as dev dependencies. On a cold
+// (no `.parcel-cache`) build this newly-registered transformer dev-dep
+// chain hits a Parcel race condition that surfaces as:
+//
+//   Error: Worker send back a reference to a missing dev dep request.
+//   This might happen due to internal in-memory build caches not being
+//   cleared between builds or due a race condition. This is a bug in Parcel.
+//
+// Workaround: in the markdown → html pass we hide every inline `<script>`
+// inside an HTML comment containing the original attributes and body in
+// base64. The HTML transformer can't see the tag, so it doesn't extract it
+// and the buggy dev-dep chain never gets registered.
+//
+// The companion plugin `@microsoft/parcel-optimizer-inline-script-restore`
+// restores the original `<script>` tags as a Parcel optimizer, which runs
+// on the final bundle after every transformer. A separate plugin is
+// required because Parcel dedupes transformers by name per asset, so
+// re-registering this same transformer for the `*.html` pipeline does not
+// trigger a second invocation (see Transformation.js `runTransformer`).
+//
+// The marker uses only base64 characters between the `::` separators, so
+// `<!--…-->` can never be ambiguous (base64 has no `-`) and HTML comment
+// rules (no `--` inside) are respected.
+const ATLAS_INLINE_SCRIPT_MARKER = 'ATLAS_INLINE_SCRIPT_V1';
+const SCRIPT_TAG_REGEX = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+
+function hideInlineScripts(html) {
+	return html.replace(SCRIPT_TAG_REGEX, (match, rawAttrs, content) => {
+		// `src`'d scripts reference external assets — Parcel must continue to
+		// resolve and bundle them, so leave them alone.
+		if (/\bsrc\s*=/i.test(rawAttrs)) {
+			return match;
+		}
+		const attrsB64 = Buffer.from(rawAttrs, 'utf8').toString('base64');
+		const contentB64 = Buffer.from(content, 'utf8').toString('base64');
+		return `<!--${ATLAS_INLINE_SCRIPT_MARKER}::${attrsB64}::${contentB64}-->`;
+	});
+}
+
 const languageDisplayNames = {
 	html: 'HTML',
 	js: 'JavaScript',
@@ -231,20 +275,22 @@ module.exports = new Transformer({
 			asset.invalidateOnFileChange(templateFilename);
 			const githubLink = buildGithubLink(asset.filePath);
 			asset.setCode(
-				mustache.render(template, {
-					body: parsedCode,
-					githubLink,
-					toc: { name: 'TOC', entries: tocEntries },
-					breadcrumbs: renderBreadcrumbsMarkup(tocEntries, asset.filePath),
-					...attributes,
-					tokens,
-					cssTokenSource,
-					figmaEmbed,
-					hero
-				})
+				hideInlineScripts(
+					mustache.render(template, {
+						body: parsedCode,
+						githubLink,
+						toc: { name: 'TOC', entries: tocEntries },
+						breadcrumbs: renderBreadcrumbsMarkup(tocEntries, asset.filePath),
+						...attributes,
+						tokens,
+						cssTokenSource,
+						figmaEmbed,
+						hero
+					})
+				)
 			);
 		} else {
-			asset.setCode(parsedCode);
+			asset.setCode(hideInlineScripts(parsedCode));
 		}
 
 		return [asset];

--- a/plugins/parcel-transformer-markdown-html/lib/index.js
+++ b/plugins/parcel-transformer-markdown-html/lib/index.js
@@ -5,6 +5,7 @@ const hljs = require('highlight.js');
 const frontMatter = require('front-matter');
 const mustache = require('mustache');
 const path = require('path');
+const parse5 = require('parse5');
 const allTokens = require('@microsoft/atlas-css/dist/tokens.json');
 const { renderBreadcrumbsMarkup } = require('./breadcrumbs');
 const { buildGithubLink } = require('./github-link');
@@ -37,20 +38,82 @@ const { buildGithubLink } = require('./github-link');
 // The marker uses only base64 characters between the `::` separators, so
 // `<!--…-->` can never be ambiguous (base64 has no `-`) and HTML comment
 // rules (no `--` inside) are respected.
+//
+// Implementation note: we deliberately use the parse5 HTML parser instead
+// of a regex to locate `<script>` tags. Regex-based HTML tag matching is
+// brittle (browsers accept odd constructions like `</script foo="bar">`,
+// uppercase tag names, etc.) and gets flagged by `js/bad-tag-filter` style
+// security tools. parse5 implements the WHATWG HTML parsing algorithm, so
+// it sees exactly what the browser would.
 const ATLAS_INLINE_SCRIPT_MARKER = 'ATLAS_INLINE_SCRIPT_V1';
-const SCRIPT_TAG_REGEX = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+
+function findInlineScriptNodes(root) {
+	const scripts = [];
+	const stack = [root];
+	while (stack.length > 0) {
+		const node = stack.pop();
+		if (
+			node.tagName === 'script' &&
+			Array.isArray(node.attrs) &&
+			!node.attrs.some(a => a.name === 'src') &&
+			node.sourceCodeLocation &&
+			node.sourceCodeLocation.startTag
+		) {
+			scripts.push(node);
+		}
+		if (node.childNodes) {
+			for (const child of node.childNodes) {
+				stack.push(child);
+			}
+		}
+	}
+	return scripts;
+}
+
+function serializeAttrs(attrs) {
+	return attrs
+		.map(attr => {
+			const escaped = String(attr.value).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+			return ` ${attr.name}="${escaped}"`;
+		})
+		.join('');
+}
 
 function hideInlineScripts(html) {
-	return html.replace(SCRIPT_TAG_REGEX, (match, rawAttrs, content) => {
-		// `src`'d scripts reference external assets — Parcel must continue to
-		// resolve and bundle them, so leave them alone.
-		if (/\bsrc\s*=/i.test(rawAttrs)) {
-			return match;
-		}
+	// Cheap pre-check: if there is no `<script` substring at all there is
+	// nothing for us to do and we can skip the parse entirely.
+	if (!/<script/i.test(html)) {
+		return html;
+	}
+
+	const fragment = parse5.parseFragment(html, { sourceCodeLocationInfo: true });
+	const scripts = findInlineScriptNodes(fragment);
+	if (scripts.length === 0) {
+		return html;
+	}
+
+	// Sort by start offset descending so we can splice into the original
+	// string without invalidating later offsets.
+	scripts.sort((a, b) => b.sourceCodeLocation.startOffset - a.sourceCodeLocation.startOffset);
+
+	let result = html;
+	for (const node of scripts) {
+		const loc = node.sourceCodeLocation;
+		const startOffset = loc.startOffset;
+		const endOffset = loc.endOffset;
+		const startTagEnd = loc.startTag.endOffset;
+		const endTagStart = loc.endTag ? loc.endTag.startOffset : endOffset;
+
+		const rawAttrs = serializeAttrs(node.attrs);
+		const content = html.slice(startTagEnd, endTagStart);
+
 		const attrsB64 = Buffer.from(rawAttrs, 'utf8').toString('base64');
 		const contentB64 = Buffer.from(content, 'utf8').toString('base64');
-		return `<!--${ATLAS_INLINE_SCRIPT_MARKER}::${attrsB64}::${contentB64}-->`;
-	});
+		const marker = `<!--${ATLAS_INLINE_SCRIPT_MARKER}::${attrsB64}::${contentB64}-->`;
+
+		result = result.slice(0, startOffset) + marker + result.slice(endOffset);
+	}
+	return result;
 }
 
 const languageDisplayNames = {

--- a/plugins/parcel-transformer-markdown-html/package.json
+++ b/plugins/parcel-transformer-markdown-html/package.json
@@ -21,6 +21,7 @@
 		"marked": "^5.1.0",
 		"highlight.js": "11.11.1",
 		"front-matter": "4.0.2",
-		"mustache": "4.2.0"
+		"mustache": "4.2.0",
+		"parse5": "7.3.0"
 	}
 }

--- a/site/.parcelrc
+++ b/site/.parcelrc
@@ -7,5 +7,11 @@
 		"*.md": [
 			"@microsoft/parcel-transformer-markdown-html"
 		]
+	},
+	"optimizers": {
+		"*.html": [
+			"@microsoft/parcel-optimizer-inline-script-restore",
+			"..."
+		]
 	}
 }

--- a/site/package.json
+++ b/site/package.json
@@ -35,6 +35,7 @@
 		"lightningcss": "1.30.2",
 		"@parcel/transformer-sass": "2.16.3",
 		"@microsoft/parcel-transformer-markdown-html": "2.7.3",
+		"@microsoft/parcel-optimizer-inline-script-restore": "1.0.0",
 		"fs-extra": "^11.1.1",
 		"front-matter": "^4.0.2",
 		"typescript": "^5.1.5",

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -18,7 +18,7 @@ The layout component provides a flexible and efficient way to structure the majo
 This page is utilizing the holy grail layout, but you can use the buttons below to toggle layouts and test them out by resizing the screen. Try the "Toggle container labels" button below to see the css classes on each of the containers inside `.layout`.
 
 <div class="buttons buttons-addons margin-top-sm">
-  <button class="button" data-set-layout="layout-holy-grail" aria-pressed="true">Holy grail</button>
+  <button class="button" data-set-layout="layout-holy-grail">Holy grail</button>
   <button class="button" data-set-layout="layout-twin">Twin</button>
   <button class="button" data-set-layout="layout-single">Single</button>
   <button class="button" data-set-layout="layout-sidecar-left">Sidecar left</button>

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -6,6 +6,7 @@ classType: Component
 classPrefixes:
   - layout
 hero: true
+layoutViewName: atlas-layout-page
 ---
 
 # Layout
@@ -362,6 +363,26 @@ For example, to hide an element when the menu is collapsed and show a different 
 | `.display-flex-layout-aside-collapsed` | `display: flex` when aside is collapsed |
 | `.display-none-layout-aside-collapsed` | Hidden when aside is collapsed          |
 
+### Display helpers gated on JS restoration
+
+When `createLayoutState` (from `@microsoft/atlas-js`) finishes applying stored layout state, it sets `data-layout-restored="true"` on `<html>`. These helpers apply only while that attribute is absent, letting you hide content until JS initializes or show a placeholder only while it boots.
+
+```scss
+.display-{value}-until-layout-restored
+```
+
+Generated values: `none`, `block`, `flex`, `grid`, `inline`, `inline-block`, `inline-flex`.
+
+```html-no-example
+<!-- Hidden until restored. -->
+<div class="display-none-until-layout-restored">…</div>
+
+<!-- Shown only until restored. -->
+<div class="display-block-until-layout-restored">Loading…</div>
+```
+
+Use these only with the [inline restoration snippet](#persisting-layout-state-across-page-loads); without `createLayoutState`, the attribute is never set and the rules keep applying.
+
 ## Scaling container widths
 
 On wider screens, the menu and aside containers automatically scale up to give navigation and supplementary content more room. This happens at two breakpoints:
@@ -461,3 +482,66 @@ document.documentElement.classList.add('layout-holy-grail');
 ```
 
 You'll seldom have occasion to do this in the middle of a user's visit, but it can be useful for things like opening a code editor in a wider layout or adopting a focused reading mode.
+
+## Persisting layout state across page loads
+
+`@microsoft/atlas-js` exports `createLayoutState`, which persists `layout-*` classes on `<html>` to `localStorage` and restores them the next time the page loads. See the [atlas-js README](https://github.com/microsoft/atlas-design/tree/main/js#readme) for the API. Skip this section if your page layout never changes after load.
+
+### Creating layout state and subscribing to changes
+
+Import `createLayoutState` from `@microsoft/atlas-js` and call it once per page (typically from your main module entry). It returns a `LayoutStateInstance` whose `subscribe()` method fires whenever a watched `layout-*` class is added to or removed from `<html>` — including the initial restoration on page load. A new subscriber replays immediately if the current state already matches, so the same callback that reacts to user toggles can also sync UI on first load.
+
+```typescript
+const layoutState = createLayoutState({
+	viewName: 'my-view-name',
+	useViewTransitionOnRestore: true
+});
+
+// Keep a "Collapse menu" button's `aria-expanded` in sync with the layout
+// class. Fires once on restoration with the persisted state, and again on
+// every later toggle. Pass `'added'` or `'removed'` to filter; `'always'`
+// fires for both.
+const unsubscribe = layoutState.subscribe('layout-menu-collapsed', 'always', ({ isApplied }) => {
+	const button = document.querySelector<HTMLButtonElement>('[data-menu-collapse-toggle]');
+	button?.setAttribute('aria-expanded', String(!isApplied));
+});
+
+// Toggling the class on <html> persists the change and fires the subscriber.
+document.documentElement.classList.toggle('layout-menu-collapsed');
+
+// Drop the subscription when it's no longer needed.
+unsubscribe();
+```
+
+The `viewName` option scopes persisted state — pages with different `viewName`s read and write separate `localStorage` buckets, so a layout toggled on one page doesn't bleed into another. Pass a function (`viewName: () => currentView`) to follow a runtime-varying view name without recreating the instance.
+
+Calling `createLayoutState()` from a module bundle restores classes, but **not before first paint** — module scripts run after HTML parse, so the browser briefly renders the original markup layout, causing a visible reflow.
+
+### Inline restore script in `<head>`
+
+Place this synchronous IIFE in `<head>` before the bundle. It reads the same `localStorage` key that `createLayoutState` uses and applies the saved classes to `<html>` during parse:
+
+```html-no-example
+<head>
+	<script>
+		(function () {
+			try {
+				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
+				var view = state['my-view-name'] || {};
+				var html = document.documentElement;
+				for (var c in view) {
+					if (view[c]) html.classList.add(c);
+					else html.classList.remove(c);
+				}
+			} catch (e) {}
+		})();
+	</script>
+	<script type="module" src="/your-bundle.js"></script>
+</head>
+```
+
+Atlas ships ready-made helpers for this — see [Display helpers gated on JS restoration](#display-helpers-gated-on-js-restoration). The sentinel is a data attribute rather than a `layout-*` class, so `createLayoutState` does not persist it.
+
+### Content Security Policy
+
+Inline `<script>` requires `'unsafe-inline'` or a `'sha256-...'` hash in `script-src`. Atlas places the snippet **before** the CSP `<meta>` tag so the policy applies only to later elements; alternatively, add the script body's SHA-256 hash to `script-src`.

--- a/site/src/scaffold/index.ts
+++ b/site/src/scaffold/index.ts
@@ -14,6 +14,11 @@ import { initLayoutPageControls } from './scripts/layout-page';
 import { handleFullScreenNavButton } from './scripts/mobile-navigation';
 import { initReadingDirectionButtons } from './scripts/direction-buttons';
 
+// Run layout-state restoration as early as possible so any previously
+// selected layout is applied to <html> before the first paint, avoiding a
+// brief flash of the markup-default layout (`layout-holy-grail`).
+initLayoutPageControls();
+
 initTheme();
 initDismiss();
 initPopover();
@@ -24,6 +29,5 @@ initSnapScroll();
 initFullScreenToggle();
 handleFocusableIfScrollable();
 handleFullScreenNavButton();
-initLayoutPageControls();
 initLayout();
 initReadingDirectionButtons();

--- a/site/src/scaffold/scripts/layout-page.ts
+++ b/site/src/scaffold/scripts/layout-page.ts
@@ -1,3 +1,5 @@
+import { createLayoutState } from '@microsoft/atlas-js/src/index';
+
 const layoutsClasses = [
 	'layout-single',
 	'layout-twin',
@@ -25,6 +27,49 @@ function getCurrentLayoutClass() {
 }
 
 export function initLayoutPageControls() {
+	// Only the layout demo page contains the layout-set buttons.
+	// On every other site page this function should be a no-op so we don't
+	// persist or restore layout-* classes that don't belong to it.
+	if (!document.querySelector('[data-set-layout]')) {
+		return;
+	}
+
+	// Persist `layout-*` classes on <html> and replay them when the layout
+	// demo page reloads. Subscribers below sync each demo button's UI to the
+	// restored state, then re-fire on subsequent toggles so click handlers
+	// don't need to update aria attributes themselves.
+	const layoutState = createLayoutState({
+		viewName: 'atlas-layout-page',
+		useViewTransitionOnRestore: true
+	});
+
+	for (const layoutClass of layoutsClasses) {
+		layoutState.subscribe(layoutClass, 'always', ({ isApplied }) => {
+			const button = document.querySelector<HTMLButtonElement>(
+				`[data-set-layout="${layoutClass}"]`
+			);
+			if (button) {
+				button.setAttribute('aria-pressed', String(isApplied));
+			}
+		});
+	}
+
+	layoutState.subscribe('layout-menu-collapsed', 'always', ({ isApplied }) => {
+		syncCollapseTrigger('[data-menu-collapse-toggle]', isApplied);
+	});
+
+	layoutState.subscribe('layout-aside-collapsed', 'always', ({ isApplied }) => {
+		syncCollapseTrigger('[data-aside-collapse-toggle]', isApplied);
+	});
+
+	layoutState.subscribe('layout-constrained', 'always', ({ isApplied }) => {
+		syncToggleButton('[data-toggle-layout-height-constraint]', isApplied);
+	});
+
+	layoutState.subscribe('layout-flyout-active', 'always', ({ isApplied }) => {
+		syncToggleButton('[data-toggle-flyout-visibility]', isApplied);
+	});
+
 	window.addEventListener('click', (e: MouseEvent) => {
 		const target =
 			e.target instanceof Element && (e.target.closest('[data-set-layout]') as HTMLElement);
@@ -260,4 +305,22 @@ function asideCollapseBehaviorAllowed(layoutClass: string) {
 		layoutClass === 'layout-sidecar-right' ||
 		layoutClass === 'layout-twin'
 	);
+}
+
+function syncCollapseTrigger(selector: string, isCollapsed: boolean): void {
+	const trigger = document.querySelector<HTMLButtonElement>(selector);
+	if (!trigger) {
+		return;
+	}
+	trigger.classList.toggle('button-filled', isCollapsed);
+	trigger.setAttribute('aria-expanded', String(!isCollapsed));
+}
+
+function syncToggleButton(selector: string, isApplied: boolean): void {
+	const trigger = document.querySelector<HTMLButtonElement>(selector);
+	if (!trigger) {
+		return;
+	}
+	trigger.classList.toggle('button-filled', isApplied);
+	trigger.setAttribute('aria-pressed', String(isApplied));
 }

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -5,6 +5,17 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
 		<title>{{title}} | Atlas Design | Microsoft</title>
+		<script>
+			(function () {
+					var s = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
+					var v = s['{{{layoutViewName}}}'] || {};
+					var html = document.documentElement;
+					for (var c in v) {
+						if (v[c]) html.classList.add(c);
+						else html.classList.remove(c);
+					}
+			})();
+		</script>
 		<meta property="og:title" content="{{title}}" />
 		<meta property="og:type" content="website" />
 		<meta name="color-scheme" content="light dark" />
@@ -30,7 +41,7 @@
 							<path d="M11.5216 0.5H0V11.9067H11.5216V0.5Z" fill="#f25022" />
 							<path d="M24.2418 0.5H12.7202V11.9067H24.2418V0.5Z" fill="#7fba00" />
 							<path d="M11.5216 13.0933H0V24.5H11.5216V13.0933Z" fill="#00a4ef" />
-							<path d="M24.2418 13.0933H12.7202V24.5H24.2418V13.0933Z" fill="#ffb900" />
+							<path d="M24.2418 13.093312.7202V24.5H24.2418V13.0933Z" fill="#ffb900" />
 						</svg>
 					</a>
 

--- a/site/src/scaffold/token.html
+++ b/site/src/scaffold/token.html
@@ -9,6 +9,17 @@
 		<meta property="og:type" content="website" />
 		<meta name="color-scheme" content="light dark" />
 		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-src 'self' https://www.figma.com/; img-src data: 'self' https://github.com/ https://badge.fury.io/ https://*.cloudfront.net https://via.placeholder.com https://docs.microsoft.com https://learn.microsoft.com; style-src 'self' 'unsafe-inline'" >
+		<script>
+			(function () {
+					var s = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
+					var v = s['{{{layoutViewName}}}'] || {};
+					var html = document.documentElement;
+					for (var c in v) {
+						if (v[c]) html.classList.add(c);
+						else html.classList.remove(c);
+					}
+			})();
+		</script>
 		<link rel="stylesheet" href="~/src/scaffold/index.scss">
 		<script type="module" src="~/src/scaffold/index.ts"></script>
 		<link rel="icon" href="~/src/atlas-light.svg" type="image/svg+xml">


### PR DESCRIPTION
changes.

Link: [preview](http://localhost:1111/)

I've been trying to create some code that helps us restore the layout related html classes on the documentElement, then create an API subscribers can listen for changes and also use the same api just to make changes they want to happen on page load. It's been hard to fully figure out, and I've been bouncing between ideas to get the right balance.
 
I landed on the following:

We put an IIEF directly in the markup of pages on the consumer site. This is a short snippet that essentially checks local storage and uses it to restore the same, if we're on the same page template. This happens quickly, synchronously, before we get into any bundle code. This is a common method for restoring color themes without flashes of different themes too. It just lives in documentation, not source.

Next, (we are in the bundles now), we read the state again (which is keyed on page templates / view names), and create a thing (`layoutState`) that can both watch for changes to the relevant html classes on the documentElement _and_ save the changes to state.

Subscribers write functions that run when a particular state is true - and they also run right away once if the state matches their conditions.

Put in another set of css helper classes, which are design to hide things if the layout is still restoring.

What this'll do ensure that we never see any jank on load, and give us the flexibility we need to easily write functions that target specific states.

Additionally, there is a bug with parcel that breaks the initial uncached build when a plain script tag is added to HTML. There is a workaround in place in a new workspace in /plugins/parcel-optimizer-inline-script-restore which circumvents the logic to fix the bug.

## Testing

1. Visit layout page.
2. Select a relevant expand/collapse toggle, such as toggling the menu, aside, or the flyout.
3. Refresh page. You should see the same state as you left off.
4. Note that the Atlas doc site does not support expanding/collapsing of elements off the layout page.

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [x] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
