### PR TITLE
Switch viewName to storageKey for createLayoutState

### DIFF
--- a/.changeset/layout-state-storage-key.md
+++ b/.changeset/layout-state-storage-key.md
@@ -2,4 +2,4 @@
 '@microsoft/atlas-js': patch
 ---
 
-Replace `viewName` with `storageKey` on `createLayoutState`. The option now serves a single concept — the bucket key under `atlas-layout-preferences` and the value surfaced in `LayoutCallbackEvent.storageKey` — so distinct pages can share persisted state by passing the same `storageKey`. The previous `viewName` option (and the `LayoutCallbackEvent.viewName` field) is removed; callers should rename `viewName` to `storageKey`. `storageKey` defaults to `'default'`, accepts a static string or a getter, and coerces unsafe object keys (`__proto__`, `prototype`, `constructor`) to `'default'`.
+Rename `viewName` to `storageKey` on `createLayoutState` (and on `LayoutCallbackEvent`).

--- a/.changeset/layout-state-storage-key.md
+++ b/.changeset/layout-state-storage-key.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': patch
+---
+
+Add a `storageKey` option to `createLayoutState` so distinct views can share persisted `layout-*` state while keeping their own `viewName` identity in callback events. `storageKey` defaults to `viewName`, so existing callers are unaffected. Accepts a static string or a getter, matching the `viewName` accessor pattern.

--- a/.changeset/layout-state-storage-key.md
+++ b/.changeset/layout-state-storage-key.md
@@ -2,4 +2,4 @@
 '@microsoft/atlas-js': patch
 ---
 
-Add a `storageKey` option to `createLayoutState` so distinct views can share persisted `layout-*` state while keeping their own `viewName` identity in callback events. `storageKey` defaults to `viewName`, so existing callers are unaffected. Accepts a static string or a getter, matching the `viewName` accessor pattern.
+Replace `viewName` with `storageKey` on `createLayoutState`. The option now serves a single concept — the bucket key under `atlas-layout-preferences` and the value surfaced in `LayoutCallbackEvent.storageKey` — so distinct pages can share persisted state by passing the same `storageKey`. The previous `viewName` option (and the `LayoutCallbackEvent.viewName` field) is removed; callers should rename `viewName` to `storageKey`. `storageKey` defaults to `'default'`, accepts a static string or a getter, and coerces unsafe object keys (`__proto__`, `prototype`, `constructor`) to `'default'`.

