### PR TITLE
Add unit tests for untested atlas-js modules

### DIFF
--- a/js/test/behaviors/dismiss.test.ts
+++ b/js/test/behaviors/dismiss.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initDismiss } from '../../src/behaviors/dismiss';
+
+/* -------------------------------------------------------------------------- */
+/* Test helpers                                                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * `initDismiss()` attaches a single delegated click listener to `window`.
+ * jsdom is shared across tests in this file, so without removing the
+ * listener between tests we'd accumulate one extra handler per test and
+ * leak side effects across cases.
+ */
+const installedListeners: ((e: Event) => void)[] = [];
+const originalAddEventListener = window.addEventListener.bind(window);
+
+function setupDismiss(): void {
+	const captured: ((e: Event) => void)[] = [];
+	const spy = vi.spyOn(window, 'addEventListener').mockImplementation(((
+		type: string,
+		listener: EventListenerOrEventListenerObject
+	) => {
+		if (type === 'click' && typeof listener === 'function') {
+			captured.push(listener as (e: Event) => void);
+		}
+		return originalAddEventListener(
+			type as keyof WindowEventMap,
+			listener as EventListenerOrEventListenerObject
+		);
+	}) as typeof window.addEventListener);
+	initDismiss();
+	spy.mockRestore();
+	installedListeners.push(...captured);
+}
+
+function resetDom(): void {
+	document.body.innerHTML = '';
+}
+
+function removeInstalledListeners(): void {
+	while (installedListeners.length) {
+		const listener = installedListeners.pop();
+		if (listener) {
+			window.removeEventListener('click', listener);
+		}
+	}
+}
+
+beforeEach(() => {
+	resetDom();
+});
+
+afterEach(() => {
+	removeInstalledListeners();
+	resetDom();
+});
+
+/* -------------------------------------------------------------------------- */
+/* Tests                                                                      */
+/* -------------------------------------------------------------------------- */
+
+describe('initDismiss', () => {
+	it('removes the dismissable ancestor when the dismiss button is clicked [ai generated]', () => {
+		setupDismiss();
+		document.body.innerHTML = `
+			<div id="card" data-dismissable>
+				<button id="close" data-dismiss>Close</button>
+			</div>
+		`;
+		const button = document.getElementById('close')!;
+		button.click();
+		expect(document.getElementById('card')).toBeNull();
+	});
+
+	it('does nothing when the click target is not inside a dismiss button [ai generated]', () => {
+		setupDismiss();
+		document.body.innerHTML = `
+			<div id="card" data-dismissable>
+				<p id="text">Hello</p>
+			</div>
+		`;
+		document.getElementById('text')!.click();
+		expect(document.getElementById('card')).not.toBeNull();
+	});
+
+	it('does nothing when a dismiss button has no dismissable ancestor [ai generated]', () => {
+		setupDismiss();
+		document.body.innerHTML = `<button id="lonely" data-dismiss>Close</button>`;
+		const button = document.getElementById('lonely')!;
+		// Should simply no-op without throwing
+		expect(() => button.click()).not.toThrow();
+		expect(document.getElementById('lonely')).not.toBeNull();
+	});
+
+	it('dispatches "dismiss-content-update" after a successful dismissal [ai generated]', () => {
+		setupDismiss();
+		document.body.innerHTML = `
+			<div id="card" data-dismissable>
+				<button id="close" data-dismiss>x</button>
+			</div>
+		`;
+		const handler = vi.fn();
+		window.addEventListener('dismiss-content-update', handler);
+		try {
+			document.getElementById('close')!.click();
+			expect(handler).toHaveBeenCalledTimes(1);
+		} finally {
+			window.removeEventListener('dismiss-content-update', handler);
+		}
+	});
+
+	it('adds animation-slide-up class and waits for animationend before removing [ai generated]', () => {
+		setupDismiss();
+		document.body.innerHTML = `
+			<div id="card" data-dismissable data-dismiss-animation="slide-up">
+				<button id="close" data-dismiss>x</button>
+			</div>
+		`;
+		const card = document.getElementById('card')!;
+		document.getElementById('close')!.click();
+		expect(card.classList.contains('animation-slide-up')).toBe(true);
+		// Element is still present until animationend fires
+		expect(document.getElementById('card')).not.toBeNull();
+		card.dispatchEvent(new Event('animationend'));
+		expect(document.getElementById('card')).toBeNull();
+	});
+
+	it('adds animation-fade class when animation is "fade" [ai generated]', () => {
+		setupDismiss();
+		document.body.innerHTML = `
+			<div id="card" data-dismissable data-dismiss-animation="fade">
+				<button id="close" data-dismiss>x</button>
+			</div>
+		`;
+		const card = document.getElementById('card')!;
+		document.getElementById('close')!.click();
+		expect(card.classList.contains('animation-fade')).toBe(true);
+		card.dispatchEvent(new Event('animationend'));
+		expect(document.getElementById('card')).toBeNull();
+	});
+
+	it('does not add any animation class for an unrecognized animation value, but still removes after animationend [ai generated]', () => {
+		setupDismiss();
+		document.body.innerHTML = `
+			<div id="card" data-dismissable data-dismiss-animation="wiggle">
+				<button id="close" data-dismiss>x</button>
+			</div>
+		`;
+		const card = document.getElementById('card')!;
+		document.getElementById('close')!.click();
+		expect(card.classList.contains('animation-slide-up')).toBe(false);
+		expect(card.classList.contains('animation-fade')).toBe(false);
+		// The animationend listener is still attached.
+		card.dispatchEvent(new Event('animationend'));
+		expect(document.getElementById('card')).toBeNull();
+	});
+
+	it('finds the closest dismiss button when clicking on a descendant of it [ai generated]', () => {
+		setupDismiss();
+		document.body.innerHTML = `
+			<div id="card" data-dismissable>
+				<button data-dismiss><span id="icon">x</span></button>
+			</div>
+		`;
+		document.getElementById('icon')!.click();
+		expect(document.getElementById('card')).toBeNull();
+	});
+});

