### PR TITLE
update light-theme visited link color

### DIFF
--- a/.changeset/visited-link-contrast.md
+++ b/.changeset/visited-link-contrast.md
@@ -2,4 +2,4 @@
 '@microsoft/atlas-css': patch
 ---
 
-Update light theme visited link color to use the approved token value `palette.$palette-purple-60` (`#8661c5`) for improved accessibility contrast.
+Add `palette.$palette-purple-d` (`#6659a5`) and apply it to the light theme visited link color for improved accessibility contrast.

--- a/.changeset/visited-link-contrast.md
+++ b/.changeset/visited-link-contrast.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Update light theme visited link color to use the approved token value `palette.$palette-purple-60` (`#8661c5`) for improved accessibility contrast.

--- a/css/src/tokens/palette.scss
+++ b/css/src/tokens/palette.scss
@@ -235,6 +235,7 @@ $palette-purple-100: #03002c !default;
 $palette-purple-a: #cd9bcf !default;
 $palette-purple-b: #702573 !default; // light
 $palette-purple-c: #b84dc6 !default;
+$palette-purple-d: #6659a5 !default;
 
 $palette-purple-opacity-30: hsl(251deg 47% 18% / 30%) !default;
 $palette-purple-opacity-70: hsl(251deg 47% 18% / 70%) !default;

--- a/css/src/tokens/themes.scss
+++ b/css/src/tokens/themes.scss
@@ -44,7 +44,7 @@ $themes: (
 		'control-border-bottom': palette.$palette-grey-170,
 		'inline-code': palette.$palette-grey-40,
 		'code-highlight-background': palette.$palette-yellow-50,
-		'visited': palette.$palette-purple-60,
+		'visited': palette.$palette-purple-d,
 		'score-low-off': palette.$palette-red-opacity-30,
 		'score-low': palette.$palette-red-120,
 		'score-medium-off': palette.$palette-yellow-opacity-30,

--- a/css/src/tokens/themes.scss
+++ b/css/src/tokens/themes.scss
@@ -44,7 +44,7 @@ $themes: (
 		'control-border-bottom': palette.$palette-grey-170,
 		'inline-code': palette.$palette-grey-40,
 		'code-highlight-background': palette.$palette-yellow-50,
-		'visited': palette.$palette-purple-70,
+		'visited': palette.$palette-purple-60,
 		'score-low-off': palette.$palette-red-opacity-30,
 		'score-low': palette.$palette-red-120,
 		'score-medium-off': palette.$palette-yellow-opacity-30,


### PR DESCRIPTION
Link: [preview](http://localhost:1111/)

This pull request updates the light theme visited link color to improve accessibility contrast while keeping the palette structure consistent.

What changed

1. Added a new purple variant token in the palette: $palette-purple-d with value #6659A5.
2. Updated the light theme visited mapping to use the new token.
3. Left dark and high-contrast visited mappings unchanged.

Why
The previous light-theme visited color did not meet the desired contrast criteria, so this introduces a dedicated token for the approved value and applies it only where needed. 

The requirements are: 
Greater than 3:1 contrast with body text #161616
Greater than 4.5:1 contrast with these backgrounds:
body-background: #fff
body-background-medium: #fafafa
body-background-dark: #f2f2f2

## Testing

Verify light theme visited links use #6659A5.
Verify contrast requirements are satisfied.
Verify no regressions for other themes.

## Contributor checklist

☑️ Did you update the description of this pull request with a review link and test steps?
☑️Did you submit a changeset? Changesets are required for all code changes.