--- a/integration/tests/layout.spec.ts
+++ b/integration/tests/layout.spec.ts
@@ -640,7 +640,7 @@ test('layout-menu-collapsed state persists across a page reload @desktop', async
 	await expect(html).not.toHaveClass(/\blayout-menu-collapsed\b/);
 
 	// Collapse the menu. createLayoutState should persist this to
-	// localStorage under the 'atlas-layout-page' view name.
+	// localStorage under the 'atlas-layout-page' storage key.
 	await page.locator(toggleMenuCollapsedSelector).click();
 	await expect(html).toHaveClass(/\blayout-menu-collapsed\b/);
 

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -58,15 +58,14 @@ export function initLayout() {
 
 /**
  * Observes `layout-*` class changes on a root element (default: `<html>`) and
- * persists them via a Storage backend, bucketed per `storageKey` (which
- * defaults to `viewName`). Consumers `subscribe()` to specific class
- * transitions; a new subscription replays immediately if the current state
- * already matches.
+ * persists them via a Storage backend, bucketed per `storageKey` (defaults
+ * to `'default'`). Consumers `subscribe()` to specific class transitions; a
+ * new subscription replays immediately if the current state already matches.
  *
- * `viewName` is the view's identity — it appears in `LayoutCallbackEvent`s
- * and is the default bucket key. `storageKey` overrides only the bucket,
- * letting two views with different `viewName`s share persisted state while
- * each keeps its own identity in event payloads.
+ * `storageKey` identifies the bucket under the shared `atlas-layout-preferences`
+ * storage entry and is surfaced in `LayoutCallbackEvent`s. Distinct pages
+ * with different keys read and write separate buckets; pages that should
+ * share persisted state simply pass the same `storageKey`.
  *
  * Restoration and the `MutationObserver` are wired synchronously inside the
  * factory — by return time the instance is live. Subscriber callbacks are
@@ -92,7 +91,7 @@ export type LayoutClassWhen = 'added' | 'removed' | 'always';
 export interface LayoutCallbackEvent {
 	className: string;
 	isApplied: boolean;
-	viewName: string;
+	storageKey: string;
 }
 
 export type LayoutCallback = (event: LayoutCallbackEvent) => void;
@@ -111,20 +110,14 @@ export interface LayoutStateOptions {
 	/** Storage backend matching `getItem`/`setItem`. Defaults to `localStorage`. */
 	storage?: Pick<Storage, 'getItem' | 'setItem'>;
 	/**
-	 * Identity of the current view, surfaced in `LayoutCallbackEvent.viewName`.
-	 * May be a static string or a getter that is called every time the view
-	 * name is needed — the function variant lets a single instance follow a
-	 * dynamically changing "current view" without being recreated. Also used
-	 * as the default `storageKey` when none is provided.
-	 */
-	viewName?: string | (() => string);
-	/**
-	 * Bucket key under the `atlas-layout-preferences` storage entry. Defaults
-	 * to `viewName`. Pass an explicit `storageKey` when distinct views (with
-	 * different `viewName`s) should share persisted `layout-*` state — e.g.
-	 * a "docs article" and "docs landing" template both restoring the same
-	 * sidebar-collapsed preference. Like `viewName`, accepts a getter for
-	 * dynamic resolution.
+	 * Bucket key under the `atlas-layout-preferences` storage entry, and the
+	 * identifier surfaced in `LayoutCallbackEvent.storageKey`. Pages with
+	 * different `storageKey`s persist independently; pages that should share
+	 * persisted state — e.g. a "docs article" and "docs landing" template
+	 * both restoring the same sidebar-collapsed preference — pass the same
+	 * `storageKey`. May be a static string or a getter called every time the
+	 * key is needed, letting a single instance follow a dynamically changing
+	 * key without being recreated. Defaults to `'default'`.
 	 */
 	storageKey?: string | (() => string);
 	/**
@@ -183,8 +176,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 	const {
 		root: targetRoot = document.documentElement,
 		storage = window.localStorage,
-		viewName: viewNameOption = 'default',
-		storageKey: storageKeyOption,
+		storageKey: storageKeyOption = 'default',
 		deferCallbacksUntil = Promise.resolve(),
 		useViewTransitionOnRestore = false
 	} = options;
@@ -199,21 +191,9 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		return raw === '__proto__' || raw === 'prototype' || raw === 'constructor' ? 'default' : raw;
 	}
 
-	// Resolve the view name on demand so consumers can pass a getter and have
-	// each persistence / dispatch call see the current value. Unsafe object
-	// keys are coerced to 'default' to keep storage writes prototype-safe.
-	function getViewName(): string {
-		const raw = typeof viewNameOption === 'function' ? viewNameOption() : viewNameOption;
-		return sanitizeKey(raw);
-	}
-
-	// Resolve the storage bucket on demand. Falls back to the resolved
-	// viewName when no explicit storageKey was supplied, preserving the
-	// previous `{ [viewName]: ... }` storage shape for existing callers.
+	// Resolve the storage bucket on demand so consumers can pass a getter
+	// and have each persistence / dispatch call see the current value.
 	function getStorageKey(): string {
-		if (storageKeyOption === undefined) {
-			return getViewName();
-		}
 		const raw = typeof storageKeyOption === 'function' ? storageKeyOption() : storageKeyOption;
 		return sanitizeKey(raw);
 	}
@@ -398,14 +378,14 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 
 	function fireMatching(className: string, applied: boolean): void {
 		// Resolve once per fire so every event in this batch carries the same
-		// viewName as the storage write that just happened.
-		const eventViewName = getViewName();
+		// storageKey as the storage write that just happened.
+		const eventStorageKey = getStorageKey();
 		for (const sub of subscriptions) {
 			if (sub.className === className && matches(sub, applied)) {
 				const { callback, useViewTransition } = sub;
 				dispatch(() => {
 					startOptionalViewTransition(useViewTransition, () => {
-						callback({ className, isApplied: applied, viewName: eventViewName });
+						callback({ className, isApplied: applied, storageKey: eventStorageKey });
 					});
 				});
 			}
@@ -428,11 +408,11 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 
 		const applied = isClassApplied(className);
 		if (matches(sub, applied)) {
-			const eventViewName = getViewName();
+			const eventStorageKey = getStorageKey();
 			const { useViewTransition } = sub;
 			dispatch(() => {
 				startOptionalViewTransition(useViewTransition, () => {
-					callback({ className, isApplied: applied, viewName: eventViewName });
+					callback({ className, isApplied: applied, storageKey: eventStorageKey });
 				});
 			});
 		}

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -58,9 +58,15 @@ export function initLayout() {
 
 /**
  * Observes `layout-*` class changes on a root element (default: `<html>`) and
- * persists them via a Storage backend, scoped per `viewName`. Consumers
- * `subscribe()` to specific class transitions; a new subscription replays
- * immediately if the current state already matches.
+ * persists them via a Storage backend, bucketed per `storageKey` (which
+ * defaults to `viewName`). Consumers `subscribe()` to specific class
+ * transitions; a new subscription replays immediately if the current state
+ * already matches.
+ *
+ * `viewName` is the view's identity — it appears in `LayoutCallbackEvent`s
+ * and is the default bucket key. `storageKey` overrides only the bucket,
+ * letting two views with different `viewName`s share persisted state while
+ * each keeps its own identity in event payloads.
  *
  * Restoration and the `MutationObserver` are wired synchronously inside the
  * factory — by return time the instance is live. Subscriber callbacks are
@@ -96,7 +102,7 @@ export interface LayoutStateView {
 }
 
 export interface LayoutStatePersisted {
-	[viewName: string]: LayoutStateView;
+	[storageKey: string]: LayoutStateView;
 }
 
 export interface LayoutStateOptions {
@@ -105,12 +111,22 @@ export interface LayoutStateOptions {
 	/** Storage backend matching `getItem`/`setItem`. Defaults to `localStorage`. */
 	storage?: Pick<Storage, 'getItem' | 'setItem'>;
 	/**
-	 * Scope for stored state, e.g. per page template. May be a static string
-	 * or a getter function that is called every time a view name is needed —
-	 * the function variant lets a single instance follow a dynamically
-	 * changing "current view" without being recreated.
+	 * Identity of the current view, surfaced in `LayoutCallbackEvent.viewName`.
+	 * May be a static string or a getter that is called every time the view
+	 * name is needed — the function variant lets a single instance follow a
+	 * dynamically changing "current view" without being recreated. Also used
+	 * as the default `storageKey` when none is provided.
 	 */
 	viewName?: string | (() => string);
+	/**
+	 * Bucket key under the `atlas-layout-preferences` storage entry. Defaults
+	 * to `viewName`. Pass an explicit `storageKey` when distinct views (with
+	 * different `viewName`s) should share persisted `layout-*` state — e.g.
+	 * a "docs article" and "docs landing" template both restoring the same
+	 * sidebar-collapsed preference. Like `viewName`, accepts a getter for
+	 * dynamic resolution.
+	 */
+	storageKey?: string | (() => string);
 	/**
 	 * Subscriber callbacks are queued until this resolves. Defaults to a
 	 * resolved promise (fires on next microtask). Pass `contentLoaded` to
@@ -144,9 +160,9 @@ export interface LayoutStateInstance {
 		callback: LayoutCallback,
 		options?: LayoutSubscribeOptions
 	): () => void;
-	/** Persisted view state for this view name. */
+	/** Persisted layout state for this instance's `storageKey` bucket. */
 	getViewState(): LayoutStateView;
-	/** Persisted state across all view names. */
+	/** Persisted state across all `storageKey` buckets. */
 	getState(): LayoutStatePersisted;
 	/** Stop observing. Subscriptions remain registered. */
 	stop(): void;
@@ -168,6 +184,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		root: targetRoot = document.documentElement,
 		storage = window.localStorage,
 		viewName: viewNameOption = 'default',
+		storageKey: storageKeyOption,
 		deferCallbacksUntil = Promise.resolve(),
 		useViewTransitionOnRestore = false
 	} = options;
@@ -176,12 +193,29 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 	const STORAGE_KEY = 'atlas-layout-preferences';
 	const RESTORED_ATTRIBUTE = 'data-layout-restored';
 
+	// Coerce unsafe object keys to 'default' so prototype-key writes can't
+	// corrupt the persisted state map.
+	function sanitizeKey(raw: string): string {
+		return raw === '__proto__' || raw === 'prototype' || raw === 'constructor' ? 'default' : raw;
+	}
+
 	// Resolve the view name on demand so consumers can pass a getter and have
 	// each persistence / dispatch call see the current value. Unsafe object
 	// keys are coerced to 'default' to keep storage writes prototype-safe.
 	function getViewName(): string {
 		const raw = typeof viewNameOption === 'function' ? viewNameOption() : viewNameOption;
-		return raw === '__proto__' || raw === 'prototype' || raw === 'constructor' ? 'default' : raw;
+		return sanitizeKey(raw);
+	}
+
+	// Resolve the storage bucket on demand. Falls back to the resolved
+	// viewName when no explicit storageKey was supplied, preserving the
+	// previous `{ [viewName]: ... }` storage shape for existing callers.
+	function getStorageKey(): string {
+		if (storageKeyOption === undefined) {
+			return getViewName();
+		}
+		const raw = typeof storageKeyOption === 'function' ? storageKeyOption() : storageKeyOption;
+		return sanitizeKey(raw);
 	}
 
 	const subscriptions = new Set<LayoutSubscription>();
@@ -345,7 +379,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 	}
 
 	function getViewState(): LayoutStateView {
-		return loadState()[getViewName()] ?? {};
+		return loadState()[getStorageKey()] ?? {};
 	}
 
 	function isClassApplied(className: string): boolean {
@@ -431,16 +465,16 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		if (added.length + removed.length === 0) {
 			return;
 		}
-		const currentViewName = getViewName();
+		const currentStorageKey = getStorageKey();
 		const state = loadState();
-		const viewState = state[currentViewName] ?? {};
+		const viewState = state[currentStorageKey] ?? {};
 		for (const c of added) {
 			viewState[c] = true;
 		}
 		for (const c of removed) {
 			viewState[c] = false;
 		}
-		state[currentViewName] = viewState;
+		state[currentStorageKey] = viewState;
 		saveState(state);
 	}
 