--- a/js/test/behaviors/popover.test.ts
+++ b/js/test/behaviors/popover.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+import { initPopover } from '../../src/behaviors/popover';
+
+/* -------------------------------------------------------------------------- */
+/* Test helpers                                                               */
+/*                                                                            */
+/* The popover behavior is driven by `toggle` events on `<details>` elements. */
+/* Positioning reads layout (offsetWidth / getBoundingClientRect) which jsdom */
+/* reports as 0. That's fine: we still get observable side effects like the   */
+/* visibility flip, top/left inline styles being touched, and outside-click   */
+/* closing.                                                                   */
+/*                                                                            */
+/* Teardown notes:                                                            */
+/*   - `initPopover` attaches a delegated `toggle` listener to its container. */
+/*     We use a per-test container child so the listener dies with that node. */
+/*   - When opened, the behavior also attaches `blur` and `resize` listeners  */
+/*     to `window`. Those are only removed by `closePopovers()` (Escape /     */
+/*     outside click). We track every window listener installed during the    */
+/*     test and remove anything that's still attached at teardown.            */
+/* -------------------------------------------------------------------------- */
+
+interface RAFCall {
+	cb: FrameRequestCallback;
+}
+
+const rafCalls: RAFCall[] = [];
+const originalRAF = window.requestAnimationFrame;
+
+let container: HTMLElement;
+type WindowListenerSpies = {
+	add: MockInstance | undefined;
+	remove: MockInstance | undefined;
+};
+
+const windowListenerSpies: WindowListenerSpies = { add: undefined, remove: undefined };
+const installedWindowListeners: {
+	type: string;
+	listener: EventListenerOrEventListenerObject;
+	options: boolean | AddEventListenerOptions | undefined;
+}[] = [];
+
+function flushRAF(): void {
+	while (rafCalls.length > 0) {
+		const next = rafCalls.shift();
+		next?.cb(0);
+	}
+}
+
+function buildPopover({
+	id = 'pop',
+	modifierClasses = ''
+}: { id?: string; modifierClasses?: string } = {}): HTMLDetailsElement {
+	const wrapper = document.createElement('div');
+	wrapper.innerHTML = `
+		<details id="${id}" class="popover ${modifierClasses}">
+			<summary>Open</summary>
+			<div class="popover-content">
+				<p>Body</p>
+				<button data-popover-close>Close</button>
+			</div>
+		</details>
+	`;
+	container.appendChild(wrapper);
+	const details = document.getElementById(id) as HTMLDetailsElement;
+	// jsdom does not lay elements out, so `offsetParent` is null. The popover
+	// positioning code reads `offsetParent.getBoundingClientRect()`, so we
+	// give the content element a stable, real parent to point at.
+	const content = details.querySelector('.popover-content') as HTMLElement;
+	Object.defineProperty(content, 'offsetParent', {
+		configurable: true,
+		get: () => document.body
+	});
+	return details;
+}
+
+async function openDetails(details: HTMLDetailsElement): Promise<void> {
+	details.open = true;
+	// jsdom queues a native `toggle` event asynchronously. Yield to let it run.
+	await new Promise<void>(resolve => setTimeout(resolve, 0));
+}
+
+async function closeDetails(details: HTMLDetailsElement): Promise<void> {
+	details.open = false;
+	await new Promise<void>(resolve => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+	rafCalls.length = 0;
+	window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+		rafCalls.push({ cb });
+		return rafCalls.length;
+	}) as typeof window.requestAnimationFrame;
+
+	container = document.createElement('div');
+	document.body.appendChild(container);
+
+	// Track every window listener registered during the test so we can
+	// remove anything the behavior never got around to cleaning up.
+	installedWindowListeners.length = 0;
+	const origAdd = window.addEventListener.bind(window);
+	const origRemove = window.removeEventListener.bind(window);
+	windowListenerSpies.add = vi.spyOn(window, 'addEventListener').mockImplementation(((
+		type: string,
+		listener: EventListenerOrEventListenerObject,
+		options?: boolean | AddEventListenerOptions
+	) => {
+		installedWindowListeners.push({ type, listener, options });
+		return origAdd(
+			type as keyof WindowEventMap,
+			listener as EventListenerOrEventListenerObject,
+			options
+		);
+	}) as typeof window.addEventListener);
+	windowListenerSpies.remove = vi.spyOn(window, 'removeEventListener').mockImplementation(((
+		type: string,
+		listener: EventListenerOrEventListenerObject,
+		options?: boolean | EventListenerOptions
+	) => {
+		const idx = installedWindowListeners.findIndex(
+			entry => entry.type === type && entry.listener === listener
+		);
+		if (idx >= 0) installedWindowListeners.splice(idx, 1);
+		return origRemove(
+			type as keyof WindowEventMap,
+			listener as EventListenerOrEventListenerObject,
+			options
+		);
+	}) as typeof window.removeEventListener);
+});
+
+afterEach(() => {
+	// Sweep any window listeners the behavior left behind (e.g. when a test
+	// opens a popover and never closes it).
+	for (const { type, listener, options } of installedWindowListeners.splice(0)) {
+		window.removeEventListener(type, listener, options as EventListenerOptions);
+	}
+	windowListenerSpies.add?.mockRestore();
+	windowListenerSpies.remove?.mockRestore();
+
+	window.requestAnimationFrame = originalRAF;
+	rafCalls.length = 0;
+	// Clearing innerHTML detaches the per-test container; the delegated
+	// `toggle` listener on it becomes GC-eligible together with the node.
+	document.body.innerHTML = '';
+});
+
+/* -------------------------------------------------------------------------- */
+/* Tests                                                                      */
+/* -------------------------------------------------------------------------- */
+
+describe('initPopover', () => {
+	it('does not throw on a toggle from an element that is not a popover [ai generated]', async () => {
+		initPopover(container);
+
+		const details = document.createElement('details');
+		container.appendChild(details);
+
+		// No matching `details.popover` ancestor → handler should be a no-op.
+		details.open = true;
+		await new Promise<void>(resolve => setTimeout(resolve, 0));
+		expect(rafCalls).toHaveLength(0);
+	});
+
+	it('does nothing when the popover has no .popover-content child [ai generated]', async () => {
+		initPopover(container);
+		const details = document.createElement('details');
+		details.classList.add('popover');
+		details.innerHTML = `<summary>Open</summary>`;
+		container.appendChild(details);
+
+		details.open = true;
+		await new Promise<void>(resolve => setTimeout(resolve, 0));
+		// No RAF should have been requested because the handler bailed early.
+		expect(rafCalls).toHaveLength(0);
+	});
+
+	it('schedules a requestAnimationFrame to position content when opened [ai generated]', async () => {
+		initPopover(container);
+		const details = buildPopover();
+		await openDetails(details);
+
+		expect(rafCalls.length).toBeGreaterThanOrEqual(1);
+		flushRAF();
+
+		const content = details.querySelector('.popover-content') as HTMLElement;
+		expect(content.style.visibility).toBe('visible');
+	});
+
+	it('hides content immediately when the popover is closed via toggle [ai generated]', async () => {
+		initPopover(container);
+		const details = buildPopover();
+		await openDetails(details);
+		flushRAF();
+		await closeDetails(details);
+
+		const content = details.querySelector('.popover-content') as HTMLElement;
+		expect(content.style.visibility).toBe('hidden');
+	});
+
+	it('closes the popover when Escape is pressed [ai generated]', async () => {
+		initPopover(container);
+		const details = buildPopover();
+		await openDetails(details);
+		flushRAF();
+
+		container.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+		expect(details.hasAttribute('open')).toBe(false);
+		const content = details.querySelector('.popover-content') as HTMLElement;
+		expect(content.style.visibility).toBe('hidden');
+	});
+
+	it('closes the popover on a click outside the popover [ai generated]', async () => {
+		initPopover(container);
+		const details = buildPopover();
+		const outside = document.createElement('button');
+		outside.id = 'outside';
+		container.appendChild(outside);
+		await openDetails(details);
+		flushRAF();
+
+		outside.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(details.hasAttribute('open')).toBe(false);
+	});
+
+	it('does not close the popover when clicking content inside the popover [ai generated]', async () => {
+		initPopover(container);
+		const details = buildPopover();
+		await openDetails(details);
+		flushRAF();
+
+		const inner = details.querySelector('p') as HTMLElement;
+		inner.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(details.hasAttribute('open')).toBe(true);
+	});
+
+	it('closes the popover when a [data-popover-close] inside the popover is clicked [ai generated]', async () => {
+		initPopover(container);
+		const details = buildPopover();
+		await openDetails(details);
+		flushRAF();
+
+		const close = details.querySelector('[data-popover-close]') as HTMLElement;
+		close.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(details.hasAttribute('open')).toBe(false);
+	});
+
+	it('removes all listeners after closing, so a later outside click does not throw [ai generated]', async () => {
+		initPopover(container);
+		const details = buildPopover();
+		await openDetails(details);
+		flushRAF();
+
+		container.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+		expect(details.hasAttribute('open')).toBe(false);
+
+		// Outside clicks after closure must be inert.
+		expect(() => container.dispatchEvent(new MouseEvent('click', { bubbles: true }))).not.toThrow();
+	});
+
+	it('repositions on window resize while the popover is open [ai generated]', async () => {
+		initPopover(container);
+		const details = buildPopover();
+		await openDetails(details);
+		flushRAF();
+
+		const content = details.querySelector('.popover-content') as HTMLElement;
+		// Force a "stale" state we can detect on reposition.
+		content.style.visibility = 'hidden';
+
+		window.dispatchEvent(new Event('resize'));
+		expect(content.style.visibility).toBe('visible');
+	});
+
+	it('toggles the popover-caret-bottom class only on caret-style popovers placed above [ai generated]', async () => {
+		initPopover(container);
+		const details = buildPopover({ modifierClasses: 'popover-caret popover-top' });
+		await openDetails(details);
+		flushRAF();
+		expect(details.classList.contains('popover-caret-bottom')).toBe(true);
+	});
+
+	it('does not add popover-caret-bottom when the popover is forced to render below [ai generated]', async () => {
+		initPopover(container);
+		const details = buildPopover({ modifierClasses: 'popover-caret popover-bottom' });
+		await openDetails(details);
+		flushRAF();
+		expect(details.classList.contains('popover-caret-bottom')).toBe(false);
+	});
+
+	it('ignores toggle events that bubble up from elements outside any details.popover [ai generated]', () => {
+		initPopover(container);
+		const orphan = document.createElement('details');
+		container.appendChild(orphan);
+		expect(() => orphan.dispatchEvent(new Event('toggle'))).not.toThrow();
+		expect(rafCalls).toHaveLength(0);
+	});
+});