--- a/js/test/behaviors/layout.test.ts
+++ b/js/test/behaviors/layout.test.ts
@@ -175,20 +175,20 @@ describe('createLayoutState', () => {
 			const { storage } = createFakeStorage({
 				[STORAGE_KEY]: JSON.stringify(persisted)
 			});
-			const state = track(createLayoutState({ storage, viewName: 'viewA' }));
+			const state = track(createLayoutState({ storage, storageKey: 'viewA' }));
 			expect(state.getState()).toEqual(persisted);
 			expect(state.getViewState()).toEqual({ 'layout-twin': true });
 		});
 
-		it('returns empty view state when this view name has no stored entry [ai generated]', () => {
+		it('returns empty view state when this storage key has no stored entry [ai generated]', () => {
 			const { storage } = createFakeStorage({
 				[STORAGE_KEY]: JSON.stringify({ other: { 'layout-twin': true } })
 			});
-			const state = track(createLayoutState({ storage, viewName: 'mine' }));
+			const state = track(createLayoutState({ storage, storageKey: 'mine' }));
 			expect(state.getViewState()).toEqual({});
 		});
 
-		it('falls back to "default" view name when none is provided [ai generated]', () => {
+		it('falls back to "default" storage key when none is provided [ai generated]', () => {
 			const { storage } = createFakeStorage({
 				[STORAGE_KEY]: JSON.stringify({ default: { 'layout-twin': true } })
 			});
@@ -207,7 +207,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -224,7 +224,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -241,7 +241,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -260,7 +260,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root,
 						storage,
-						viewName: 'v',
+						storageKey: 'v',
 						useViewTransitionOnRestore: true,
 						deferCallbacksUntil: Promise.resolve()
 					})
@@ -304,7 +304,7 @@ describe('createLayoutState', () => {
 						createLayoutState({
 							root,
 							storage,
-							viewName: 'v',
+							storageKey: 'v',
 							useViewTransitionOnRestore: true,
 							deferCallbacksUntil: Promise.resolve()
 						})
@@ -335,7 +335,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -353,7 +353,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -369,7 +369,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -386,7 +386,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -405,7 +405,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -430,7 +430,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'mine',
+					storageKey: 'mine',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -451,7 +451,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -465,7 +465,7 @@ describe('createLayoutState', () => {
 			expect(cb).toHaveBeenCalledWith({
 				className: 'layout-twin',
 				isApplied: true,
-				viewName: 'v'
+				storageKey: 'v'
 			});
 		});
 
@@ -477,7 +477,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -491,7 +491,7 @@ describe('createLayoutState', () => {
 			expect(cb).toHaveBeenCalledWith({
 				className: 'layout-twin',
 				isApplied: false,
-				viewName: 'v'
+				storageKey: 'v'
 			});
 		});
 
@@ -502,7 +502,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -527,7 +527,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -539,7 +539,7 @@ describe('createLayoutState', () => {
 			expect(cb).toHaveBeenCalledWith({
 				className: 'layout-twin',
 				isApplied: true,
-				viewName: 'v'
+				storageKey: 'v'
 			});
 		});
 
@@ -550,7 +550,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -569,7 +569,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -580,7 +580,7 @@ describe('createLayoutState', () => {
 			expect(cb).toHaveBeenCalledWith({
 				className: 'layout-twin',
 				isApplied: true,
-				viewName: 'v'
+				storageKey: 'v'
 			});
 		});
 
@@ -591,7 +591,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -621,7 +621,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: deferPromise
 				})
 			);
@@ -644,7 +644,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root,
 						storage,
-						viewName: 'v',
+						storageKey: 'v',
 						deferCallbacksUntil: Promise.resolve()
 					})
 				);
@@ -668,7 +668,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root,
 						storage,
-						viewName: 'v',
+						storageKey: 'v',
 						deferCallbacksUntil: Promise.resolve()
 					})
 				);
@@ -690,7 +690,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -718,7 +718,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root,
 						storage,
-						viewName: 'v',
+						storageKey: 'v',
 						deferCallbacksUntil: Promise.resolve()
 					})
 				);
@@ -765,7 +765,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root,
 						storage,
-						viewName: 'v',
+						storageKey: 'v',
 						useViewTransitionOnRestore: true,
 						deferCallbacksUntil: Promise.resolve()
 					})
@@ -804,7 +804,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root,
 						storage,
-						viewName: 'v',
+						storageKey: 'v',
 						deferCallbacksUntil: Promise.resolve()
 					})
 				);
@@ -835,7 +835,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root,
 						storage,
-						viewName: 'v',
+						storageKey: 'v',
 						deferCallbacksUntil: Promise.resolve()
 					})
 				);
@@ -871,7 +871,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -915,7 +915,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: deferPromise
 				})
 			);
@@ -931,7 +931,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -946,7 +946,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -962,7 +962,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -979,7 +979,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'v',
+					storageKey: 'v',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -1010,7 +1010,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root,
 						storage: throwingStorage,
-						viewName: 'v',
+						storageKey: 'v',
 						deferCallbacksUntil: Promise.resolve()
 					})
 				).toThrow('storage exploded');
@@ -1031,7 +1031,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root,
 						storage,
-						viewName: 'v',
+						storageKey: 'v',
 						deferCallbacksUntil: Promise.resolve()
 					})
 				);
@@ -1059,7 +1059,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root,
 						storage,
-						viewName: 'v',
+						storageKey: 'v',
 						deferCallbacksUntil: Promise.reject(new Error('defer rejected'))
 					})
 				);
@@ -1075,27 +1075,27 @@ describe('createLayoutState', () => {
 		});
 	});
 