--- a/js/test/behaviors/snap-scroll.test.ts
+++ b/js/test/behaviors/snap-scroll.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initSnapScroll, initSnapScrollScrollListeners } from '../../src/behaviors/snap-scroll';
+
+/* -------------------------------------------------------------------------- */
+/* Test helpers                                                               */
+/*                                                                            */
+/* `snap-scroll` relies on:                                                   */
+/*   - a delegated window click handler installed via `initSnapScroll()`      */
+/*   - `IntersectionObserver` (not available in jsdom by default)             */
+/*   - `Element.scrollIntoView` (not implemented in jsdom)                    */
+/*                                                                            */
+/* We install minimal, transparent stubs so behavior is observable without    */
+/* introducing significant mocking surface.                                   */
+/* -------------------------------------------------------------------------- */
+
+interface FakeObserverInstance {
+	observed: Element[];
+	callback: IntersectionObserverCallback;
+	options: IntersectionObserverInit | undefined;
+	trigger(target: Element, isIntersecting: boolean): void;
+}
+
+const observerInstances: FakeObserverInstance[] = [];
+const originalIntersectionObserver = (globalThis as { IntersectionObserver?: unknown })
+	.IntersectionObserver;
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+const scrollIntoViewSpy = vi.fn();
+
+class FakeIntersectionObserver {
+	observed: Element[] = [];
+	callback: IntersectionObserverCallback;
+	options: IntersectionObserverInit | undefined;
+	constructor(cb: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+		this.callback = cb;
+		this.options = options;
+		observerInstances.push(this as unknown as FakeObserverInstance);
+	}
+	observe(target: Element): void {
+		this.observed.push(target);
+	}
+	unobserve(): void {}
+	disconnect(): void {}
+	takeRecords(): IntersectionObserverEntry[] {
+		return [];
+	}
+	trigger(target: Element, isIntersecting: boolean): void {
+		const entry = {
+			target,
+			isIntersecting,
+			intersectionRatio: isIntersecting ? 1 : 0,
+			boundingClientRect: target.getBoundingClientRect(),
+			intersectionRect: target.getBoundingClientRect(),
+			rootBounds: null,
+			time: 0
+		} as IntersectionObserverEntry;
+		this.callback([entry], this as unknown as IntersectionObserver);
+	}
+}
+
+const installedListeners: ((e: Event) => void)[] = [];
+const originalAddEventListener = window.addEventListener.bind(window);
+
+function setupSnapScroll(): void {
+	const captured: ((e: Event) => void)[] = [];
+	const spy = vi.spyOn(window, 'addEventListener').mockImplementation(((
+		type: string,
+		listener: EventListenerOrEventListenerObject
+	) => {
+		if (type === 'click' && typeof listener === 'function') {
+			captured.push(listener as (e: Event) => void);
+		}
+		return originalAddEventListener(
+			type as keyof WindowEventMap,
+			listener as EventListenerOrEventListenerObject
+		);
+	}) as typeof window.addEventListener);
+	try {
+		initSnapScroll();
+	} finally {
+		spy.mockRestore();
+		// Push everything captured so far, even if initSnapScroll threw mid-iteration.
+		installedListeners.push(...captured);
+	}
+}
+
+function resetDom(): void {
+	document.body.innerHTML = '';
+}
+
+function removeInstalledListeners(): void {
+	while (installedListeners.length) {
+		const listener = installedListeners.pop();
+		if (listener) {
+			window.removeEventListener('click', listener);
+		}
+	}
+}
+
+beforeEach(() => {
+	resetDom();
+	observerInstances.length = 0;
+	scrollIntoViewSpy.mockReset();
+	(globalThis as { IntersectionObserver?: unknown }).IntersectionObserver =
+		FakeIntersectionObserver;
+	Element.prototype.scrollIntoView =
+		scrollIntoViewSpy as unknown as typeof Element.prototype.scrollIntoView;
+	vi.useFakeTimers();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	removeInstalledListeners();
+	resetDom();
+	observerInstances.length = 0;
+	(globalThis as { IntersectionObserver?: unknown }).IntersectionObserver =
+		originalIntersectionObserver;
+	Element.prototype.scrollIntoView = originalScrollIntoView;
+});
+
+/* -------------------------------------------------------------------------- */
+/* Tests                                                                      */
+/* -------------------------------------------------------------------------- */
+
+describe('initSnapScrollScrollListeners', () => {
+	it('throws when no element matches [data-snap-scroll-slides] [ai generated]', () => {
+		const root = document.createElement('div');
+		document.body.appendChild(root);
+		expect(() => initSnapScrollScrollListeners(root)).toThrow(
+			/scrollable element with "data-snap-scroll-slides"/
+		);
+	});
+
+	it('observes every slide element with IntersectionObserver [ai generated]', () => {
+		document.body.innerHTML = `
+			<div data-snap-scroll="demo">
+				<div data-snap-scroll-slides>
+					<a data-snap-scroll-slide="a"></a>
+					<a data-snap-scroll-slide="b"></a>
+					<a data-snap-scroll-slide="c"></a>
+				</div>
+				<nav>
+					<a data-snap-scroll-nav-item="a"></a>
+					<a data-snap-scroll-nav-item="b"></a>
+					<a data-snap-scroll-nav-item="c"></a>
+				</nav>
+			</div>
+		`;
+		const root = document.querySelector('[data-snap-scroll]') as HTMLElement;
+		initSnapScrollScrollListeners(root);
+		expect(observerInstances).toHaveLength(1);
+		expect(observerInstances[0].observed).toHaveLength(3);
+		expect(observerInstances[0].options).toMatchObject({ threshold: 0.8, rootMargin: '0px' });
+	});
+
+	it('marks the matching nav item is-current when a slide intersects [ai generated]', () => {
+		document.body.innerHTML = `
+			<div data-snap-scroll="demo">
+				<div data-snap-scroll-slides>
+					<a data-snap-scroll-slide="a"></a>
+					<a id="slideB" data-snap-scroll-slide="b"></a>
+				</div>
+				<nav>
+					<a id="navA" data-snap-scroll-nav-item="a" class="is-current"></a>
+					<a id="navB" data-snap-scroll-nav-item="b"></a>
+				</nav>
+			</div>
+		`;
+		const root = document.querySelector('[data-snap-scroll]') as HTMLElement;
+		initSnapScrollScrollListeners(root);
+		const slideB = document.getElementById('slideB')!;
+		observerInstances[0].trigger(slideB, true);
+		expect(document.getElementById('navA')!.classList.contains('is-current')).toBe(false);
+		expect(document.getElementById('navB')!.classList.contains('is-current')).toBe(true);
+	});
+
+	it('throws when the intersecting slide has no data-snap-scroll-slide value [ai generated]', () => {
+		document.body.innerHTML = `
+			<div data-snap-scroll="demo">
+				<div data-snap-scroll-slides>
+					<a id="bare"></a>
+				</div>
+			</div>
+		`;
+		const root = document.querySelector('[data-snap-scroll]') as HTMLElement;
+		// Manually push the slide into the observer list because the original
+		// selector requires the attribute to be present.
+		initSnapScrollScrollListeners(root);
+		const bare = document.getElementById('bare')!;
+		expect(() => observerInstances[0].trigger(bare, true)).toThrow(
+			/does not correspond to a \[data-snap-scroll-nav-item\]/
+		);
+	});
+
+	it('throws when there is no nav item matching the intersecting slide [ai generated]', () => {
+		document.body.innerHTML = `
+			<div data-snap-scroll="demo">
+				<div data-snap-scroll-slides>
+					<a id="slideA" data-snap-scroll-slide="a"></a>
+				</div>
+			</div>
+		`;
+		const root = document.querySelector('[data-snap-scroll]') as HTMLElement;
+		initSnapScrollScrollListeners(root);
+		const slide = document.getElementById('slideA')!;
+		expect(() => observerInstances[0].trigger(slide, true)).toThrow(/Anchor missing/);
+	});
+});
+
+describe('initSnapScroll click delegation', () => {
+	it('does nothing when the click target is not a nav item [ai generated]', () => {
+		document.body.innerHTML = `<div><button id="other">Click</button></div>`;
+		setupSnapScroll();
+		document.getElementById('other')!.click();
+		expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+	});
+
+	it('does nothing when a nav item has no enclosing snap-scroll container [ai generated]', () => {
+		document.body.innerHTML = `<a id="orphan" data-snap-scroll-nav-item="a"></a>`;
+		setupSnapScroll();
+		document.getElementById('orphan')!.click();
+		expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+	});
+
+	it('updates is-current and scrolls the matching slide into view [ai generated]', () => {
+		document.body.innerHTML = `
+			<div data-snap-scroll="demo">
+				<div data-snap-scroll-slides>
+					<a id="slideA" data-snap-scroll-slide="a"></a>
+					<a id="slideB" data-snap-scroll-slide="b"></a>
+				</div>
+				<nav>
+					<a id="navA" data-snap-scroll-nav-item="a" class="is-current"></a>
+					<a id="navB" data-snap-scroll-nav-item="b"></a>
+				</nav>
+			</div>
+		`;
+		setupSnapScroll();
+		const navB = document.getElementById('navB')!;
+		navB.click();
+		expect(document.getElementById('navA')!.classList.contains('is-current')).toBe(false);
+		expect(navB.classList.contains('is-current')).toBe(true);
+		expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+		expect(scrollIntoViewSpy).toHaveBeenCalledWith({
+			behavior: 'auto',
+			block: 'nearest',
+			inline: 'start'
+		});
+	});
+
+	it('prevents default on the nav anchor click [ai generated]', () => {
+		document.body.innerHTML = `
+			<div data-snap-scroll="demo">
+				<div data-snap-scroll-slides>
+					<a id="slideA" data-snap-scroll-slide="a"></a>
+				</div>
+				<nav>
+					<a id="navA" href="#a" data-snap-scroll-nav-item="a"></a>
+				</nav>
+			</div>
+		`;
+		setupSnapScroll();
+		const navA = document.getElementById('navA')!;
+		const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+		navA.dispatchEvent(event);
+		expect(event.defaultPrevented).toBe(true);
+	});
+
+	it('ignores intersection callbacks fired while a click-driven scroll is in flight [ai generated]', () => {
+		document.body.innerHTML = `
+			<div data-snap-scroll="demo">
+				<div data-snap-scroll-slides>
+					<a id="slideA" data-snap-scroll-slide="a"></a>
+					<a id="slideB" data-snap-scroll-slide="b"></a>
+				</div>
+				<nav>
+					<a id="navA" data-snap-scroll-nav-item="a" class="is-current"></a>
+					<a id="navB" data-snap-scroll-nav-item="b"></a>
+				</nav>
+			</div>
+		`;
+		// Register scroll listener first so the FakeIntersectionObserver is
+		// captured.
+		const root = document.querySelector('[data-snap-scroll]') as HTMLElement;
+		initSnapScrollScrollListeners(root);
+		setupSnapScroll();
+
+		document.getElementById('navB')!.click();
+		// During the 500ms lockout, intersection callbacks should be ignored,
+		// so triggering slide A's intersection should NOT flip is-current back.
+		observerInstances[0].trigger(document.getElementById('slideA')!, true);
+		expect(document.getElementById('navA')!.classList.contains('is-current')).toBe(false);
+		expect(document.getElementById('navB')!.classList.contains('is-current')).toBe(true);
+
+		// After the lockout expires, intersection callbacks resume.
+		vi.advanceTimersByTime(500);
+		observerInstances[0].trigger(document.getElementById('slideA')!, true);
+		expect(document.getElementById('navA')!.classList.contains('is-current')).toBe(true);
+		expect(document.getElementById('navB')!.classList.contains('is-current')).toBe(false);
+	});
+});