-	describe('viewName accessor', () => {
-		it('accepts a function that returns the view name [ai generated]', () => {
+	describe('storageKey accessor', () => {
+		it('accepts a function that returns the storage key [ai generated]', () => {
 			const { storage } = createFakeStorage({
 				[STORAGE_KEY]: JSON.stringify({
 					alpha: { 'layout-twin': true },
 					beta: { 'layout-single': true }
 				})
 			});
-			const state = track(createLayoutState({ storage, viewName: () => 'alpha' }));
+			const state = track(createLayoutState({ storage, storageKey: () => 'alpha' }));
 			expect(state.getViewState()).toEqual({ 'layout-twin': true });
 		});
 
-		it('calls the function each time the view name is needed [ai generated]', async () => {
+		it('calls the function each time the storage key is needed [ai generated]', async () => {
 			const root = createRoot();
 			const { storage, data } = createFakeStorage();
-			let currentView = 'alpha';
+			let currentKey = 'alpha';
 			const state = track(
 				createLayoutState({
 					root,
 					storage,
-					viewName: () => currentView,
+					storageKey: () => currentKey,
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -1104,7 +1104,7 @@ describe('createLayoutState', () => {
 			await flush();
 			expect(state.getViewState()).toEqual({ 'layout-twin': true });
 
-			currentView = 'beta';
+			currentKey = 'beta';
 			root.classList.add('layout-single');
 			await flush();
 
@@ -1115,15 +1115,15 @@ describe('createLayoutState', () => {
 			expect(state.getViewState()).toEqual({ 'layout-single': true });
 		});
 
-		it('passes the resolved viewName at fire time to subscriber events [ai generated]', async () => {
+		it('passes the resolved storageKey at fire time to subscriber events [ai generated]', async () => {
 			const root = createRoot();
 			const { storage } = createFakeStorage();
-			let currentView = 'alpha';
+			let currentKey = 'alpha';
 			const state = track(
 				createLayoutState({
 					root,
 					storage,
-					viewName: () => currentView,
+					storageKey: () => currentKey,
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -1135,10 +1135,10 @@ describe('createLayoutState', () => {
 			expect(cb).toHaveBeenLastCalledWith({
 				className: 'layout-twin',
 				isApplied: true,
-				viewName: 'alpha'
+				storageKey: 'alpha'
 			});
 
-			currentView = 'beta';
+			currentKey = 'beta';
 			root.classList.remove('layout-twin');
 			state.subscribe('layout-twin', 'removed', cb);
 			root.classList.add('layout-twin');
@@ -1147,7 +1147,7 @@ describe('createLayoutState', () => {
 			expect(cb).toHaveBeenLastCalledWith({
 				className: 'layout-twin',
 				isApplied: false,
-				viewName: 'beta'
+				storageKey: 'beta'
 			});
 		});
 
@@ -1158,7 +1158,7 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root,
 					storage,
-					viewName: () => '__proto__',
+					storageKey: () => '__proto__',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -1170,14 +1170,14 @@ describe('createLayoutState', () => {
 			});
 		});
 
-		it('still coerces unsafe static viewName strings to "default" [ai generated]', async () => {
+		it('coerces unsafe static storageKey strings to "default" [ai generated]', async () => {
 			const root = createRoot();
 			const { storage, data } = createFakeStorage();
 			const state = track(
 				createLayoutState({
 					root,
 					storage,
-					viewName: 'prototype',
+					storageKey: 'prototype',
 					deferCallbacksUntil: Promise.resolve()
 				})
 			);
@@ -1188,51 +1188,8 @@ describe('createLayoutState', () => {
 				default: { 'layout-twin': true }
 			});
 		});
-	});
 
-	describe('storageKey option', () => {
-		it('restores from storageKey instead of viewName when both are set', () => {
-			const persisted = {
-				'docs-article': { 'layout-single': true },
-				'docs-shared': { 'layout-twin': true }
-			};
-			const { storage } = createFakeStorage({
-				[STORAGE_KEY]: JSON.stringify(persisted)
-			});
-			const root = createRoot();
-			const state = track(
-				createLayoutState({
-					root,
-					storage,
-					viewName: 'docs-article',
-					storageKey: 'docs-shared'
-				})
-			);
-			expect(state.getViewState()).toEqual({ 'layout-twin': true });
-			expect(root.classList.contains('layout-twin')).toBe(true);
-			expect(root.classList.contains('layout-single')).toBe(false);
-		});
-
-		it('persists mutations to storageKey, not viewName', async () => {
-			const root = createRoot();
-			const { storage, data } = createFakeStorage();
-			track(
-				createLayoutState({
-					root,
-					storage,
-					viewName: 'docs-article',
-					storageKey: 'docs-shared',
-					deferCallbacksUntil: Promise.resolve()
-				})
-			);
-			root.classList.add('layout-menu-collapsed');
-			await flush();
-			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
-				'docs-shared': { 'layout-menu-collapsed': true }
-			});
-		});
-
-		it('lets two instances with different viewNames share the same storageKey bucket', async () => {
+		it('lets two instances with the same storageKey share persisted state [ai generated]', async () => {
 			const rootA = createRoot();
 			const rootB = createRoot();
 			const { storage, data } = createFakeStorage();
@@ -1241,7 +1198,6 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root: rootA,
 					storage,
-					viewName: 'docs-article',
 					storageKey: 'docs-shared',
 					deferCallbacksUntil: Promise.resolve()
 				})
@@ -1257,7 +1213,6 @@ describe('createLayoutState', () => {
 				createLayoutState({
 					root: rootB,
 					storage,
-					viewName: 'docs-landing',
 					storageKey: 'docs-shared',
 					deferCallbacksUntil: Promise.resolve()
 				})
@@ -1266,163 +1221,6 @@ describe('createLayoutState', () => {
 			expect(rootB.classList.contains('layout-menu-collapsed')).toBe(true);
 			expect(instanceA.getViewState()).toEqual({ 'layout-menu-collapsed': true });
 			expect(instanceB.getViewState()).toEqual({ 'layout-menu-collapsed': true });
-		});
-
-		it('keeps viewName in subscriber event payloads, not storageKey', async () => {
-			const root = createRoot();
-			const { storage } = createFakeStorage();
-			const state = track(
-				createLayoutState({
-					root,
-					storage,
-					viewName: 'docs-article',
-					storageKey: 'docs-shared',
-					deferCallbacksUntil: Promise.resolve()
-				})
-			);
-			const cb = vi.fn();
-			state.subscribe('layout-twin', 'added', cb);
-
-			root.classList.add('layout-twin');
-			await flush();
-			expect(cb).toHaveBeenLastCalledWith({
-				className: 'layout-twin',
-				isApplied: true,
-				viewName: 'docs-article'
-			});
-		});
-
-		it('falls back to viewName when storageKey is omitted (default)', async () => {
-			const root = createRoot();
-			const { storage, data } = createFakeStorage();
-			track(
-				createLayoutState({
-					root,
-					storage,
-					viewName: 'solo',
-					deferCallbacksUntil: Promise.resolve()
-				})
-			);
-			root.classList.add('layout-twin');
-			await flush();
-			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
-				solo: { 'layout-twin': true }
-			});
-		});
-
-		it('accepts a function that returns the storage key', () => {
-			const persisted = {
-				alpha: { 'layout-single': true },
-				beta: { 'layout-twin': true }
-			};
-			const { storage } = createFakeStorage({
-				[STORAGE_KEY]: JSON.stringify(persisted)
-			});
-			const root = createRoot();
-			const state = track(
-				createLayoutState({
-					root,
-					storage,
-					viewName: 'view-x',
-					storageKey: () => 'beta'
-				})
-			);
-			expect(state.getViewState()).toEqual({ 'layout-twin': true });
-			expect(root.classList.contains('layout-twin')).toBe(true);
-		});
-
-		it('calls the storageKey function each time the bucket is needed', async () => {
-			const root = createRoot();
-			const { storage, data } = createFakeStorage();
-			let currentKey = 'bucket-a';
-			const state = track(
-				createLayoutState({
-					root,
-					storage,
-					viewName: 'static-view',
-					storageKey: () => currentKey,
-					deferCallbacksUntil: Promise.resolve()
-				})
-			);
-
-			root.classList.add('layout-twin');
-			await flush();
-			expect(state.getViewState()).toEqual({ 'layout-twin': true });
-
-			currentKey = 'bucket-b';
-			root.classList.add('layout-single');
-			await flush();
-
-			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
-				'bucket-a': { 'layout-twin': true },
-				'bucket-b': { 'layout-single': true }
-			});
-			expect(state.getViewState()).toEqual({
-				'layout-single': true
-			});
-		});
-
-		it('coerces unsafe storageKey strings to "default"', async () => {
-			const root = createRoot();
-			const { storage, data } = createFakeStorage();
-			track(
-				createLayoutState({
-					root,
-					storage,
-					viewName: 'safe-view',
-					storageKey: '__proto__',
-					deferCallbacksUntil: Promise.resolve()
-				})
-			);
-			root.classList.add('layout-twin');
-			await flush();
-			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
-				default: { 'layout-twin': true }
-			});
-		});
-
-		it('coerces unsafe keys returned by the storageKey function to "default"', async () => {
-			const root = createRoot();
-			const { storage, data } = createFakeStorage();
-			track(
-				createLayoutState({
-					root,
-					storage,
-					viewName: 'safe-view',
-					storageKey: () => 'constructor',
-					deferCallbacksUntil: Promise.resolve()
-				})
-			);
-			root.classList.add('layout-twin');
-			await flush();
-			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
-				default: { 'layout-twin': true }
-			});
-		});
-
-		it('does not write to viewName bucket when storageKey is set', async () => {
-			const root = createRoot();
-			const { storage, data } = createFakeStorage({
-				[STORAGE_KEY]: JSON.stringify({
-					'old-private': { 'layout-single': true }
-				})
-			});
-			track(
-				createLayoutState({
-					root,
-					storage,
-					viewName: 'old-private',
-					storageKey: 'shared',
-					deferCallbacksUntil: Promise.resolve()
-				})
-			);
-			root.classList.add('layout-twin');
-			await flush();
-
-			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
-				'old-private': { 'layout-single': true },
-				shared: { 'layout-twin': true }
-			});
 		});
 	});
 });

--- a/js/test/behaviors/layout.test.ts
+++ b/js/test/behaviors/layout.test.ts
@@ -1189,4 +1189,240 @@ describe('createLayoutState', () => {
 			});
 		});
 	});
+
+	describe('storageKey option', () => {
+		it('restores from storageKey instead of viewName when both are set', () => {
+			const persisted = {
+				'docs-article': { 'layout-single': true },
+				'docs-shared': { 'layout-twin': true }
+			};
+			const { storage } = createFakeStorage({
+				[STORAGE_KEY]: JSON.stringify(persisted)
+			});
+			const root = createRoot();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'docs-article',
+					storageKey: 'docs-shared'
+				})
+			);
+			expect(state.getViewState()).toEqual({ 'layout-twin': true });
+			expect(root.classList.contains('layout-twin')).toBe(true);
+			expect(root.classList.contains('layout-single')).toBe(false);
+		});
+
+		it('persists mutations to storageKey, not viewName', async () => {
+			const root = createRoot();
+			const { storage, data } = createFakeStorage();
+			track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'docs-article',
+					storageKey: 'docs-shared',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			root.classList.add('layout-menu-collapsed');
+			await flush();
+			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
+				'docs-shared': { 'layout-menu-collapsed': true }
+			});
+		});
+
+		it('lets two instances with different viewNames share the same storageKey bucket', async () => {
+			const rootA = createRoot();
+			const rootB = createRoot();
+			const { storage, data } = createFakeStorage();
+
+			const instanceA = track(
+				createLayoutState({
+					root: rootA,
+					storage,
+					viewName: 'docs-article',
+					storageKey: 'docs-shared',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			rootA.classList.add('layout-menu-collapsed');
+			await flush();
+
+			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
+				'docs-shared': { 'layout-menu-collapsed': true }
+			});
+
+			const instanceB = track(
+				createLayoutState({
+					root: rootB,
+					storage,
+					viewName: 'docs-landing',
+					storageKey: 'docs-shared',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+
+			expect(rootB.classList.contains('layout-menu-collapsed')).toBe(true);
+			expect(instanceA.getViewState()).toEqual({ 'layout-menu-collapsed': true });
+			expect(instanceB.getViewState()).toEqual({ 'layout-menu-collapsed': true });
+		});
+
+		it('keeps viewName in subscriber event payloads, not storageKey', async () => {
+			const root = createRoot();
+			const { storage } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'docs-article',
+					storageKey: 'docs-shared',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			const cb = vi.fn();
+			state.subscribe('layout-twin', 'added', cb);
+
+			root.classList.add('layout-twin');
+			await flush();
+			expect(cb).toHaveBeenLastCalledWith({
+				className: 'layout-twin',
+				isApplied: true,
+				viewName: 'docs-article'
+			});
+		});
+
+		it('falls back to viewName when storageKey is omitted (default)', async () => {
+			const root = createRoot();
+			const { storage, data } = createFakeStorage();
+			track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'solo',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			root.classList.add('layout-twin');
+			await flush();
+			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
+				solo: { 'layout-twin': true }
+			});
+		});
+
+		it('accepts a function that returns the storage key', () => {
+			const persisted = {
+				alpha: { 'layout-single': true },
+				beta: { 'layout-twin': true }
+			};
+			const { storage } = createFakeStorage({
+				[STORAGE_KEY]: JSON.stringify(persisted)
+			});
+			const root = createRoot();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'view-x',
+					storageKey: () => 'beta'
+				})
+			);
+			expect(state.getViewState()).toEqual({ 'layout-twin': true });
+			expect(root.classList.contains('layout-twin')).toBe(true);
+		});
+
+		it('calls the storageKey function each time the bucket is needed', async () => {
+			const root = createRoot();
+			const { storage, data } = createFakeStorage();
+			let currentKey = 'bucket-a';
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'static-view',
+					storageKey: () => currentKey,
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+
+			root.classList.add('layout-twin');
+			await flush();
+			expect(state.getViewState()).toEqual({ 'layout-twin': true });
+
+			currentKey = 'bucket-b';
+			root.classList.add('layout-single');
+			await flush();
+
+			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
+				'bucket-a': { 'layout-twin': true },
+				'bucket-b': { 'layout-single': true }
+			});
+			expect(state.getViewState()).toEqual({
+				'layout-single': true
+			});
+		});
+
+		it('coerces unsafe storageKey strings to "default"', async () => {
+			const root = createRoot();
+			const { storage, data } = createFakeStorage();
+			track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'safe-view',
+					storageKey: '__proto__',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			root.classList.add('layout-twin');
+			await flush();
+			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
+				default: { 'layout-twin': true }
+			});
+		});
+
+		it('coerces unsafe keys returned by the storageKey function to "default"', async () => {
+			const root = createRoot();
+			const { storage, data } = createFakeStorage();
+			track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'safe-view',
+					storageKey: () => 'constructor',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			root.classList.add('layout-twin');
+			await flush();
+			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
+				default: { 'layout-twin': true }
+			});
+		});
+
+		it('does not write to viewName bucket when storageKey is set', async () => {
+			const root = createRoot();
+			const { storage, data } = createFakeStorage({
+				[STORAGE_KEY]: JSON.stringify({
+					'old-private': { 'layout-single': true }
+				})
+			});
+			track(
+				createLayoutState({
+					root,
+					storage,
+					viewName: 'old-private',
+					storageKey: 'shared',
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			root.classList.add('layout-twin');
+			await flush();
+
+			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
+				'old-private': { 'layout-single': true },
+				shared: { 'layout-twin': true }
+			});
+		});
+	});
 });

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -6,7 +6,7 @@ classType: Component
 classPrefixes:
   - layout
 hero: true
-layoutViewName: atlas-layout-page
+layoutStorageKey: atlas-layout-page
 ---
 
 # Layout
@@ -493,7 +493,7 @@ Import `createLayoutState` from `@microsoft/atlas-js` and call it once per page 
 
 ```typescript
 const layoutState = createLayoutState({
-	viewName: 'my-view-name',
+	storageKey: 'my-storage-key',
 	useViewTransitionOnRestore: true
 });
 
@@ -513,18 +513,17 @@ document.documentElement.classList.toggle('layout-menu-collapsed');
 unsubscribe();
 ```
 
-The `viewName` option scopes persisted state — pages with different `viewName`s read and write separate `localStorage` buckets, so a layout toggled on one page doesn't bleed into another. Pass a function (`viewName: () => currentView`) to follow a runtime-varying view name without recreating the instance.
+The `storageKey` option scopes persisted state — pages with different `storageKey`s read and write separate `localStorage` buckets, so a layout toggled on one page doesn't bleed into another. Pass a function (`storageKey: () => currentKey`) to follow a runtime-varying key without recreating the instance. The resolved key is surfaced on `LayoutCallbackEvent.storageKey` so subscribers can disambiguate when one callback handles multiple instances.
 
-When distinct views should _share_ persisted state — e.g. a "docs article" and "docs landing" template both restoring the same sidebar-collapsed preference — pass a `storageKey` that overrides only the persistence bucket. `viewName` stays in `LayoutCallbackEvent.viewName` for telemetry and debugging; the persisted classes live under the shared `storageKey` instead. `storageKey` defaults to `viewName` and also accepts a getter.
+When distinct pages should _share_ persisted state — e.g. a "docs article" and "docs landing" template both restoring the same sidebar-collapsed preference — pass the same `storageKey` from each:
 
 ```typescript
 const layoutState = createLayoutState({
-	viewName: 'docs-article',
 	storageKey: 'docs-shared'
 });
 ```
 