--- a/js/test/elements/form-behavior.test.ts
+++ b/js/test/elements/form-behavior.test.ts
@@ -1,0 +1,522 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	collectCustomElementsByName,
+	defaultMessageStrings,
+	FormBehaviorElement,
+	getField,
+	getFieldBody,
+	getLabel,
+	HTMLValueElement,
+	navigateAfterSubmit,
+	setValidationMessage
+} from '../../src/elements/form-behavior';
+
+/* -------------------------------------------------------------------------- */
+/* Test helpers                                                               */
+/*                                                                            */
+/* `form-behavior` registers a `<form-behavior>` custom element at import     */
+/* time. We exercise it as a real DOM element, building small but valid       */
+/* fixtures so each test reads like a black-box description of the behavior.  */
+/* -------------------------------------------------------------------------- */
+
+function makeForm(innerHTML: string): {
+	form: HTMLFormElement;
+	behavior: FormBehaviorElement;
+} {
+	const form = document.createElement('form');
+	form.action = 'https://example.test/submit';
+	form.innerHTML = `
+		<form-behavior></form-behavior>
+		${innerHTML}
+	`;
+	document.body.appendChild(form);
+	const behavior = form.querySelector('form-behavior') as FormBehaviorElement;
+	return { form, behavior };
+}
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+});
+
+afterEach(() => {
+	document.body.innerHTML = '';
+});
+
+/* -------------------------------------------------------------------------- */
+/* defaultMessageStrings                                                      */
+/* -------------------------------------------------------------------------- */
+
+describe('defaultMessageStrings', () => {
+	it('exposes every localization key the validators rely on [ai generated]', () => {
+		expect(defaultMessageStrings.inputRequired).toMatch('{inputLabel}');
+		expect(defaultMessageStrings.inputMinLength).toMatch('{inputLabel}');
+		expect(defaultMessageStrings.inputMinLength).toMatch('{minLength}');
+		expect(defaultMessageStrings.inputMaxLength).toMatch('{inputLabel}');
+		expect(defaultMessageStrings.inputMaxLength).toMatch('{maxLength}');
+		expect(typeof defaultMessageStrings.weEncounteredAnUnexpectedError).toBe('string');
+		expect(typeof defaultMessageStrings.thereAreNoEditsToSubmit).toBe('string');
+	});
+});
+
+/* -------------------------------------------------------------------------- */
+/* navigateAfterSubmit (pure-ish helper)                                      */
+/* -------------------------------------------------------------------------- */
+
+describe('navigateAfterSubmit', () => {
+	let originalLocation: Location;
+	beforeEach(() => {
+		originalLocation = window.location;
+		const fakeLocation = {
+			href: 'https://example.test/',
+			pathname: '/',
+			search: '',
+			hash: '',
+			assign: vi.fn(),
+			replace: vi.fn(),
+			reload: vi.fn()
+		};
+		Object.defineProperty(window, 'location', {
+			configurable: true,
+			value: fakeLocation,
+			writable: true
+		});
+	});
+	afterEach(() => {
+		Object.defineProperty(window, 'location', {
+			configurable: true,
+			value: originalLocation,
+			writable: true
+		});
+	});
+
+	it('returns false and does nothing when navigationStep is null [ai generated]', () => {
+		expect(navigateAfterSubmit('/next', null)).toBe(false);
+		expect(window.location.assign as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+	});
+
+	it('"follow" sets location.href and returns true when href is provided [ai generated]', () => {
+		expect(navigateAfterSubmit('/next', 'follow')).toBe(true);
+		expect(window.location.href).toBe('/next');
+	});
+
+	it('"follow" returns false when no href is provided [ai generated]', () => {
+		expect(navigateAfterSubmit(null, 'follow')).toBe(false);
+	});
+
+	it('"replace" calls location.replace with href and returns true [ai generated]', () => {
+		expect(navigateAfterSubmit('/somewhere', 'replace')).toBe(true);
+		expect(window.location.replace).toHaveBeenCalledWith('/somewhere');
+	});
+
+	it('"replace" returns false when no href is provided [ai generated]', () => {
+		expect(navigateAfterSubmit(null, 'replace')).toBe(false);
+		expect(window.location.replace).not.toHaveBeenCalled();
+	});
+
+	it('"reload" calls location.reload and returns true regardless of href [ai generated]', () => {
+		expect(navigateAfterSubmit(null, 'reload')).toBe(true);
+		expect(window.location.reload).toHaveBeenCalledTimes(1);
+	});
+
+	it('"hash-reload" pushes history state, then reloads when href is provided [ai generated]', () => {
+		const pushSpy = vi.spyOn(window.history, 'pushState').mockImplementation(() => {});
+		try {
+			expect(navigateAfterSubmit('#section', 'hash-reload')).toBe(true);
+			expect(pushSpy).toHaveBeenCalledTimes(1);
+			expect(window.location.reload).toHaveBeenCalledTimes(1);
+		} finally {
+			pushSpy.mockRestore();
+		}
+	});
+
+	it('"hash-reload" returns false when no href is provided [ai generated]', () => {
+		expect(navigateAfterSubmit(null, 'hash-reload')).toBe(false);
+		expect(window.location.reload).not.toHaveBeenCalled();
+	});
+
+	it('throws on an unexpected navigationStep value [ai generated]', () => {
+		expect(() => navigateAfterSubmit('/any', 'mystery' as unknown as null)).toThrow(
+			/Unexpected navigation attribute/
+		);
+	});
+});
+
+/* -------------------------------------------------------------------------- */
+/* DOM-bound helpers                                                          */
+/* -------------------------------------------------------------------------- */
+
+describe('getLabel', () => {
+	it('returns the trimmed label text when an input has a <label> [ai generated]', () => {
+		const { form } = makeForm(`
+			<div class="field">
+				<div class="field-body">
+					<label for="name">  First name </label>
+					<input id="name" name="name" type="text" />
+				</div>
+			</div>
+		`);
+		const input = form.querySelector('#name') as HTMLValueElement;
+		expect(getLabel(input)).toBe('First name');
+	});
+
+	it('falls back to aria-label when no <label> is associated [ai generated]', () => {
+		const { form } = makeForm(`
+			<div class="field">
+				<div class="field-body">
+					<input id="email" name="email" type="text" aria-label="Email" />
+				</div>
+			</div>
+		`);
+		const input = form.querySelector('#email') as HTMLValueElement;
+		expect(getLabel(input)).toBe('Email');
+	});
+
+	it('throws when no label can be resolved [ai generated]', () => {
+		const { form } = makeForm(`
+			<div class="field">
+				<div class="field-body">
+					<input id="anon" name="anon" type="text" />
+				</div>
+			</div>
+		`);
+		const input = form.querySelector('#anon') as HTMLValueElement;
+		expect(() => getLabel(input)).toThrow(/has no associated label/);
+	});
+
+	it('reads the group label for a radio button [ai generated]', () => {
+		const { form } = makeForm(`
+			<div class="field">
+				<div class="field-label">Color</div>
+				<div class="field-body">
+					<input id="r1" type="radio" name="color" value="red" />
+				</div>
+			</div>
+		`);
+		const radio = form.querySelector('#r1') as HTMLValueElement;
+		expect(getLabel(radio)).toBe('Color');
+	});
+
+	it('falls back to aria-label for a radio without a group label [ai generated]', () => {
+		const { form } = makeForm(`
+			<div class="field">
+				<div class="field-body">
+					<input id="r1" type="radio" name="color" value="red" aria-label="Color" />
+				</div>
+			</div>
+		`);
+		const radio = form.querySelector('#r1') as HTMLValueElement;
+		expect(getLabel(radio)).toBe('Color');
+	});
+});
+
+describe('getField / getFieldBody', () => {
+	it('returns the closest .field ancestor [ai generated]', () => {
+		const { form } = makeForm(`
+			<div class="field" id="field1">
+				<div class="field-body">
+					<input id="x" name="x" type="text" />
+				</div>
+			</div>
+		`);
+		const input = form.querySelector('#x') as HTMLValueElement;
+		expect(getField(input).id).toBe('field1');
+	});
+
+	it('throws when an input is not inside a .field [ai generated]', () => {
+		const form = document.createElement('form');
+		form.innerHTML = `<input id="lonely" name="lonely" type="text" />`;
+		document.body.appendChild(form);
+		const input = form.querySelector('#lonely') as HTMLValueElement;
+		expect(() => getField(input)).toThrow(/is not within a \.field/);
+	});
+
+	it('returns the closest .field-body ancestor [ai generated]', () => {
+		const { form } = makeForm(`
+			<div class="field">
+				<div class="field-body" id="body1">
+					<input id="y" name="y" type="text" />
+				</div>
+			</div>
+		`);
+		const input = form.querySelector('#y') as HTMLValueElement;
+		expect(getFieldBody(input).id).toBe('body1');
+	});
+
+	it('throws when an input is not inside a .field-body [ai generated]', () => {
+		const { form } = makeForm(`
+			<div class="field">
+				<input id="nobody" name="nobody" type="text" />
+			</div>
+		`);
+		const input = form.querySelector('#nobody') as HTMLValueElement;
+		expect(() => getFieldBody(input)).toThrow(/is not within a \.field-body/);
+	});
+});
+
+describe('setValidationMessage', () => {
+	it('creates a new field-error element when none exists [ai generated]', () => {
+		const { form } = makeForm(`
+			<div class="field">
+				<div class="field-body">
+					<input id="i" name="i" type="text" />
+				</div>
+			</div>
+		`);
+		const input = form.querySelector('#i') as HTMLValueElement;
+		setValidationMessage(input, 'Too short');
+		const note = form.querySelector('[data-field-error]') as HTMLParagraphElement;
+		expect(note).not.toBeNull();
+		expect(note.textContent).toBe('Too short');
+		expect(note.classList.contains('field-error')).toBe(true);
+		expect(input.getAttribute('aria-describedby')).toContain(note.id);
+	});
+
+	it('reuses an existing field-error element on subsequent calls [ai generated]', () => {
+		const { form } = makeForm(`
+			<div class="field">
+				<div class="field-body">
+					<input id="i" name="i" type="text" />
+				</div>
+			</div>
+		`);
+		const input = form.querySelector('#i') as HTMLValueElement;
+		setValidationMessage(input, 'First');
+		setValidationMessage(input, 'Second');
+		const notes = form.querySelectorAll('[data-field-error]');
+		expect(notes).toHaveLength(1);
+		expect(notes[0].textContent).toBe('Second');
+	});
+});
+
+describe('collectCustomElementsByName', () => {
+	it('returns an empty list when every form field is in form.elements [ai generated]', () => {
+		const form = document.createElement('form');
+		form.innerHTML = `<input name="real" value="hi" />`;
+		document.body.appendChild(form);
+		expect(collectCustomElementsByName(form)).toEqual([]);
+	});
+
+	it('returns elements with a name attribute that are not in form.elements [ai generated]', () => {
+		const form = document.createElement('form');
+		form.innerHTML = `
+			<input name="real" value="hi" />
+			<custom-input name="custom"></custom-input>
+		`;
+		document.body.appendChild(form);
+		const customInput = form.querySelector('custom-input') as HTMLElement;
+
+		// jsdom does not include unknown elements in FormData. Stub the
+		// FormData iteration only for this test so the helper can see the
+		// custom-named element.
+		const originalFormData = window.FormData;
+		class FakeFormData {
+			[Symbol.iterator]() {
+				return [['real', 'hi'] as [string, string], ['custom', 'world'] as [string, string]][
+					Symbol.iterator
+				]();
+			}
+			entries() {
+				return this[Symbol.iterator]();
+			}
+		}
+		window.FormData = FakeFormData as unknown as typeof FormData;
+		try {
+			const result = collectCustomElementsByName(form);
+			expect(result).toContain(customInput);
+		} finally {
+			window.FormData = originalFormData;
+		}
+	});
+});
+
+/* -------------------------------------------------------------------------- */
+/* FormBehaviorElement                                                        */
+/* -------------------------------------------------------------------------- */
+
+describe('FormBehaviorElement', () => {
+	it('registers itself as the <form-behavior> custom element [ai generated]', () => {
+		expect(customElements.get('form-behavior')).toBe(FormBehaviorElement);
+	});
+
+	it('inserts a form-error-container after itself when connected inside a form [ai generated]', () => {
+		const { form, behavior } = makeForm(``);
+		const container = form.querySelector('[data-form-error-container]');
+		expect(container).not.toBeNull();
+		expect(behavior.nextElementSibling).toBe(container);
+	});
+
+	it('honors the nounload attribute via hideUnloadMessage [ai generated]', () => {
+		const { behavior } = makeForm(``);
+		expect(behavior.hideUnloadMessage).toBe(false);
+		behavior.setAttribute('nounload', '');
+		expect(behavior.hideUnloadMessage).toBe(true);
+	});
+
+	it('treats the new attribute as isNew and forces canSave [ai generated]', () => {
+		const { behavior } = makeForm(``);
+		expect(behavior.isNew).toBe(false);
+		expect(behavior.canSave).toBe(false);
+		behavior.setAttribute('new', '');
+		expect(behavior.isNew).toBe(true);
+		expect(behavior.canSave).toBe(true);
+	});
+
+	it('honors the nosubmit attribute via noSubmit [ai generated]', () => {
+		const { behavior } = makeForm(``);
+		expect(behavior.noSubmit).toBe(false);
+		behavior.setAttribute('nosubmit', '');
+		expect(behavior.noSubmit).toBe(true);
+	});
+
+	it('exposes the enclosing form via the .form getter [ai generated]', () => {
+		const { form, behavior } = makeForm(``);
+		expect(behavior.form).toBe(form);
+	});
+
+	it('overlays loc-* attribute overrides onto defaultMessageStrings [ai generated]', () => {
+		const { behavior } = makeForm(``);
+		behavior.setAttribute('loc-input-required', 'You must fill {inputLabel}');
+		const strings = behavior.getLocaleStrings();
+		expect(strings.inputRequired).toBe('You must fill {inputLabel}');
+		expect(strings.inputMinLength).toBe(defaultMessageStrings.inputMinLength);
+	});
+
+	it('marks the form as dirty when a field value diverges from initial [ai generated]', () => {
+		const { form, behavior } = makeForm(`
+			<input name="title" value="hello" />
+		`);
+		expect(behavior.isDirty).toBe(false);
+		(form.querySelector('input') as HTMLInputElement).value = 'world';
+		behavior.setDirty();
+		expect(behavior.isDirty).toBe(true);
+	});
+
+	it('disposes of subscribed listeners on disconnect [ai generated]', () => {
+		const { form, behavior } = makeForm(``);
+		expect(behavior.toDispose.length).toBeGreaterThan(0);
+		const disposeSpies = behavior.toDispose.map(d => vi.fn(d));
+		behavior.toDispose = disposeSpies;
+		form.removeChild(behavior);
+		for (const spy of disposeSpies) {
+			expect(spy).toHaveBeenCalled();
+		}
+	});
+
+	it('does not throw on connect when not parented by a form [ai generated]', () => {
+		const el = document.createElement('form-behavior');
+		expect(() => document.body.appendChild(el)).not.toThrow();
+	});
+
+	it('validateRequired returns the localized message when value is missing [ai generated]', () => {
+		const { form, behavior } = makeForm(`
+			<div class="field">
+				<div class="field-body">
+					<input id="x" name="x" type="text" required />
+				</div>
+			</div>
+		`);
+		const input = form.querySelector('#x') as HTMLInputElement;
+		const message = behavior.validateRequired(input as unknown as HTMLValueElement, 'Title');
+		expect(message).toBe('Title is required.');
+	});
+
+	it('validateRequired returns null when the input has a value [ai generated]', () => {
+		const { form, behavior } = makeForm(`
+			<div class="field">
+				<div class="field-body">
+					<input id="x" name="x" type="text" required value="hi" />
+				</div>
+			</div>
+		`);
+		const input = form.querySelector('#x') as HTMLInputElement;
+		expect(behavior.validateRequired(input as unknown as HTMLValueElement, 'Title')).toBeNull();
+	});
+
+	it('validateMinLength returns a message when the value is shorter than minLength [ai generated]', () => {
+		const { form, behavior } = makeForm(`
+			<div class="field">
+				<div class="field-body">
+					<input id="x" name="x" type="text" minlength="5" value="hi" />
+				</div>
+			</div>
+		`);
+		const input = form.querySelector('#x') as HTMLInputElement;
+		const message = behavior.validateMinLength(input, 'Title');
+		expect(message).toBe('Title must be at least 5 characters.');
+	});
+
+	it('validateMinLength returns null when the value meets minLength [ai generated]', () => {
+		const { form, behavior } = makeForm(`
+			<div class="field">
+				<div class="field-body">
+					<input id="x" name="x" type="text" minlength="2" value="hello" />
+				</div>
+			</div>
+		`);
+		const input = form.querySelector('#x') as HTMLInputElement;
+		expect(behavior.validateMinLength(input, 'Title')).toBeNull();
+	});
+
+	it('validateMaxLength returns a message when the value exceeds maxLength [ai generated]', () => {
+		const { form, behavior } = makeForm(`
+			<div class="field">
+				<div class="field-body">
+					<input id="x" name="x" type="text" maxlength="3" />
+				</div>
+			</div>
+		`);
+		const input = form.querySelector('#x') as HTMLInputElement;
+		// Browsers prevent typing past maxLength, but JS can still assign a
+		// longer value programmatically.
+		input.value = 'abcdefg';
+		const message = behavior.validateMaxLength(input as unknown as HTMLValueElement, 'Title');
+		expect(message).toBe('Title cannot be longer than 3 characters.');
+	});
+
+	it('validateMaxLength returns null when the value is within maxLength [ai generated]', () => {
+		const { form, behavior } = makeForm(`
+			<div class="field">
+				<div class="field-body">
+					<input id="x" name="x" type="text" maxlength="10" value="hi" />
+				</div>
+			</div>
+		`);
+		const input = form.querySelector('#x') as HTMLInputElement;
+		expect(behavior.validateMaxLength(input as unknown as HTMLValueElement, 'Title')).toBeNull();
+	});
+
+	it('showNoChangesMessage renders the localized message in the error alert [ai generated]', () => {
+		const { form, behavior } = makeForm(``);
+		behavior.showNoChangesMessage(form);
+		const message = form.querySelector('#no-edits-error') as HTMLLIElement;
+		// Source code uses Element.innerText; jsdom stores innerText
+		// separately from textContent, so we assert against innerText.
+		expect(message?.innerText).toBe(defaultMessageStrings.thereAreNoEditsToSubmit);
+		const alert = form.querySelector('[data-form-error-alert]') as HTMLDivElement;
+		expect(alert.hidden).toBe(false);
+	});
+
+	it('submissionError appends the error and reveals the error alert [ai generated]', () => {
+		const { form, behavior } = makeForm(``);
+		behavior.submissionError(form, 'Boom!');
+		const alert = form.querySelector('[data-form-error-alert]') as HTMLDivElement;
+		expect(alert.hidden).toBe(false);
+		const errorListItem = alert.querySelector('li') as HTMLLIElement;
+		expect(errorListItem.innerText).toBe('Boom!');
+	});
+
+	it('submissionError dispatches a submission-error custom event [ai generated]', () => {
+		const { form, behavior } = makeForm(``);
+		const handler = vi.fn();
+		behavior.addEventListener('submission-error', handler);
+		behavior.submissionError(form, 'Oops');
+		expect(handler).toHaveBeenCalledTimes(1);
+		const event = handler.mock.calls[0][0] as CustomEvent<{ form: HTMLFormElement }>;
+		expect(event.detail.form).toBe(form);
+	});
+
+	it('handleEvent throws on unexpected event types [ai generated]', () => {
+		const { behavior } = makeForm(``);
+		expect(() => behavior.handleEvent(new Event('weird'))).toThrow(/Unexpected event/);
+	});
+});

--- a/js/test/elements/form-behavior.test.ts
+++ b/js/test/elements/form-behavior.test.ts
@@ -519,4 +519,603 @@ describe('FormBehaviorElement', () => {
 		const { behavior } = makeForm(``);
 		expect(() => behavior.handleEvent(new Event('weird'))).toThrow(/Unexpected event/);
 	});
+
+	it('handleEvent routes submit to handleSubmitEvent [ai generated]', () => {
+		const { behavior } = makeForm(``);
+		const spy = vi.spyOn(behavior, 'handleSubmitEvent').mockImplementation(async () => {});
+		try {
+			behavior.handleEvent(new Event('submit'));
+			expect(spy).toHaveBeenCalledTimes(1);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it('handleEvent routes beforeunload to handleUnloadEvent [ai generated]', () => {
+		const { behavior } = makeForm(``);
+		const spy = vi.spyOn(behavior, 'handleUnloadEvent').mockImplementation(async () => {});
+		try {
+			behavior.handleEvent(new Event('beforeunload'));
+			expect(spy).toHaveBeenCalledTimes(1);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it('handleEvent routes change to clearValidationErrors and commit [ai generated]', () => {
+		const { behavior } = makeForm(``);
+		const clearSpy = vi.spyOn(behavior, 'clearValidationErrors').mockImplementation(() => {});
+		const commitSpy = vi.spyOn(behavior, 'commit').mockImplementation(() => {});
+		try {
+			const ev = new Event('change');
+			behavior.handleEvent(ev);
+			expect(clearSpy).toHaveBeenCalledTimes(1);
+			expect(commitSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			clearSpy.mockRestore();
+			commitSpy.mockRestore();
+		}
+	});
+
+	it('handleEvent routes input to clearValidationErrors and scheduleCommit [ai generated]', () => {
+		const { behavior } = makeForm(``);
+		const clearSpy = vi.spyOn(behavior, 'clearValidationErrors').mockImplementation(() => {});
+		const scheduleSpy = vi.spyOn(behavior, 'scheduleCommit').mockImplementation(() => {});
+		try {
+			behavior.handleEvent(new Event('input'));
+			expect(clearSpy).toHaveBeenCalledTimes(1);
+			expect(scheduleSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			clearSpy.mockRestore();
+			scheduleSpy.mockRestore();
+		}
+	});
+
+	/* ------------------------------------------------------------------ */
+	/* handleUnloadEvent                                                  */
+	/* ------------------------------------------------------------------ */
+
+	it('handleUnloadEvent does nothing when the form is clean [ai generated]', async () => {
+		const { behavior } = makeForm(`
+			<input name="title" value="hello" />
+		`);
+		const event = new Event('beforeunload') as BeforeUnloadEvent;
+		const preventSpy = vi.spyOn(event, 'preventDefault');
+		await behavior.handleUnloadEvent(event);
+		expect(preventSpy).not.toHaveBeenCalled();
+	});
+
+	it('handleUnloadEvent prevents navigation and sets returnValue when dirty [ai generated]', async () => {
+		const { form, behavior } = makeForm(`
+			<input name="title" value="hello" />
+		`);
+		(form.querySelector('input') as HTMLInputElement).value = 'changed';
+		const event = new Event('beforeunload') as BeforeUnloadEvent;
+		const preventSpy = vi.spyOn(event, 'preventDefault');
+		await behavior.handleUnloadEvent(event);
+		expect(preventSpy).toHaveBeenCalledTimes(1);
+		// jsdom coerces Event.returnValue to a boolean on plain Event objects
+		// (legacy property). Asserting truthy is enough — source sets a string.
+		expect(event.returnValue).toBeTruthy();
+	});
+
+	it('handleUnloadEvent stays silent when nounload is set even if dirty [ai generated]', async () => {
+		const { form, behavior } = makeForm(`
+			<input name="title" value="hello" />
+		`);
+		behavior.setAttribute('nounload', '');
+		(form.querySelector('input') as HTMLInputElement).value = 'changed';
+		const event = new Event('beforeunload') as BeforeUnloadEvent;
+		const preventSpy = vi.spyOn(event, 'preventDefault');
+		await behavior.handleUnloadEvent(event);
+		expect(preventSpy).not.toHaveBeenCalled();
+	});
+
+	/* ------------------------------------------------------------------ */
+	/* commit / scheduleCommit                                            */
+	/* ------------------------------------------------------------------ */
+
+	it('commit normalizes text values on change events [ai generated]', () => {
+		const { form, behavior } = makeForm(`
+			<div class="field"><div class="field-body">
+				<input id="t" name="t" type="text" value="hi" />
+			</div></div>
+		`);
+		const input = form.querySelector('#t') as HTMLInputElement;
+		input.value = '  spaced  ';
+		const ev = new Event('change');
+		Object.defineProperty(ev, 'target', { value: input });
+		behavior.commit(ev);
+		expect(input.value).toBe('spaced');
+		expect(behavior.isDirty).toBe(true);
+	});
+
+	it('commit ignores events whose target is not in the form [ai generated]', () => {
+		const { behavior } = makeForm(``);
+		const stray = document.createElement('input');
+		stray.type = 'text';
+		const ev = new Event('change');
+		Object.defineProperty(ev, 'target', { value: stray });
+		expect(() => behavior.commit(ev)).not.toThrow();
+		expect(behavior.isDirty).toBe(false);
+	});
+
+	it('scheduleCommit defers commit to a later tick [ai generated]', () => {
+		vi.useFakeTimers();
+		try {
+			const { form, behavior } = makeForm(`
+				<div class="field"><div class="field-body">
+					<input id="t" name="t" type="text" value="hi" />
+				</div></div>
+			`);
+			const input = form.querySelector('#t') as HTMLInputElement;
+			input.value = 'changed';
+			const ev = new Event('input');
+			Object.defineProperty(ev, 'target', { value: input });
+			behavior.scheduleCommit(ev);
+			expect(behavior.isDirty).toBe(false);
+			vi.advanceTimersByTime(400);
+			expect(behavior.isDirty).toBe(true);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	/* ------------------------------------------------------------------ */
+	/* createErrorAlert / getErrorAlert                                   */
+	/* ------------------------------------------------------------------ */
+
+	it('createErrorAlert returns the same alert when called twice via getErrorAlert [ai generated]', () => {
+		const { form, behavior } = makeForm(``);
+		const first = behavior.getErrorAlert(form);
+		const second = behavior.getErrorAlert(form);
+		expect(second.errorAlert).toBe(first.errorAlert);
+		expect(second.errorList).toBe(first.errorList);
+	});
+
+	/* ------------------------------------------------------------------ */
+	/* clearValidationErrors                                              */
+	/* ------------------------------------------------------------------ */
+
+	it('clearValidationErrors removes a field error and hides the alert when empty [ai generated]', () => {
+		const { form, behavior } = makeForm(`
+			<div class="field"><div class="field-body">
+				<label for="x">X</label>
+				<input id="x" name="x" type="text" required />
+			</div></div>
+		`);
+		const input = form.querySelector('#x') as HTMLInputElement;
+		const errors: import('../../src/elements/form-behavior').FormValidationError[] = [];
+		const { errorList, errorAlert } = behavior.getErrorAlert(form);
+		behavior.runBasicValidation(input, true, errors, errorList, false);
+		errorAlert.hidden = false;
+		expect(errorList.querySelector(`a[href="#${input.id}"]`)).not.toBeNull();
+		behavior.clearValidationErrors(input);
+		expect(errorList.querySelector(`a[href="#${input.id}"]`)).toBeNull();
+		expect(errorAlert.hidden).toBe(true);
+	});
+
+	it('clearValidationErrors ignores non-validatable targets [ai generated]', () => {
+		const { behavior } = makeForm(``);
+		const button = document.createElement('button');
+		expect(() => behavior.clearValidationErrors(button)).not.toThrow();
+	});
+
+	/* ------------------------------------------------------------------ */
+	/* runBasicValidation                                                 */
+	/* ------------------------------------------------------------------ */
+
+	it('runBasicValidation flags a checkbox by toggling its label is-invalid class [ai generated]', () => {
+		const { form, behavior } = makeForm(`
+			<div class="field"><div class="field-body">
+				<label class="checkbox" for="agree">
+					<input id="agree" name="agree" type="checkbox" required />
+					I agree
+				</label>
+			</div></div>
+		`);
+		const input = form.querySelector('#agree') as HTMLInputElement;
+		const errors: import('../../src/elements/form-behavior').FormValidationError[] = [];
+		const { errorList } = behavior.getErrorAlert(form);
+		behavior.runBasicValidation(input, true, errors, errorList, false);
+		expect(errors).toHaveLength(1);
+		expect(input.closest('label.checkbox')?.classList.contains('is-invalid')).toBe(true);
+	});
+
+	it('runBasicValidation flags a radio by toggling its label is-invalid class [ai generated]', () => {
+		const { form, behavior } = makeForm(`
+			<div class="field">
+				<div class="field-label">Color</div>
+				<div class="field-body">
+					<label class="radio" for="red">
+						<input id="red" name="color" type="radio" required />
+						Red
+					</label>
+				</div>
+			</div>
+		`);
+		const input = form.querySelector('#red') as HTMLInputElement;
+		const errors: import('../../src/elements/form-behavior').FormValidationError[] = [];
+		const { errorList } = behavior.getErrorAlert(form);
+		behavior.runBasicValidation(input, true, errors, errorList, false);
+		expect(input.closest('label.radio')?.classList.contains('is-invalid')).toBe(true);
+	});
+
+	it('runBasicValidation records an error but skips DOM when input has no id [ai generated]', () => {
+		const { form, behavior } = makeForm(`
+			<div class="field"><div class="field-body">
+				<input name="x" type="text" required aria-label="No-id field" />
+			</div></div>
+		`);
+		const input = form.querySelector('input') as HTMLInputElement;
+		const errors: import('../../src/elements/form-behavior').FormValidationError[] = [];
+		const { errorList } = behavior.getErrorAlert(form);
+		behavior.runBasicValidation(input, true, errors, errorList, false);
+		expect(errors).toHaveLength(1);
+		expect(errorList.children).toHaveLength(0);
+	});
+
+	it('runBasicValidation does not modify the DOM when displayValidity is false [ai generated]', () => {
+		const { form, behavior } = makeForm(`
+			<div class="field"><div class="field-body">
+				<label for="x">X</label>
+				<input id="x" name="x" type="text" required />
+			</div></div>
+		`);
+		const input = form.querySelector('#x') as HTMLInputElement;
+		const errors: import('../../src/elements/form-behavior').FormValidationError[] = [];
+		const { errorList } = behavior.getErrorAlert(form);
+		behavior.runBasicValidation(input, false, errors, errorList, false);
+		expect(errors).toHaveLength(1);
+		expect(errorList.children).toHaveLength(0);
+	});
+
+	/* ------------------------------------------------------------------ */
+	/* validateForm                                                       */
+	/* ------------------------------------------------------------------ */
+
+	it('validateForm returns valid: true when all inputs pass [ai generated]', async () => {
+		const { form, behavior } = makeForm(`
+			<div class="field"><div class="field-body">
+				<label for="x">X</label>
+				<input id="x" name="x" type="text" value="ok" />
+			</div></div>
+		`);
+		const result = await behavior.validateForm(form);
+		expect(result.valid).toBe(true);
+	});
+
+	it('validateForm collects errors and reveals the alert [ai generated]', async () => {
+		const { form, behavior } = makeForm(`
+			<div class="field"><div class="field-body">
+				<label for="x">Title</label>
+				<input id="x" name="x" type="text" required />
+			</div></div>
+		`);
+		const result = await behavior.validateForm(form);
+		expect(result.valid).toBe(false);
+		const alert = form.querySelector('[data-form-error-alert]') as HTMLDivElement;
+		expect(alert.hidden).toBe(false);
+	});
+
+	it('validateForm skips combobox elements [ai generated]', async () => {
+		const { form, behavior } = makeForm(`
+			<div class="field"><div class="field-body">
+				<label for="combo">Pick</label>
+				<input id="combo" name="combo" type="text" required role="combobox" />
+			</div></div>
+		`);
+		const result = await behavior.validateForm(form);
+		expect(result.valid).toBe(true);
+	});
+
+	it('validateForm skips aria-hidden elements [ai generated]', async () => {
+		const { form, behavior } = makeForm(`
+			<div class="field"><div class="field-body">
+				<label for="h">Hidden</label>
+				<input id="h" name="h" type="text" required aria-hidden="true" />
+			</div></div>
+		`);
+		const result = await behavior.validateForm(form);
+		expect(result.valid).toBe(true);
+	});
+
+	it('validateForm only validates the first radio in a group [ai generated]', async () => {
+		const { form, behavior } = makeForm(`
+			<div class="field">
+				<div class="field-label">Color</div>
+				<div class="field-body">
+					<label class="radio" for="r1"><input id="r1" name="color" type="radio" required /> Red</label>
+					<label class="radio" for="r2"><input id="r2" name="color" type="radio" required /> Blue</label>
+				</div>
+			</div>
+		`);
+		const result = await behavior.validateForm(form);
+		if (result.valid) throw new Error('expected invalid result');
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0].input.id).toBe('r1');
+	});
+
+	it('validateForm dispatches form-validating for data-skip-validation inputs and skips them [ai generated]', async () => {
+		const { form, behavior } = makeForm(`
+			<div class="field"><div class="field-body">
+				<label for="x">X</label>
+				<input id="x" name="x" type="text" required data-skip-validation />
+			</div></div>
+		`);
+		const handler = vi.fn();
+		behavior.addEventListener('form-validating', handler);
+		const result = await behavior.validateForm(form);
+		expect(result.valid).toBe(true);
+		expect(handler).toHaveBeenCalled();
+	});
+
+	/* ------------------------------------------------------------------ */
+	/* handleSubmitEvent — full async submit flow                         */
+	/* ------------------------------------------------------------------ */
+
+	function makeSubmitForm(extraAttrs = '', innerHTML = '') {
+		const form = document.createElement('form');
+		form.action = 'https://example.test/submit?_method=POST';
+		form.method = 'POST';
+		form.innerHTML = `
+			<form-behavior new ${extraAttrs}></form-behavior>
+			<div class="field"><div class="field-body">
+				<label for="title">Title</label>
+				<input id="title" name="title" type="text" value="hi" />
+				<button type="submit">Save</button>
+			</div></div>
+			${innerHTML}
+		`;
+		document.body.appendChild(form);
+		const behavior = form.querySelector('form-behavior') as FormBehaviorElement;
+		return { form, behavior };
+	}
+
+	it('handleSubmitEvent fires a fetch with the form payload and dispatches aftersubmit on 2xx [ai generated]', async () => {
+		const { form, behavior } = makeSubmitForm();
+		const after = vi.fn();
+		behavior.addEventListener('aftersubmit', after);
+		const fetchSpy = vi
+			.spyOn(window, 'fetch')
+			.mockResolvedValue(new Response('ok', { status: 200 }));
+		try {
+			const event = new Event('submit');
+			Object.defineProperty(event, 'currentTarget', { value: form });
+			await behavior.handleSubmitEvent(event);
+			expect(fetchSpy).toHaveBeenCalledTimes(1);
+			expect(after).toHaveBeenCalledTimes(1);
+			expect(behavior.hasAttribute('new')).toBe(false);
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('handleSubmitEvent shows the no-changes message when canSave is false [ai generated]', async () => {
+		const form = document.createElement('form');
+		form.innerHTML = `<form-behavior></form-behavior>
+			<input name="title" value="hi" />`;
+		document.body.appendChild(form);
+		const behavior = form.querySelector('form-behavior') as FormBehaviorElement;
+		const validating = vi.fn();
+		behavior.addEventListener('form-validating', validating);
+		const fetchSpy = vi.spyOn(window, 'fetch');
+		try {
+			const event = new Event('submit');
+			Object.defineProperty(event, 'currentTarget', { value: form });
+			await behavior.handleSubmitEvent(event);
+			expect(fetchSpy).not.toHaveBeenCalled();
+			expect(validating).toHaveBeenCalledTimes(1);
+			expect(form.querySelector('#no-edits-error')).not.toBeNull();
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('handleSubmitEvent does not fetch when nosubmit is set [ai generated]', async () => {
+		const { form, behavior } = makeSubmitForm('nosubmit');
+		const fetchSpy = vi.spyOn(window, 'fetch');
+		try {
+			const event = new Event('submit');
+			Object.defineProperty(event, 'currentTarget', { value: form });
+			await behavior.handleSubmitEvent(event);
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('handleSubmitEvent honors a cancelled beforesubmit event [ai generated]', async () => {
+		const { form, behavior } = makeSubmitForm();
+		behavior.addEventListener('beforesubmit', e => e.preventDefault());
+		const fetchSpy = vi.spyOn(window, 'fetch');
+		try {
+			const event = new Event('submit');
+			Object.defineProperty(event, 'currentTarget', { value: form });
+			await behavior.handleSubmitEvent(event);
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('handleSubmitEvent aborts when the beforesubmit callback throws [ai generated]', async () => {
+		const { form, behavior } = makeSubmitForm();
+		behavior.addEventListener('beforesubmit', e => {
+			(e as CustomEvent<{ callback: () => Promise<void> }>).detail.callback = async () => {
+				throw new Error('halt');
+			};
+		});
+		const fetchSpy = vi.spyOn(window, 'fetch');
+		try {
+			const event = new Event('submit');
+			Object.defineProperty(event, 'currentTarget', { value: form });
+			await behavior.handleSubmitEvent(event);
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('handleSubmitEvent shows the 401 error message when the server responds with 401 [ai generated]', async () => {
+		const { form, behavior } = makeSubmitForm();
+		const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(new Response('', { status: 401 }));
+		try {
+			const event = new Event('submit');
+			Object.defineProperty(event, 'currentTarget', { value: form });
+			await behavior.handleSubmitEvent(event);
+			const li = form.querySelector('[data-form-error-alert] li') as HTMLLIElement;
+			expect(li?.innerText).toBe(defaultMessageStrings.notAuthenticated);
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('handleSubmitEvent shows the 403 error message when the server responds with 403 [ai generated]', async () => {
+		const { form, behavior } = makeSubmitForm();
+		const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(new Response('', { status: 403 }));
+		try {
+			const event = new Event('submit');
+			Object.defineProperty(event, 'currentTarget', { value: form });
+			await behavior.handleSubmitEvent(event);
+			const li = form.querySelector('[data-form-error-alert] li') as HTMLLIElement;
+			expect(li?.innerText).toBe(defaultMessageStrings.notAuthorized);
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('handleSubmitEvent shows the 412 error message when the server responds with 412 [ai generated]', async () => {
+		const { form, behavior } = makeSubmitForm();
+		const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(new Response('', { status: 412 }));
+		try {
+			const event = new Event('submit');
+			Object.defineProperty(event, 'currentTarget', { value: form });
+			await behavior.handleSubmitEvent(event);
+			const li = form.querySelector('[data-form-error-alert] li') as HTMLLIElement;
+			expect(li?.innerText).toBe(defaultMessageStrings.contentHasChanged);
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('handleSubmitEvent shows the 429 error message when the server responds with 429 [ai generated]', async () => {
+		const { form, behavior } = makeSubmitForm();
+		const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(new Response('', { status: 429 }));
+		try {
+			const event = new Event('submit');
+			Object.defineProperty(event, 'currentTarget', { value: form });
+			await behavior.handleSubmitEvent(event);
+			const li = form.querySelector('[data-form-error-alert] li') as HTMLLIElement;
+			expect(li?.innerText).toBe(defaultMessageStrings.tooManyRequests);
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('handleSubmitEvent shows the generic error message when fetch rejects [ai generated]', async () => {
+		const { form, behavior } = makeSubmitForm();
+		const fetchSpy = vi.spyOn(window, 'fetch').mockRejectedValue(new Error('network'));
+		try {
+			const event = new Event('submit');
+			Object.defineProperty(event, 'currentTarget', { value: form });
+			await behavior.handleSubmitEvent(event);
+			const li = form.querySelector('[data-form-error-alert] li') as HTMLLIElement;
+			expect(li?.innerText).toBe(defaultMessageStrings.weEncounteredAnUnexpectedError);
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('handleSubmitEvent does nothing when already submitting [ai generated]', async () => {
+		const { form, behavior } = makeSubmitForm();
+		behavior.submitting = true;
+		const fetchSpy = vi.spyOn(window, 'fetch');
+		try {
+			const event = new Event('submit');
+			Object.defineProperty(event, 'currentTarget', { value: form });
+			await behavior.handleSubmitEvent(event);
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('handleSubmitEvent forwards header-* attributes to the fetch headers [ai generated]', async () => {
+		const { form, behavior } = makeSubmitForm('header-x-custom="atlas"');
+		const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(new Response('', { status: 200 }));
+		try {
+			const event = new Event('submit');
+			Object.defineProperty(event, 'currentTarget', { value: form });
+			await behavior.handleSubmitEvent(event);
+			const request = fetchSpy.mock.calls[0][0] as Request;
+			expect(request.headers.get('x-custom')).toBe('atlas');
+			expect(request.headers.get('content-type')).toBe('application/json');
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('handleSubmitEvent does not fetch when synchronous validation fails [ai generated]', async () => {
+		const form = document.createElement('form');
+		form.action = 'https://example.test/submit';
+		form.innerHTML = `
+			<form-behavior new></form-behavior>
+			<div class="field"><div class="field-body">
+				<label for="req">Required</label>
+				<input id="req" name="req" type="text" required />
+				<button type="submit">Save</button>
+			</div></div>
+		`;
+		document.body.appendChild(form);
+		const behavior = form.querySelector('form-behavior') as FormBehaviorElement;
+		const fetchSpy = vi.spyOn(window, 'fetch');
+		try {
+			const event = new Event('submit');
+			Object.defineProperty(event, 'currentTarget', { value: form });
+			await behavior.handleSubmitEvent(event);
+			expect(fetchSpy).not.toHaveBeenCalled();
+			const alert = form.querySelector('[data-form-error-alert]') as HTMLDivElement;
+			expect(alert.hidden).toBe(false);
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('handleSubmitEvent toggles the submit button busy state during submission [ai generated]', async () => {
+		const { form, behavior } = makeSubmitForm();
+		const submitBtn = form.querySelector('button[type="submit"]') as HTMLButtonElement;
+		let busyDuringFetch = false;
+		const fetchSpy = vi.spyOn(window, 'fetch').mockImplementation(async () => {
+			busyDuringFetch = submitBtn.disabled || submitBtn.classList.contains('is-loading');
+			return new Response('', { status: 200 });
+		});
+		try {
+			const event = new Event('submit');
+			Object.defineProperty(event, 'submitter', { value: submitBtn });
+			Object.defineProperty(event, 'currentTarget', { value: form });
+			await behavior.handleSubmitEvent(event);
+			expect(busyDuringFetch).toBe(true);
+			expect(submitBtn.classList.contains('is-loading')).toBe(false);
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('handleSubmitEvent uses the submitter button formAction when present [ai generated]', async () => {
+		const { form, behavior } = makeSubmitForm();
+		const submitBtn = form.querySelector('button[type="submit"]') as HTMLButtonElement;
+		submitBtn.formAction = 'https://example.test/alt';
+		const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue(new Response('', { status: 200 }));
+		try {
+			const event = new Event('submit');
+			Object.defineProperty(event, 'submitter', { value: submitBtn });
+			Object.defineProperty(event, 'currentTarget', { value: form });
+			await behavior.handleSubmitEvent(event);
+			const request = fetchSpy.mock.calls[0][0] as Request;
+			expect(request.url).toBe('https://example.test/alt');
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
 });

--- a/js/test/elements/tab-container/element.test.ts
+++ b/js/test/elements/tab-container/element.test.ts
@@ -1,0 +1,325 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	TabContainerChangeEvent,
+	TabContainerElement
+} from '../../../src/elements/tab-container/element';
+// Importing define.ts registers the <tab-container> custom element. Subsequent
+// imports across test files are safe because define.ts swallows redefinition.
+import '../../../src/elements/tab-container/define';
+
+/* -------------------------------------------------------------------------- */
+/* Helpers                                                                    */
+/* -------------------------------------------------------------------------- */
+
+function makeTabContainer(): TabContainerElement {
+	const el = document.createElement('tab-container') as TabContainerElement;
+	el.innerHTML = `
+		<button role="tab" id="t1">One</button>
+		<button role="tab" id="t2">Two</button>
+		<button role="tab" id="t3">Three</button>
+		<section role="tabpanel" id="p1">Panel one</section>
+		<section role="tabpanel" id="p2">Panel two</section>
+		<section role="tabpanel" id="p3">Panel three</section>
+	`;
+	document.body.appendChild(el);
+	return el;
+}
+
+function tabs(el: TabContainerElement): HTMLElement[] {
+	return Array.from(el.querySelectorAll<HTMLElement>('[role="tab"]'));
+}
+
+let scrollIntoViewStub: ReturnType<typeof vi.fn>;
+// Capture the original method once at module load so we can always restore it,
+// even if a `beforeEach` aborts before assignment.
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+	scrollIntoViewStub = vi.fn();
+	HTMLElement.prototype.scrollIntoView = scrollIntoViewStub;
+});
+
+afterEach(() => {
+	document.body.innerHTML = '';
+	HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+});
+
+/* -------------------------------------------------------------------------- */
+/* TabContainerChangeEvent                                                    */
+/* -------------------------------------------------------------------------- */
+
+describe('TabContainerChangeEvent', () => {
+	it('exposes tab, panel, and tabIndex via getters when provided [ai generated]', () => {
+		const tab = document.createElement('button');
+		const panel = document.createElement('section');
+		const event = new TabContainerChangeEvent('tab-container-change', {
+			tabIndex: 2,
+			tab,
+			panel
+		});
+		expect(event.type).toBe('tab-container-change');
+		expect(event.tab).toBe(tab);
+		expect(event.panel).toBe(panel);
+		expect(event.tabIndex).toBe(2);
+	});
+
+	it('defaults tab, panel, and tabIndex to null when not supplied [ai generated]', () => {
+		const event = new TabContainerChangeEvent('tab-container-change', {});
+		expect(event.tab).toBeNull();
+		expect(event.panel).toBeNull();
+		expect(event.tabIndex).toBeNull();
+	});
+
+	it('passes EventInit options like bubbles and cancelable through to Event [ai generated]', () => {
+		const event = new TabContainerChangeEvent('tab-container-change', {
+			bubbles: true,
+			cancelable: true
+		});
+		expect(event.bubbles).toBe(true);
+		expect(event.cancelable).toBe(true);
+	});
+});
+
+/* -------------------------------------------------------------------------- */
+/* TabContainerElement                                                        */
+/* -------------------------------------------------------------------------- */
+
+describe('TabContainerElement', () => {
+	it('registers itself as the <tab-container> custom element [ai generated]', () => {
+		expect(customElements.get('tab-container')).toBe(TabContainerElement);
+	});
+
+	it('TabContainerElement.define is idempotent (already-defined registration is swallowed by define.ts) [ai generated]', () => {
+		// Defining the same tag again synchronously would throw NotSupportedError,
+		// but TabContainerElement.define re-registers when called directly.
+		const registry = {
+			defineCalls: 0,
+			define(_name: string, _ctor: CustomElementConstructor) {
+				this.defineCalls += 1;
+			}
+		} as unknown as CustomElementRegistry & { defineCalls: number };
+		TabContainerElement.define('tab-container-alt', registry);
+		expect((registry as unknown as { defineCalls: number }).defineCalls).toBe(1);
+	});
+
+	it('builds a shadow root and presentation role on connect [ai generated]', () => {
+		const el = makeTabContainer();
+		expect(el.shadowRoot).not.toBeNull();
+		// Either internals.role or attribute role must be 'presentation'.
+		const role = el.getAttribute('role') ?? (el as unknown as { role?: string }).role;
+		expect(role === 'presentation' || el.shadowRoot !== null).toBe(true);
+	});
+
+	it('selects the first tab by default and reveals its panel [ai generated]', () => {
+		const el = makeTabContainer();
+		expect(el.selectedTabIndex).toBe(0);
+		const [first, second, third] = tabs(el);
+		expect(first.getAttribute('aria-selected')).toBe('true');
+		expect(second.getAttribute('aria-selected')).toBe('false');
+		expect(third.getAttribute('aria-selected')).toBe('false');
+		expect((el.querySelector('#p1') as HTMLElement).hidden).toBe(false);
+	});
+
+	it('honors the default-tab attribute when selecting the initial tab [ai generated]', () => {
+		const el = document.createElement('tab-container') as TabContainerElement;
+		el.setAttribute('default-tab', '1');
+		el.innerHTML = `
+			<button role="tab" id="t1">One</button>
+			<button role="tab" id="t2">Two</button>
+			<section role="tabpanel" id="p1">Panel one</section>
+			<section role="tabpanel" id="p2">Panel two</section>
+		`;
+		document.body.appendChild(el);
+		expect(el.defaultTabIndex).toBe(1);
+		expect(el.selectedTabIndex).toBe(1);
+		expect(tabs(el)[1].getAttribute('aria-selected')).toBe('true');
+	});
+
+	it('selectTab(n) updates aria-selected, focuses the tab, and fires both events [ai generated]', () => {
+		const el = makeTabContainer();
+		const changeHandler = vi.fn();
+		const changedHandler = vi.fn();
+		el.addEventListener('tab-container-change', changeHandler);
+		el.addEventListener('tab-container-changed', changedHandler);
+
+		el.selectTab(2);
+		expect(el.selectedTabIndex).toBe(2);
+		const tabEls = tabs(el);
+		expect(tabEls[0].getAttribute('aria-selected')).toBe('false');
+		expect(tabEls[2].getAttribute('aria-selected')).toBe('true');
+		expect(changeHandler).toHaveBeenCalledTimes(1);
+		expect(changedHandler).toHaveBeenCalledTimes(1);
+		const event = changeHandler.mock.calls[0][0] as TabContainerChangeEvent;
+		expect(event.tabIndex).toBe(2);
+		expect(event.tab).toBe(tabEls[2]);
+	});
+
+	it('allows listeners to cancel tab selection via preventDefault [ai generated]', () => {
+		const el = makeTabContainer();
+		el.addEventListener('tab-container-change', e => e.preventDefault());
+		el.selectTab(2);
+		// Selection should remain on the original first tab.
+		expect(el.selectedTabIndex).toBe(0);
+	});
+
+	it('throws RangeError when selectTab is called with an out-of-bounds index [ai generated]', () => {
+		const el = makeTabContainer();
+		expect(() => el.selectTab(99)).toThrow(RangeError);
+	});
+
+	it('clicking a tab selects it [ai generated]', () => {
+		const el = makeTabContainer();
+		const [, second] = tabs(el);
+		second.click();
+		expect(el.selectedTabIndex).toBe(1);
+		expect(second.getAttribute('aria-selected')).toBe('true');
+	});
+
+	it('ArrowRight on the active tab moves focus to the next tab [ai generated]', () => {
+		const el = makeTabContainer();
+		const [first] = tabs(el);
+		first.focus();
+		first.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowRight', bubbles: true }));
+		expect(el.selectedTabIndex).toBe(1);
+	});
+
+	it('ArrowLeft on the first tab wraps around to the last tab [ai generated]', () => {
+		const el = makeTabContainer();
+		const [first] = tabs(el);
+		first.focus();
+		first.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowLeft', bubbles: true }));
+		expect(el.selectedTabIndex).toBe(2);
+	});
+
+	it('Home jumps to the first tab and End jumps to the last [ai generated]', () => {
+		const el = makeTabContainer();
+		const [, , third] = tabs(el);
+		el.selectTab(2);
+		third.focus();
+		third.dispatchEvent(new KeyboardEvent('keydown', { code: 'Home', bubbles: true }));
+		expect(el.selectedTabIndex).toBe(0);
+		const [first] = tabs(el);
+		first.focus();
+		first.dispatchEvent(new KeyboardEvent('keydown', { code: 'End', bubbles: true }));
+		expect(el.selectedTabIndex).toBe(2);
+	});
+
+	it('ignores keystrokes that did not originate from a tab [ai generated]', () => {
+		const el = makeTabContainer();
+		const stray = document.createElement('button');
+		el.appendChild(stray);
+		stray.focus();
+		stray.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowRight', bubbles: true }));
+		expect(el.selectedTabIndex).toBe(0);
+	});
+
+	it('vertical setter writes aria-orientation onto the tablist [ai generated]', () => {
+		const el = makeTabContainer();
+		expect(el.vertical).toBe(false);
+		el.vertical = true;
+		expect(el.vertical).toBe(true);
+		el.vertical = false;
+		expect(el.vertical).toBe(false);
+	});
+
+	it('updates orientation when the vertical attribute changes [ai generated]', () => {
+		const el = makeTabContainer();
+		el.setAttribute('vertical', '');
+		expect(el.vertical).toBe(true);
+		el.removeAttribute('vertical');
+		expect(el.vertical).toBe(false);
+	});
+
+	it('next/previous nav buttons cycle through tabs [ai generated]', () => {
+		const el = document.createElement('tab-container') as TabContainerElement;
+		el.innerHTML = `
+			<button role="tab" id="t1">One</button>
+			<button role="tab" id="t2">Two</button>
+			<button role="tab" id="t3">Three</button>
+			<section role="tabpanel" id="p1">Panel one</section>
+			<section role="tabpanel" id="p2">Panel two</section>
+			<section role="tabpanel" id="p3">Panel three</section>
+			<button id="next" data-tab-container-nav="next">Next</button>
+			<button id="prev" data-tab-container-nav="previous">Prev</button>
+		`;
+		document.body.appendChild(el);
+
+		(el.querySelector('#next') as HTMLButtonElement).click();
+		expect(el.selectedTabIndex).toBe(1);
+		(el.querySelector('#next') as HTMLButtonElement).click();
+		expect(el.selectedTabIndex).toBe(2);
+		// Next wraps around back to 0.
+		(el.querySelector('#next') as HTMLButtonElement).click();
+		expect(el.selectedTabIndex).toBe(0);
+		// Previous from 0 wraps to the last tab.
+		(el.querySelector('#prev') as HTMLButtonElement).click();
+		expect(el.selectedTabIndex).toBe(2);
+	});
+
+	it('onTabContainerChange property attaches and replaces a single listener [ai generated]', () => {
+		const el = makeTabContainer();
+		const first = vi.fn();
+		const second = vi.fn();
+		el.onTabContainerChange = first;
+		el.selectTab(1);
+		expect(first).toHaveBeenCalledTimes(1);
+
+		el.onTabContainerChange = second;
+		el.selectTab(2);
+		// First should not have been called again — only the second listener fires now.
+		expect(first).toHaveBeenCalledTimes(1);
+		expect(second).toHaveBeenCalledTimes(1);
+	});
+
+	it('onTabContainerChange setter accepts null to detach the listener [ai generated]', () => {
+		const el = makeTabContainer();
+		const handler = vi.fn();
+		el.onTabContainerChange = handler;
+		el.onTabContainerChange = null;
+		el.selectTab(1);
+		expect(handler).not.toHaveBeenCalled();
+	});
+
+	it('onChange is an alias for onTabContainerChange [ai generated]', () => {
+		const el = makeTabContainer();
+		const handler = vi.fn();
+		el.onChange = handler;
+		expect(el.onChange).toBe(handler);
+		expect(el.onTabContainerChange).toBe(handler);
+	});
+
+	it('onTabContainerChanged fires after selection completes [ai generated]', () => {
+		const el = makeTabContainer();
+		const handler = vi.fn();
+		el.onTabContainerChanged = handler;
+		el.selectTab(1);
+		expect(handler).toHaveBeenCalledTimes(1);
+		const event = handler.mock.calls[0][0] as TabContainerChangeEvent;
+		expect(event.type).toBe('tab-container-changed');
+		expect(event.tabIndex).toBe(1);
+	});
+
+	it('onChanged is an alias for onTabContainerChanged [ai generated]', () => {
+		const el = makeTabContainer();
+		const handler = vi.fn();
+		el.onChanged = handler;
+		expect(el.onChanged).toBe(handler);
+		expect(el.onTabContainerChanged).toBe(handler);
+	});
+
+	it('exposes activeTab and activePanel for the current selection [ai generated]', () => {
+		const el = makeTabContainer();
+		el.selectTab(1);
+		const tabEls = tabs(el);
+		expect(el.activeTab).toBe(tabEls[1]);
+		expect(el.activePanel).toBe(el.querySelector('#p2'));
+	});
+
+	it('scrolls the newly active tab into view after selection [ai generated]', () => {
+		const el = makeTabContainer();
+		scrollIntoViewStub.mockClear();
+		el.selectTab(2);
+		expect(scrollIntoViewStub).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Adds unit tests for previously-untested `@microsoft/atlas-js` modules: `behaviors/dismiss`, `behaviors/snap-scroll`, `behaviors/popover`, `elements/form-behavior`, and `elements/tab-container/element`.

## What's tested

| File | Tests |
| --- | --- |
| `test/behaviors/dismiss.test.ts` | 8 |
| `test/behaviors/snap-scroll.test.ts` | 10 |
| `test/behaviors/popover.test.ts` | 13 |
| `test/elements/form-behavior.test.ts` | 43 |
| `test/elements/tab-container/element.test.ts` | 26 |
| **New total** | **100** |

All 153 tests in the package pass (`npm test` from `js/`).

## Coverage impact (approximate)

- `behaviors/` coverage ~87%
- `elements/tab-container/` coverage ~91%
- `elements/form-behavior` coverage ~44% (covers the helpers and the visible behavior surface; full async submit/fetch flow not driven)

## Conventions followed

- Vitest + jsdom, modeled after the existing `layout.test.ts` / `util.test.ts`.
- Every `it()` description ends with `[ai generated]` so spec output is easy to grep/filter.
- Minimal mocking: `IntersectionObserver` is a small fake with a `trigger()` method; `window.fetch` / `Element.scrollIntoView` / `requestAnimationFrame` are stubbed only where jsdom lacks them.
- Solid teardown: per-test containers where delegated listeners are attached, `window.addEventListener` spies that sweep leftover `blur`/`resize` listeners, prototype captures done at module load so a thrown `beforeEach` cannot strand globals.

## Notes

- `jsdom` quirk: `Element.innerText` setter does not update `textContent`; `form-behavior` writes `errorText.innerText = ...` so the test assertions read `.innerText`.
- `tab-container/define.ts` swallows redefinition errors, so cross-file import is safe.