-If you also use the inline restore script below, update the `state[...]` lookup to read from the shared `storageKey` instead of the `viewName`.
+If you also use the inline restore script below, read from the same `storageKey` in the `state[...]` lookup.
 
 Calling `createLayoutState()` from a module bundle restores classes, but **not before first paint** — module scripts run after HTML parse, so the browser briefly renders the original markup layout, causing a visible reflow.
 
@@ -538,7 +537,7 @@ Place this synchronous IIFE in `<head>` before the bundle. It reads the same `lo
 		(function () {
 			try {
 				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
-				var view = state['my-view-name'] || {};
+					var view = state['my-storage-key'] || {};
 				var html = document.documentElement;
 				for (var c in view) {
 					if (view[c]) html.classList.add(c);

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -515,6 +515,17 @@ unsubscribe();
 
 The `viewName` option scopes persisted state — pages with different `viewName`s read and write separate `localStorage` buckets, so a layout toggled on one page doesn't bleed into another. Pass a function (`viewName: () => currentView`) to follow a runtime-varying view name without recreating the instance.
 
+When distinct views should _share_ persisted state — e.g. a "docs article" and "docs landing" template both restoring the same sidebar-collapsed preference — pass a `storageKey` that overrides only the persistence bucket. `viewName` stays in `LayoutCallbackEvent.viewName` for telemetry and debugging; the persisted classes live under the shared `storageKey` instead. `storageKey` defaults to `viewName` and also accepts a getter.
+
+```typescript
+const layoutState = createLayoutState({
+	viewName: 'docs-article',
+	storageKey: 'docs-shared'
+});
+```
+
+If you also use the inline restore script below, update the `state[...]` lookup to read from the shared `storageKey` instead of the `viewName`.
+
 Calling `createLayoutState()` from a module bundle restores classes, but **not before first paint** — module scripts run after HTML parse, so the browser briefly renders the original markup layout, causing a visible reflow.
 
 ### Inline restore script in `<head>`

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -537,7 +537,7 @@ Place this synchronous IIFE in `<head>` before the bundle. It reads the same `lo
 		(function () {
 			try {
 				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
-					var view = state['my-storage-key'] || {};
+				var view = state['my-storage-key'] || {};
 				var html = document.documentElement;
 				for (var c in view) {
 					if (view[c]) html.classList.add(c);

--- a/site/src/scaffold/scripts/layout-page.ts
+++ b/site/src/scaffold/scripts/layout-page.ts
@@ -39,7 +39,7 @@ export function initLayoutPageControls() {
 	// restored state, then re-fire on subsequent toggles so click handlers
 	// don't need to update aria attributes themselves.
 	const layoutState = createLayoutState({
-		viewName: 'atlas-layout-page',
+		storageKey: 'atlas-layout-page',
 		useViewTransitionOnRestore: true
 	});
 

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -8,7 +8,7 @@
 		<script>
 			(function () {
 					var s = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
-					var v = s['{{{layoutViewName}}}'] || {};
+					var v = s['{{{layoutStorageKey}}}'] || {};
 					var html = document.documentElement;
 					for (var c in v) {
 						if (v[c]) html.classList.add(c);

--- a/site/src/scaffold/token.html
+++ b/site/src/scaffold/token.html
@@ -12,7 +12,7 @@
 		<script>
 			(function () {
 					var s = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
-					var v = s['{{{layoutViewName}}}'] || {};
+					var v = s['{{{layoutStorageKey}}}'] || {};
 					var html = document.documentElement;
 					for (var c in v) {
 						if (v[c]) html.classList.add(c);


### PR DESCRIPTION
Swtich viewName to storageKey for createLayoutState. The reason for this change is that viewName does not sound quite right. It's possible for different distinct views to track state together. By naming it like this, it should be clearer that the key itself can be passed in any way that makes sense to the developer.

Link: [preview](http://localhost:1111/components/index)

## Testing

1. Visit test link above.
2. Check persistence of containers continue to work,

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [x] Did your pull request add anything to the /js/ folder? Consider adding unit tests.

