### PR TITLE
layout persistence now can exclude specific scenarios

### DIFF
--- a/.changeset/layout-state-excludes.md
+++ b/.changeset/layout-state-excludes.md
@@ -2,4 +2,4 @@
 '@microsoft/atlas-js': minor
 ---
 
-Add `excludesScope` and `excludes` options to `createLayoutState` so views that share a `storageKey` can opt specific `layout-*` classes out of restore, persist, and subscriber dispatch. Rules are persisted under a new `localStorage` entry, `atlas-layout-exclusions`, and honored by the inline pre-paint script.
+Add `excludesKey` and `excludes` options to `createLayoutState` so views that share a `storageKey` can opt specific `layout-*` classes out of restore, persist, and subscriber dispatch. Rules are persisted under a new `localStorage` entry, `atlas-layout-exclusions`, and honored by the inline pre-paint script.

--- a/.changeset/layout-state-excludes.md
+++ b/.changeset/layout-state-excludes.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': minor
+---
+
+Add `excludesScope` and `excludes` options to `createLayoutState` so views that share a `storageKey` can opt specific `layout-*` classes out of restore, persist, and subscriber dispatch. Rules are persisted under a new `localStorage` entry, `atlas-layout-exclusions`, and honored by the inline pre-paint script.

--- a/integration/tests/layout.spec.ts
+++ b/integration/tests/layout.spec.ts
@@ -667,3 +667,58 @@ test('layout-menu-collapsed state persists across a page reload @desktop', async
 
 	await expect(html).toHaveClass(/\blayout-menu-collapsed\b/);
 });
+
+test('createLayoutState seeds atlas-layout-exclusions on init and leaves sibling keys alone @desktop', async ({
+	page
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'Widescreen Chromium',
+		'Skip test if display screen is not widescreen'
+	);
+
+	// Pre-seed the secondary atlas-layout-exclusions entry with two scopes:
+	// the demo's own excludesKey ('atlas-layout-page-view') plus an unrelated
+	// scope. The demo passes `excludes: []`, so on init the bundle's
+	// createLayoutState should overwrite its own scope to `{}` and leave the
+	// unrelated scope untouched — this is the whole point of keying multiple
+	// views' blocklists into a single shared entry.
+	await page.addInitScript(() => {
+		try {
+			localStorage.setItem(
+				'atlas-layout-exclusions',
+				JSON.stringify({
+					'atlas-layout-page-view': { sentinel: true },
+					'untouched-view': { 'layout-menu-collapsed': true }
+				})
+			);
+		} catch {
+			// Storage may be unavailable in some test contexts; the assertion
+			// below will fail loudly rather than silently passing.
+		}
+	});
+
+	await page.goto('/components/layout.html');
+	await page.waitForLoadState('domcontentloaded');
+
+	// Poll until both invariants hold so the test is not racing the bundle's
+	// init work.
+	await expect
+		.poll(() =>
+			page.evaluate(() => {
+				try {
+					const stored = JSON.parse(
+						localStorage.getItem('atlas-layout-exclusions') || '{}'
+					) as Record<string, Record<string, unknown>>;
+					const own = stored['atlas-layout-page-view'];
+					const sibling = stored['untouched-view'];
+					const ownIsEmptyObject =
+						!!own && typeof own === 'object' && Object.keys(own).length === 0;
+					const siblingIntact = !!sibling && sibling['layout-menu-collapsed'] === true;
+					return ownIsEmptyObject && siblingIntact;
+				} catch {
+					return false;
+				}
+			})
+		)
+		.toBe(true);
+});

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -4,14 +4,14 @@ const setLayoutCssVariables = () => {
 	const header = document.querySelector('.layout-body-header');
 	const headerHeight = header?.clientHeight || 0;
 	const headerCssProp = headerHeight ? `${headerHeight}px` : '0px';
-	const headerY = header?.getBoundingClientRect().y || 0; // determine if header is visible, assign visible heights as well
+	const headerY = header?.getBoundingClientRect().y || 0;
 	const visibleHeaderHeight = Math.max(0, headerY + headerHeight);
 	const visibleHeaderCssProp = `${visibleHeaderHeight}px`;
 
 	const footer = document.querySelector('.layout-body-footer');
 	const footerHeight = footer?.clientHeight || 0;
 	const footerCssProp = footerHeight ? `${footerHeight}px` : '0px';
-	const footerY = footer?.getBoundingClientRect().y || 0; // determine if header and footer are visible, assign visible heights as well
+	const footerY = footer?.getBoundingClientRect().y || 0;
 
 	const visibleFooterHeight =
 		footerY < window.innerHeight ? Math.min(window.innerHeight - footerY, footerHeight) : 0;
@@ -46,7 +46,7 @@ export function initLayout() {
 
 	window.addEventListener('DOMContentLoaded', dispatchAtlasLayoutUpdateEvent);
 
-	// determine if header/footer are visible below the top of the viewport - remove with atlas-js 1.13.1
+	// TODO: remove with atlas-js 1.13.1.
 	window.addEventListener('scroll', dispatchAtlasLayoutUpdateEvent, {
 		passive: true
 	});
@@ -57,33 +57,17 @@ export function initLayout() {
 /* -------------------------------------------------------------------------- */
 
 /**
- * Observes `layout-*` class changes on a root element (default: `<html>`) and
- * persists them via a Storage backend, bucketed per `storageKey` (defaults
- * to `'default'`). Consumers `subscribe()` to specific class transitions; a
- * new subscription replays immediately if the current state already matches.
+ * Persists `layout-*` class state per `storageKey`. Instance is live on return.
  *
- * `storageKey` identifies the bucket under the shared `atlas-layout-preferences`
- * storage entry and is surfaced in `LayoutCallbackEvent`s. Distinct pages
- * with different keys read and write separate buckets; pages that should
- * share persisted state simply pass the same `storageKey`.
+ * Subscribers fire on class transitions, with an immediate replay if the current
+ * state already matches. Initial replay waits for `deferCallbacksUntil`.
  *
- * Restoration and the `MutationObserver` are wired synchronously inside the
- * factory — by return time the instance is live. Subscriber callbacks are
- * queued until `deferCallbacksUntil` resolves (default: a resolved promise,
- * so they fire on the next microtask) so they can safely touch the DOM.
+ * `data-layout-restored="true"` is always set after the initial flush — even on
+ * setup or callback failure — so CSS gated on it cannot leave content hidden.
+ * Setup errors are re-thrown.
  *
- * After the initial flush, sets `data-layout-restored="true"` on the root.
- * The attribute is set even if setup throws, `deferCallbacksUntil` rejects,
- * or a queued subscriber throws — CSS rules gated on it (e.g.
- * `display-*-until-layout-restored`) won't permanently hide content. Setup
- * errors are re-thrown.
- *
- * View-transition coordination: requests to wrap restoration or a
- * subscriber callback in `document.startViewTransition` are coordinated per
- * instance to avoid `InvalidStateError` aborts. Subscriber callbacks queued
- * in the same microtask coalesce into a single transition; any request made
- * while a transition is already animating runs synchronously instead of
- * starting (and aborting) another one.
+ * View transitions coalesce same-microtask callbacks and skip while another is
+ * animating, avoiding `InvalidStateError` aborts.
  */
 
 export type LayoutClassWhen = 'added' | 'removed' | 'always';
@@ -105,84 +89,44 @@ export interface LayoutStatePersisted {
 }
 
 export interface LayoutStateOptions {
-	/** Element whose classList is observed and toggled. Defaults to `<html>`. */
+	/** Observed element. Defaults to `<html>`. */
 	root?: HTMLElement;
-	/** Storage backend matching `getItem`/`setItem`. Defaults to `localStorage`. */
+	/** Storage backend. Defaults to `localStorage`. */
 	storage?: Pick<Storage, 'getItem' | 'setItem'>;
 	/**
-	 * Bucket key under the `atlas-layout-preferences` storage entry, and the
-	 * identifier surfaced in `LayoutCallbackEvent.storageKey`. Pages with
-	 * different `storageKey`s persist independently; pages that should share
-	 * persisted state — e.g. a "docs article" and "docs landing" template
-	 * both restoring the same sidebar-collapsed preference — pass the same
-	 * `storageKey`. May be a static string or a getter called every time the
-	 * key is needed, letting a single instance follow a dynamically changing
-	 * key without being recreated. Defaults to `'default'`.
+	 * Bucket key under `atlas-layout-preferences` and the value surfaced as
+	 * `LayoutCallbackEvent.storageKey`. Same key shares state. Getter is
+	 * re-read per operation. Defaults to `'default'`.
 	 */
 	storageKey?: string | (() => string);
 	/**
-	 * Lookup key into the secondary `atlas-layout-exclusions` storage entry.
-	 * The entry's shape is `{ [key]: { [className]: true } }`; if a class
-	 * appears under this key (regardless of value), the instance and the
-	 * inline IIFE both skip it everywhere: restore, persist, AND subscriber
-	 * dispatch (including the immediate replay at `subscribe()` time).
-	 *
-	 * Lets views that share a primary `storageKey` opt into different
-	 * exclusion rules without changing the shared state model. Because the
-	 * rules live in storage rather than in code, they survive SPA
-	 * navigation and direct hard reloads — the inline `<head>` IIFE reads
-	 * the same entry, so pre-paint restore honors them.
-	 *
-	 * Pair with `excludes` to have this instance seed/refresh the entry on
-	 * construction. Omitted entirely → no exclusions consulted (matches the
-	 * original behavior).
-	 *
-	 * May be a static string or a getter called every time the key is
-	 * needed, letting a single instance follow a dynamically changing key
-	 * without being recreated.
+	 * Key into `atlas-layout-exclusions`. Classes listed under this key are
+	 * skipped during restore, persist, subscriber dispatch (including initial
+	 * replay), and the inline pre-paint restore. Getter is re-read per
+	 * operation. Omit to disable exclusion lookup.
 	 */
 	excludesKey?: string | (() => string);
 	/**
-	 * Class names this view excludes from layout persistence. On
-	 * construction the instance writes this list into
-	 * `localStorage['atlas-layout-exclusions'][excludesKey]`, overwriting
-	 * any prior entry for that key. Subsequent restore, persist, and
-	 * subscriber dispatch — plus the inline pre-paint IIFE on the next
-	 * page load — read the persisted entry and skip these classes
-	 * symmetrically.
-	 *
-	 * Requires `excludesKey` to be set; ignored otherwise. Pass an empty
-	 * array to clear the key's blocklist without removing the entry.
-	 * Omitted entirely → the instance does not touch the exclusions entry,
-	 * but still honors whatever is already persisted there.
+	 * Classes to write into `atlas-layout-exclusions[excludesKey]` on
+	 * construction. Requires `excludesKey`. Empty array clears the blocklist;
+	 * omission leaves any persisted entry untouched.
 	 */
 	excludes?: string[];
-	/**
-	 * Subscriber callbacks are queued until this resolves. Defaults to a
-	 * resolved promise (fires on next microtask). Pass `contentLoaded` to
-	 * wait for `DOMContentLoaded`.
-	 */
+	/** Delays initial subscriber callbacks. Defaults to next microtask. */
 	deferCallbacksUntil?: Promise<unknown>;
 	/** Wrap initial restoration in `document.startViewTransition` if available. */
 	useViewTransitionOnRestore?: boolean;
 }
 
 export interface LayoutSubscribeOptions {
-	/**
-	 * Wrap this callback's invocation in `document.startViewTransition` if
-	 * available. Multiple subscriptions firing in the same microtask coalesce
-	 * into a single transition, and the wrap is skipped (callback runs
-	 * synchronously) when another transition is already animating, so
-	 * subscribers can opt in without worrying about aborting each other.
-	 */
+	/** Wrap in a coalesced view transition; runs sync if one is already active. */
 	useViewTransition?: boolean;
 }
 
 export interface LayoutStateInstance {
 	/**
-	 * Register a callback for transitions of `className`. Fires immediately
-	 * if the current state already matches (queued behind
-	 * `deferCallbacksUntil`). Returns an unsubscribe function.
+	 * Subscribe to `className` transitions. Replays once if the current state
+	 * matches (queued behind `deferCallbacksUntil`). Returns an unsubscribe fn.
 	 */
 	subscribe(
 		className: string,
@@ -190,11 +134,11 @@ export interface LayoutStateInstance {
 		callback: LayoutCallback,
 		options?: LayoutSubscribeOptions
 	): () => void;
-	/** Persisted layout state for this instance's `storageKey` bucket. */
+	/** Current bucket state. */
 	getViewState(): LayoutStateView;
-	/** Persisted state across all `storageKey` buckets. */
+	/** All bucket state. */
 	getState(): LayoutStatePersisted;
-	/** Stop observing. Subscriptions remain registered. */
+	/** Stop observing; subscriptions remain registered. */
 	stop(): void;
 }
 
@@ -209,12 +153,7 @@ type DocumentWithViewTransition = Document & {
 	startViewTransition?: (updateCallback: () => void) => unknown;
 };
 
-/**
- * Shape of the secondary `atlas-layout-exclusions` storage entry — a map of
- * key → object whose own keys name the `layout-*` classes blocked under
- * that entry. Value associated with each class is ignored; presence is
- * what matters.
- */
+/** `atlas-layout-exclusions` shape: key → set of excluded `layout-*` class names. */
 export interface LayoutExclusionsPersisted {
 	[key: string]: { [className: string]: true };
 }
@@ -240,21 +179,17 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 	const STORAGE_KEY = 'atlas-layout-preferences';
 	const RESTORED_ATTRIBUTE = 'data-layout-restored';
 
-	// Coerce unsafe object keys to 'default' so prototype-key writes can't
-	// corrupt the persisted state map.
+	// Coerce prototype keys to avoid poisoning the persisted state map.
 	function sanitizeKey(raw: string): string {
 		return sanitizeExclusionsKey(raw);
 	}
 
-	// Resolve the storage bucket on demand so consumers can pass a getter
-	// and have each persistence / dispatch call see the current value.
 	function getStorageKey(): string {
 		const raw = typeof storageKeyOption === 'function' ? storageKeyOption() : storageKeyOption;
 		return sanitizeKey(raw);
 	}
 
-	// Resolve the excludes key on demand. Null means none was configured —
-	// exclusions are skipped entirely.
+	// Null disables exclusions.
 	function getExcludesKey(): string | null {
 		if (excludesKeyOption === undefined) {
 			return null;
@@ -263,11 +198,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		return sanitizeKey(raw);
 	}
 
-	// Seed the persisted exclusions for this instance's key from the
-	// `excludes` option. Runs once at construction so the very next page
-	// load's inline IIFE sees the rules in storage. No-op when either
-	// `excludes` or `excludesKey` is omitted, so consumers can use just
-	// the key to read pre-existing rules.
+	// Seed exclusions so the next pre-paint IIFE sees them.
 	function writeConfiguredExclusions(): void {
 		if (excludesOption === undefined) {
 			return;
@@ -285,7 +216,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 					state = parsed;
 				}
 			} catch {
-				// Treat unparseable storage as empty and overwrite below.
+				// Unparseable: overwrite below.
 			}
 		}
 		const next: { [className: string]: true } = {};
@@ -296,9 +227,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		try {
 			storage.setItem(EXCLUSIONS_STORAGE_KEY, JSON.stringify(state));
 		} catch (err) {
-			// Quota / storage-disabled. Persist filtering still works via
-			// in-memory `excludesOption`, but cross-load IIFE pre-paint
-			// won't see the rules. Surface so consumers can react.
+			// In-memory exclusions still apply; pre-paint restore won't see them.
 			// eslint-disable-next-line no-console
 			console.error(
 				'createLayoutState: failed to write atlas-layout-exclusions; in-memory exclusions still apply',
@@ -307,10 +236,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		}
 	}
 
-	// Read the persisted exclusions for the current key. Returns an empty
-	// set when no key is configured, no entry exists, or the data is
-	// unparseable. Uses own-property semantics so a tampered `__proto__`
-	// key can't poison the blocklist.
+	// Own-property lookup prevents prototype poisoning.
 	function getExcludedClasses(): Set<string> {
 		const key = getExcludesKey();
 		if (key === null) {
@@ -340,11 +266,8 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 	let callbacksReady = false;
 	const pendingCallbacks: (() => void)[] = [];
 
-	// View-transition coordination (per instance). `activeTransitionCount`
-	// gates new transitions so callbacks fired while one is animating run
-	// synchronously instead of aborting it with InvalidStateError.
-	// `pendingTransitionFns` lets subscriber callbacks queued in the same
-	// microtask coalesce into a single transition.
+	// Per-instance gate: coalesce same-microtask callbacks; run sync while active
+	// to avoid `InvalidStateError`.
 	let activeTransitionCount = 0;
 	const pendingTransitionFns: (() => void)[] = [];
 	let transitionMicrotaskQueued = false;
@@ -357,7 +280,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		}
 	}
 
-	// Sentinel attribute (not a class, to stay out of the layout-* persistence path).
+	// Attribute, not class, to stay off the `layout-*` persistence path.
 	function markRestored(): void {
 		targetRoot.setAttribute(RESTORED_ATTRIBUTE, 'true');
 	}
@@ -370,7 +293,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 				try {
 					invoke();
 				} catch (err) {
-					// Isolate one bad subscriber; keep draining.
+					// Keep draining after a subscriber error.
 					// eslint-disable-next-line no-console
 					console.error('createLayoutState: a subscriber callback threw during initial flush', err);
 				}
@@ -402,8 +325,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 			fn();
 			return;
 		}
-		// A transition is already animating — starting another now would abort
-		// it with InvalidStateError. Apply the change without a transition.
+		// Run sync to avoid aborting the active transition.
 		if (activeTransitionCount > 0) {
 			fn();
 			return;
@@ -428,9 +350,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 			if (batch.length === 0) {
 				return;
 			}
-			// Something else (e.g. a sync restore in another instance) started
-			// a transition between scheduling and now. Apply the batched
-			// changes without a transition so we don't abort it.
+			// Another transition started since scheduling; run sync to avoid aborting it.
 			if (activeTransitionCount > 0) {
 				invokeTransitionCallbacks(batch);
 				return;
@@ -461,9 +381,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		if (finished && typeof finished.then === 'function') {
 			finished.then(settle, settle);
 		} else {
-			// No .finished (e.g. a test stub). Treat the transition as
-			// complete immediately so subsequent calls can either batch or
-			// start a fresh transition cleanly.
+			// No `.finished` (e.g. test stub); settle immediately to unblock follow-ups.
 			settle();
 		}
 	}
@@ -514,9 +432,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 	}
 
 	function fireMatching(className: string, applied: boolean): void {
-		// Resolve once per fire so every event in this batch carries the same
-		// storageKey as the storage write that just happened, and so any
-		// exclusion rules added between observer fires apply consistently.
+		// One exclusion snapshot per dispatch; one key read so events match the write.
 		if (getExcludedClasses().has(className)) {
 			return;
 		}
@@ -548,9 +464,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		subscriptions.add(sub);
 
 		const applied = isClassApplied(className);
-		// Symmetric with fireMatching: an excluded class is not ours, so
-		// skip the initial replay too. Re-evaluated on subsequent mutations
-		// in case the rules change.
+		// Excluded classes skip initial replay too.
 		if (matches(sub, applied) && !getExcludedClasses().has(className)) {
 			const eventStorageKey = getStorageKey();
 			const { useViewTransition } = sub;
@@ -568,9 +482,9 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 
 	function restoreInitialState(): void {
 		const viewState = getViewState();
-		const blocked = getExcludedClasses();
+		const excluded = getExcludedClasses();
 		for (const className of Object.keys(viewState)) {
-			if (blocked.has(className)) {
+			if (excluded.has(className)) {
 				continue;
 			}
 			targetRoot.classList.toggle(className, viewState[className]);
@@ -593,22 +507,21 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		if (added.length + removed.length === 0) {
 			return;
 		}
-		// Refresh on every write so any rules added by a SPA router between
-		// observer fires are honored without needing the instance to know.
-		const blocked = getExcludedClasses();
+		// Refresh per write to catch SPA-updated exclusions.
+		const excluded = getExcludedClasses();
 		const currentStorageKey = getStorageKey();
 		const state = loadState();
 		const viewState = state[currentStorageKey] ?? {};
 		let touched = false;
 		for (const c of added) {
-			if (blocked.has(c)) {
+			if (excluded.has(c)) {
 				continue;
 			}
 			viewState[c] = true;
 			touched = true;
 		}
 		for (const c of removed) {
-			if (blocked.has(c)) {
+			if (excluded.has(c)) {
 				continue;
 			}
 			viewState[c] = false;
@@ -626,8 +539,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		observer = null;
 	}
 
-	// Wired synchronously so the instance is live on return. Wrapped so a
-	// failure can't strand CSS rules keyed on `data-layout-restored`.
+	// Mark restored even on setup failure so CSS gates can't strand content.
 	try {
 		startOptionalViewTransition(useViewTransitionOnRestore, restoreInitialState, {
 			sync: true

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -122,8 +122,8 @@ export interface LayoutStateOptions {
 	storageKey?: string | (() => string);
 	/**
 	 * Lookup key into the secondary `atlas-layout-exclusions` storage entry.
-	 * The entry's shape is `{ [scope]: { [className]: true } }`; if a class
-	 * appears under this scope (regardless of value), the instance and the
+	 * The entry's shape is `{ [key]: { [className]: true } }`; if a class
+	 * appears under this key (regardless of value), the instance and the
 	 * inline IIFE both skip it everywhere: restore, persist, AND subscriber
 	 * dispatch (including the immediate replay at `subscribe()` time).
 	 *
@@ -131,28 +131,28 @@ export interface LayoutStateOptions {
 	 * exclusion rules without changing the shared state model. Because the
 	 * rules live in storage rather than in code, they survive SPA
 	 * navigation and direct hard reloads — the inline `<head>` IIFE reads
-	 * the same entry, so pre-paint restore stays in scope.
+	 * the same entry, so pre-paint restore honors them.
 	 *
 	 * Pair with `excludes` to have this instance seed/refresh the entry on
 	 * construction. Omitted entirely → no exclusions consulted (matches the
 	 * original behavior).
 	 *
-	 * May be a static string or a getter called every time the scope is
-	 * needed, letting a single instance follow a dynamically changing scope
+	 * May be a static string or a getter called every time the key is
+	 * needed, letting a single instance follow a dynamically changing key
 	 * without being recreated.
 	 */
-	excludesScope?: string | (() => string);
+	excludesKey?: string | (() => string);
 	/**
 	 * Class names this view excludes from layout persistence. On
 	 * construction the instance writes this list into
-	 * `localStorage['atlas-layout-exclusions'][excludesScope]`, overwriting
-	 * any prior entry for that scope. Subsequent restore, persist, and
+	 * `localStorage['atlas-layout-exclusions'][excludesKey]`, overwriting
+	 * any prior entry for that key. Subsequent restore, persist, and
 	 * subscriber dispatch — plus the inline pre-paint IIFE on the next
 	 * page load — read the persisted entry and skip these classes
 	 * symmetrically.
 	 *
-	 * Requires `excludesScope` to be set; ignored otherwise. Pass an empty
-	 * array to clear the scope's blocklist without removing the scope key.
+	 * Requires `excludesKey` to be set; ignored otherwise. Pass an empty
+	 * array to clear the key's blocklist without removing the entry.
 	 * Omitted entirely → the instance does not touch the exclusions entry,
 	 * but still honors whatever is already persisted there.
 	 */
@@ -211,12 +211,12 @@ type DocumentWithViewTransition = Document & {
 
 /**
  * Shape of the secondary `atlas-layout-exclusions` storage entry — a map of
- * scope key → object whose own keys name the `layout-*` classes blocked
- * within that scope. Value associated with each key is ignored; presence is
+ * key → object whose own keys name the `layout-*` classes blocked under
+ * that entry. Value associated with each class is ignored; presence is
  * what matters.
  */
 export interface LayoutExclusionsPersisted {
-	[scope: string]: { [className: string]: true };
+	[key: string]: { [className: string]: true };
 }
 
 const EXCLUSIONS_STORAGE_KEY = 'atlas-layout-exclusions';
@@ -230,7 +230,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		root: targetRoot = document.documentElement,
 		storage = window.localStorage,
 		storageKey: storageKeyOption = 'default',
-		excludesScope: excludesScopeOption,
+		excludesKey: excludesKeyOption,
 		excludes: excludesOption,
 		deferCallbacksUntil = Promise.resolve(),
 		useViewTransitionOnRestore = false
@@ -253,28 +253,27 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		return sanitizeKey(raw);
 	}
 
-	// Resolve the excludes scope on demand. Null means "no scope was
-	// configured" — exclusions are skipped entirely.
-	function getExcludesScope(): string | null {
-		if (excludesScopeOption === undefined) {
+	// Resolve the excludes key on demand. Null means none was configured —
+	// exclusions are skipped entirely.
+	function getExcludesKey(): string | null {
+		if (excludesKeyOption === undefined) {
 			return null;
 		}
-		const raw =
-			typeof excludesScopeOption === 'function' ? excludesScopeOption() : excludesScopeOption;
+		const raw = typeof excludesKeyOption === 'function' ? excludesKeyOption() : excludesKeyOption;
 		return sanitizeKey(raw);
 	}
 
-	// Seed the persisted exclusions for this instance's scope from the
+	// Seed the persisted exclusions for this instance's key from the
 	// `excludes` option. Runs once at construction so the very next page
 	// load's inline IIFE sees the rules in storage. No-op when either
-	// `excludes` or `excludesScope` is omitted, so consumers can use just
-	// the scope to read pre-existing rules.
+	// `excludes` or `excludesKey` is omitted, so consumers can use just
+	// the key to read pre-existing rules.
 	function writeConfiguredExclusions(): void {
 		if (excludesOption === undefined) {
 			return;
 		}
-		const scope = getExcludesScope();
-		if (scope === null) {
+		const key = getExcludesKey();
+		if (key === null) {
 			return;
 		}
 		const raw = storage.getItem(EXCLUSIONS_STORAGE_KEY);
@@ -293,7 +292,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		for (const c of excludesOption) {
 			next[c] = true;
 		}
-		state[scope] = next;
+		state[key] = next;
 		try {
 			storage.setItem(EXCLUSIONS_STORAGE_KEY, JSON.stringify(state));
 		} catch (err) {
@@ -308,13 +307,13 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		}
 	}
 
-	// Read the persisted exclusions for the current scope. Returns an empty
-	// set when no scope is configured, no entry exists, or the data is
+	// Read the persisted exclusions for the current key. Returns an empty
+	// set when no key is configured, no entry exists, or the data is
 	// unparseable. Uses own-property semantics so a tampered `__proto__`
 	// key can't poison the blocklist.
 	function getExcludedClasses(): Set<string> {
-		const scope = getExcludesScope();
-		if (scope === null) {
+		const key = getExcludesKey();
+		if (key === null) {
 			return new Set();
 		}
 		const raw = storage.getItem(EXCLUSIONS_STORAGE_KEY);
@@ -327,8 +326,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		} catch {
 			return new Set();
 		}
-		const scoped =
-			parsed && Object.prototype.hasOwnProperty.call(parsed, scope) ? parsed[scope] : null;
+		const scoped = parsed && Object.prototype.hasOwnProperty.call(parsed, key) ? parsed[key] : null;
 		if (!scoped || typeof scoped !== 'object') {
 			return new Set();
 		}

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -129,16 +129,32 @@ export interface LayoutStateOptions {
 	 * Lets views that share a primary `storageKey` opt into different
 	 * exclusion rules without changing the shared state model. Because the
 	 * rules live in storage rather than in code, they survive SPA
-	 * navigation and direct hard reloads (the inline `<head>` IIFE reads
-	 * the same entry, so pre-paint restore stays in scope). Update at any
-	 * time via the free helper `setLayoutExclusions(scope, classes)`.
+	 * navigation and direct hard reloads — the inline `<head>` IIFE reads
+	 * the same entry, so pre-paint restore stays in scope.
+	 *
+	 * Pair with `excludes` to have this instance seed/refresh the entry on
+	 * construction. Omitted entirely → no exclusions consulted (matches the
+	 * original behavior).
 	 *
 	 * May be a static string or a getter called every time the scope is
 	 * needed, letting a single instance follow a dynamically changing scope
-	 * without being recreated. Omitted entirely → no exclusions consulted
-	 * (matches the original behavior).
+	 * without being recreated.
 	 */
 	excludesScope?: string | (() => string);
+	/**
+	 * Class names this view excludes from layout persistence. On
+	 * construction the instance writes this list into
+	 * `localStorage['atlas-layout-exclusions'][excludesScope]`, overwriting
+	 * any prior entry for that scope. Subsequent restore and persist
+	 * operations — and the inline pre-paint IIFE on the next page load —
+	 * read the persisted entry and skip these classes in both directions.
+	 *
+	 * Requires `excludesScope` to be set; ignored otherwise. Pass an empty
+	 * array to clear the scope's blocklist without removing the scope key.
+	 * Omitted entirely → the instance does not touch the exclusions entry,
+	 * but still honors whatever is already persisted there.
+	 */
+	excludes?: string[];
 	/**
 	 * Subscriber callbacks are queued until this resolves. Defaults to a
 	 * resolved promise (fires on next microtask). Pass `contentLoaded` to
@@ -207,24 +223,13 @@ function sanitizeExclusionsKey(raw: string): string {
 	return raw === '__proto__' || raw === 'prototype' || raw === 'constructor' ? 'default' : raw;
 }
 
-function loadExclusions(storage: Pick<Storage, 'getItem' | 'setItem'>): LayoutExclusionsPersisted {
-	const raw = storage.getItem(EXCLUSIONS_STORAGE_KEY);
-	if (!raw) {
-		return {};
-	}
-	try {
-		return JSON.parse(raw) as LayoutExclusionsPersisted;
-	} catch {
-		return {};
-	}
-}
-
 export function createLayoutState(options: LayoutStateOptions = {}): LayoutStateInstance {
 	const {
 		root: targetRoot = document.documentElement,
 		storage = window.localStorage,
 		storageKey: storageKeyOption = 'default',
 		excludesScope: excludesScopeOption,
+		excludes: excludesOption,
 		deferCallbacksUntil = Promise.resolve(),
 		useViewTransitionOnRestore = false
 	} = options;
@@ -257,6 +262,50 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		return sanitizeKey(raw);
 	}
 
+	// Seed the persisted exclusions for this instance's scope from the
+	// `excludes` option. Runs once at construction so the very next page
+	// load's inline IIFE sees the rules in storage. No-op when either
+	// `excludes` or `excludesScope` is omitted, so consumers can use just
+	// the scope to read pre-existing rules.
+	function writeConfiguredExclusions(): void {
+		if (excludesOption === undefined) {
+			return;
+		}
+		const scope = getExcludesScope();
+		if (scope === null) {
+			return;
+		}
+		const raw = storage.getItem(EXCLUSIONS_STORAGE_KEY);
+		let state: LayoutExclusionsPersisted = {};
+		if (raw) {
+			try {
+				const parsed = JSON.parse(raw) as LayoutExclusionsPersisted;
+				if (parsed && typeof parsed === 'object') {
+					state = parsed;
+				}
+			} catch {
+				// Treat unparseable storage as empty and overwrite below.
+			}
+		}
+		const next: { [className: string]: true } = {};
+		for (const c of excludesOption) {
+			next[c] = true;
+		}
+		state[scope] = next;
+		try {
+			storage.setItem(EXCLUSIONS_STORAGE_KEY, JSON.stringify(state));
+		} catch (err) {
+			// Quota / storage-disabled. Persist filtering still works via
+			// in-memory `excludesOption`, but cross-load IIFE pre-paint
+			// won't see the rules. Surface so consumers can react.
+			// eslint-disable-next-line no-console
+			console.error(
+				'createLayoutState: failed to write atlas-layout-exclusions; in-memory exclusions still apply',
+				err
+			);
+		}
+	}
+
 	// Read the persisted exclusions for the current scope. Returns an empty
 	// set when no scope is configured, no entry exists, or the data is
 	// unparseable. Uses own-property semantics so a tampered `__proto__`
@@ -283,6 +332,8 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		}
 		return new Set(Object.keys(scoped));
 	}
+
+	writeConfiguredExclusions();
 
 	const subscriptions = new Set<LayoutSubscription>();
 	let observer: MutationObserver | null = null;
@@ -619,50 +670,4 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		getState: loadState,
 		stop
 	};
-}
-
-/* -------------------------------------------------------------------------- */
-/* Layout exclusions helpers                                                  */
-/* -------------------------------------------------------------------------- */
-
-/**
- * Replace the entire blocklist for `scope` in the `atlas-layout-exclusions`
- * storage entry. Subsequent restores and persists (in this tab and others
- * once they next read) will see the updated rules. Pass an empty array to
- * clear the scope's rules without removing the scope key itself.
- *
- * Intended to be called by SPA routers on navigation, by an app shell at
- * boot to seed per-view rules, or by experiment plumbing — any source that
- * wants to teach the inline IIFE and the live instances what to skip.
- */
-export function setLayoutExclusions(
-	scope: string,
-	classes: string[],
-	storage: Pick<Storage, 'getItem' | 'setItem'> = window.localStorage
-): void {
-	const safeScope = sanitizeExclusionsKey(scope);
-	const state = loadExclusions(storage);
-	const next: { [className: string]: true } = {};
-	for (const c of classes) {
-		next[c] = true;
-	}
-	state[safeScope] = next;
-	storage.setItem(EXCLUSIONS_STORAGE_KEY, JSON.stringify(state));
-}
-
-/**
- * Read the current blocklist for `scope` as an array of class names. Reads
- * `atlas-layout-exclusions` fresh on every call.
- */
-export function getLayoutExclusions(
-	scope: string,
-	storage: Pick<Storage, 'getItem' | 'setItem'> = window.localStorage
-): string[] {
-	const safeScope = sanitizeExclusionsKey(scope);
-	const state = loadExclusions(storage);
-	const scoped = Object.prototype.hasOwnProperty.call(state, safeScope) ? state[safeScope] : null;
-	if (!scoped || typeof scoped !== 'object') {
-		return [];
-	}
-	return Object.keys(scoped);
 }

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -124,7 +124,8 @@ export interface LayoutStateOptions {
 	 * Lookup key into the secondary `atlas-layout-exclusions` storage entry.
 	 * The entry's shape is `{ [scope]: { [className]: true } }`; if a class
 	 * appears under this scope (regardless of value), the instance and the
-	 * inline IIFE both skip it during restore AND during persist.
+	 * inline IIFE both skip it everywhere: restore, persist, AND subscriber
+	 * dispatch (including the immediate replay at `subscribe()` time).
 	 *
 	 * Lets views that share a primary `storageKey` opt into different
 	 * exclusion rules without changing the shared state model. Because the
@@ -145,9 +146,10 @@ export interface LayoutStateOptions {
 	 * Class names this view excludes from layout persistence. On
 	 * construction the instance writes this list into
 	 * `localStorage['atlas-layout-exclusions'][excludesScope]`, overwriting
-	 * any prior entry for that scope. Subsequent restore and persist
-	 * operations — and the inline pre-paint IIFE on the next page load —
-	 * read the persisted entry and skip these classes in both directions.
+	 * any prior entry for that scope. Subsequent restore, persist, and
+	 * subscriber dispatch — plus the inline pre-paint IIFE on the next
+	 * page load — read the persisted entry and skip these classes
+	 * symmetrically.
 	 *
 	 * Requires `excludesScope` to be set; ignored otherwise. Pass an empty
 	 * array to clear the scope's blocklist without removing the scope key.
@@ -515,7 +517,11 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 
 	function fireMatching(className: string, applied: boolean): void {
 		// Resolve once per fire so every event in this batch carries the same
-		// storageKey as the storage write that just happened.
+		// storageKey as the storage write that just happened, and so any
+		// exclusion rules added between observer fires apply consistently.
+		if (getExcludedClasses().has(className)) {
+			return;
+		}
 		const eventStorageKey = getStorageKey();
 		for (const sub of subscriptions) {
 			if (sub.className === className && matches(sub, applied)) {
@@ -544,7 +550,10 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		subscriptions.add(sub);
 
 		const applied = isClassApplied(className);
-		if (matches(sub, applied)) {
+		// Symmetric with fireMatching: an excluded class is not ours, so
+		// skip the initial replay too. Re-evaluated on subsequent mutations
+		// in case the rules change.
+		if (matches(sub, applied) && !getExcludedClasses().has(className)) {
 			const eventStorageKey = getStorageKey();
 			const { useViewTransition } = sub;
 			dispatch(() => {

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -121,6 +121,25 @@ export interface LayoutStateOptions {
 	 */
 	storageKey?: string | (() => string);
 	/**
+	 * Lookup key into the secondary `atlas-layout-exclusions` storage entry.
+	 * The entry's shape is `{ [scope]: { [className]: true } }`; if a class
+	 * appears under this scope (regardless of value), the instance and the
+	 * inline IIFE both skip it during restore AND during persist.
+	 *
+	 * Lets views that share a primary `storageKey` opt into different
+	 * exclusion rules without changing the shared state model. Because the
+	 * rules live in storage rather than in code, they survive SPA
+	 * navigation and direct hard reloads (the inline `<head>` IIFE reads
+	 * the same entry, so pre-paint restore stays in scope). Update at any
+	 * time via the free helper `setLayoutExclusions(scope, classes)`.
+	 *
+	 * May be a static string or a getter called every time the scope is
+	 * needed, letting a single instance follow a dynamically changing scope
+	 * without being recreated. Omitted entirely → no exclusions consulted
+	 * (matches the original behavior).
+	 */
+	excludesScope?: string | (() => string);
+	/**
 	 * Subscriber callbacks are queued until this resolves. Defaults to a
 	 * resolved promise (fires on next microtask). Pass `contentLoaded` to
 	 * wait for `DOMContentLoaded`.
@@ -172,11 +191,40 @@ type DocumentWithViewTransition = Document & {
 	startViewTransition?: (updateCallback: () => void) => unknown;
 };
 
+/**
+ * Shape of the secondary `atlas-layout-exclusions` storage entry — a map of
+ * scope key → object whose own keys name the `layout-*` classes blocked
+ * within that scope. Value associated with each key is ignored; presence is
+ * what matters.
+ */
+export interface LayoutExclusionsPersisted {
+	[scope: string]: { [className: string]: true };
+}
+
+const EXCLUSIONS_STORAGE_KEY = 'atlas-layout-exclusions';
+
+function sanitizeExclusionsKey(raw: string): string {
+	return raw === '__proto__' || raw === 'prototype' || raw === 'constructor' ? 'default' : raw;
+}
+
+function loadExclusions(storage: Pick<Storage, 'getItem' | 'setItem'>): LayoutExclusionsPersisted {
+	const raw = storage.getItem(EXCLUSIONS_STORAGE_KEY);
+	if (!raw) {
+		return {};
+	}
+	try {
+		return JSON.parse(raw) as LayoutExclusionsPersisted;
+	} catch {
+		return {};
+	}
+}
+
 export function createLayoutState(options: LayoutStateOptions = {}): LayoutStateInstance {
 	const {
 		root: targetRoot = document.documentElement,
 		storage = window.localStorage,
 		storageKey: storageKeyOption = 'default',
+		excludesScope: excludesScopeOption,
 		deferCallbacksUntil = Promise.resolve(),
 		useViewTransitionOnRestore = false
 	} = options;
@@ -188,7 +236,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 	// Coerce unsafe object keys to 'default' so prototype-key writes can't
 	// corrupt the persisted state map.
 	function sanitizeKey(raw: string): string {
-		return raw === '__proto__' || raw === 'prototype' || raw === 'constructor' ? 'default' : raw;
+		return sanitizeExclusionsKey(raw);
 	}
 
 	// Resolve the storage bucket on demand so consumers can pass a getter
@@ -196,6 +244,44 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 	function getStorageKey(): string {
 		const raw = typeof storageKeyOption === 'function' ? storageKeyOption() : storageKeyOption;
 		return sanitizeKey(raw);
+	}
+
+	// Resolve the excludes scope on demand. Null means "no scope was
+	// configured" — exclusions are skipped entirely.
+	function getExcludesScope(): string | null {
+		if (excludesScopeOption === undefined) {
+			return null;
+		}
+		const raw =
+			typeof excludesScopeOption === 'function' ? excludesScopeOption() : excludesScopeOption;
+		return sanitizeKey(raw);
+	}
+
+	// Read the persisted exclusions for the current scope. Returns an empty
+	// set when no scope is configured, no entry exists, or the data is
+	// unparseable. Uses own-property semantics so a tampered `__proto__`
+	// key can't poison the blocklist.
+	function getExcludedClasses(): Set<string> {
+		const scope = getExcludesScope();
+		if (scope === null) {
+			return new Set();
+		}
+		const raw = storage.getItem(EXCLUSIONS_STORAGE_KEY);
+		if (!raw) {
+			return new Set();
+		}
+		let parsed: Record<string, Record<string, unknown>>;
+		try {
+			parsed = JSON.parse(raw) as Record<string, Record<string, unknown>>;
+		} catch {
+			return new Set();
+		}
+		const scoped =
+			parsed && Object.prototype.hasOwnProperty.call(parsed, scope) ? parsed[scope] : null;
+		if (!scoped || typeof scoped !== 'object') {
+			return new Set();
+		}
+		return new Set(Object.keys(scoped));
 	}
 
 	const subscriptions = new Set<LayoutSubscription>();
@@ -424,7 +510,11 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 
 	function restoreInitialState(): void {
 		const viewState = getViewState();
+		const blocked = getExcludedClasses();
 		for (const className of Object.keys(viewState)) {
+			if (blocked.has(className)) {
+				continue;
+			}
 			targetRoot.classList.toggle(className, viewState[className]);
 		}
 	}
@@ -445,14 +535,29 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		if (added.length + removed.length === 0) {
 			return;
 		}
+		// Refresh on every write so any rules added by a SPA router between
+		// observer fires are honored without needing the instance to know.
+		const blocked = getExcludedClasses();
 		const currentStorageKey = getStorageKey();
 		const state = loadState();
 		const viewState = state[currentStorageKey] ?? {};
+		let touched = false;
 		for (const c of added) {
+			if (blocked.has(c)) {
+				continue;
+			}
 			viewState[c] = true;
+			touched = true;
 		}
 		for (const c of removed) {
+			if (blocked.has(c)) {
+				continue;
+			}
 			viewState[c] = false;
+			touched = true;
+		}
+		if (!touched) {
+			return;
 		}
 		state[currentStorageKey] = viewState;
 		saveState(state);
@@ -514,4 +619,50 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		getState: loadState,
 		stop
 	};
+}
+
+/* -------------------------------------------------------------------------- */
+/* Layout exclusions helpers                                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Replace the entire blocklist for `scope` in the `atlas-layout-exclusions`
+ * storage entry. Subsequent restores and persists (in this tab and others
+ * once they next read) will see the updated rules. Pass an empty array to
+ * clear the scope's rules without removing the scope key itself.
+ *
+ * Intended to be called by SPA routers on navigation, by an app shell at
+ * boot to seed per-view rules, or by experiment plumbing — any source that
+ * wants to teach the inline IIFE and the live instances what to skip.
+ */
+export function setLayoutExclusions(
+	scope: string,
+	classes: string[],
+	storage: Pick<Storage, 'getItem' | 'setItem'> = window.localStorage
+): void {
+	const safeScope = sanitizeExclusionsKey(scope);
+	const state = loadExclusions(storage);
+	const next: { [className: string]: true } = {};
+	for (const c of classes) {
+		next[c] = true;
+	}
+	state[safeScope] = next;
+	storage.setItem(EXCLUSIONS_STORAGE_KEY, JSON.stringify(state));
+}
+
+/**
+ * Read the current blocklist for `scope` as an array of class names. Reads
+ * `atlas-layout-exclusions` fresh on every call.
+ */
+export function getLayoutExclusions(
+	scope: string,
+	storage: Pick<Storage, 'getItem' | 'setItem'> = window.localStorage
+): string[] {
+	const safeScope = sanitizeExclusionsKey(scope);
+	const state = loadExclusions(storage);
+	const scoped = Object.prototype.hasOwnProperty.call(state, safeScope) ? state[safeScope] : null;
+	if (!scoped || typeof scoped !== 'object') {
+		return [];
+	}
+	return Object.keys(scoped);
 }

--- a/js/test/behaviors/layout.test.ts
+++ b/js/test/behaviors/layout.test.ts
@@ -1676,5 +1676,137 @@ describe('createLayoutState', () => {
 				void viewF;
 			});
 		});
+
+		describe('subscribers', () => {
+			it('does not fire subscribers for excluded classes when mutated', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[EXCLUSIONS_KEY]: JSON.stringify({
+						'view-e': { 'layout-menu-collapsed': true }
+					})
+				});
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						excludesScope: 'view-e',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				const blockedCb = vi.fn();
+				const allowedCb = vi.fn();
+				state.subscribe('layout-menu-collapsed', 'always', blockedCb);
+				state.subscribe('layout-twin', 'always', allowedCb);
+				await flush();
+				blockedCb.mockClear();
+				allowedCb.mockClear();
+
+				root.classList.add('layout-menu-collapsed');
+				root.classList.add('layout-twin');
+				await flush();
+
+				expect(blockedCb).not.toHaveBeenCalled();
+				expect(allowedCb).toHaveBeenCalledWith({
+					className: 'layout-twin',
+					isApplied: true,
+					storageKey: 'v'
+				});
+			});
+
+			it('does not replay an excluded class at subscribe time', () => {
+				const root = createRoot();
+				root.classList.add('layout-menu-collapsed');
+				const { storage } = createFakeStorage({
+					[EXCLUSIONS_KEY]: JSON.stringify({
+						'view-e': { 'layout-menu-collapsed': true }
+					})
+				});
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						excludesScope: 'view-e',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				const cb = vi.fn();
+				state.subscribe('layout-menu-collapsed', 'always', cb);
+				// Subscribe-time replay runs synchronously when
+				// deferCallbacksUntil is already resolved at construction; the
+				// `dispatch` queue would drain on the next microtask, but the
+				// branch we care about is the `matches(...) && !blocked` guard
+				// — flush to make sure no callback was queued.
+				return flush().then(() => {
+					expect(cb).not.toHaveBeenCalled();
+				});
+			});
+
+			it('re-evaluates exclusions per fire so newly-blocked classes stop firing mid-life', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage();
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						excludesScope: 'view-e',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				const cb = vi.fn();
+				state.subscribe('layout-menu-collapsed', 'always', cb);
+				await flush();
+				cb.mockClear();
+
+				// No exclusion yet — first toggle fires.
+				root.classList.add('layout-menu-collapsed');
+				await flush();
+				expect(cb).toHaveBeenCalledTimes(1);
+
+				// External writer blocks the class — next toggle is silent.
+				storage.setItem(
+					EXCLUSIONS_KEY,
+					JSON.stringify({ 'view-e': { 'layout-menu-collapsed': true } })
+				);
+				root.classList.remove('layout-menu-collapsed');
+				await flush();
+				expect(cb).toHaveBeenCalledTimes(1);
+			});
+
+			it('re-evaluates exclusions per fire so newly-unblocked classes start firing mid-life', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[EXCLUSIONS_KEY]: JSON.stringify({
+						'view-e': { 'layout-menu-collapsed': true }
+					})
+				});
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						excludesScope: 'view-e',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				const cb = vi.fn();
+				state.subscribe('layout-menu-collapsed', 'always', cb);
+				await flush();
+				cb.mockClear();
+
+				// Blocked — first toggle is silent.
+				root.classList.add('layout-menu-collapsed');
+				await flush();
+				expect(cb).not.toHaveBeenCalled();
+
+				// External writer clears the rule — next toggle fires.
+				storage.setItem(EXCLUSIONS_KEY, JSON.stringify({ 'view-e': {} }));
+				root.classList.remove('layout-menu-collapsed');
+				await flush();
+				expect(cb).toHaveBeenCalledTimes(1);
+			});
+		});
 	});
 });

--- a/js/test/behaviors/layout.test.ts
+++ b/js/test/behaviors/layout.test.ts
@@ -1223,4 +1223,458 @@ describe('createLayoutState', () => {
 			expect(instanceB.getViewState()).toEqual({ 'layout-menu-collapsed': true });
 		});
 	});
+
+	describe('exclusions', () => {
+		const EXCLUSIONS_KEY = 'atlas-layout-exclusions';
+
+		describe('restore', () => {
+			it('skips classes listed for this scope during initial restore', () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({
+						v: { 'layout-twin': true, 'layout-menu-collapsed': true }
+					}),
+					[EXCLUSIONS_KEY]: JSON.stringify({
+						'view-e': { 'layout-menu-collapsed': true }
+					})
+				});
+				track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						excludesScope: 'view-e'
+					})
+				);
+				expect(root.classList.contains('layout-twin')).toBe(true);
+				expect(root.classList.contains('layout-menu-collapsed')).toBe(false);
+			});
+
+			it('applies all persisted classes when no excludesScope is set', () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({
+						v: { 'layout-twin': true, 'layout-menu-collapsed': true }
+					}),
+					[EXCLUSIONS_KEY]: JSON.stringify({
+						'some-other-scope': { 'layout-menu-collapsed': true }
+					})
+				});
+				track(createLayoutState({ root, storage, storageKey: 'v' }));
+				expect(root.classList.contains('layout-twin')).toBe(true);
+				expect(root.classList.contains('layout-menu-collapsed')).toBe(true);
+			});
+
+			it('ignores exclusions stored under unrelated scopes', () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({
+						v: { 'layout-menu-collapsed': true }
+					}),
+					[EXCLUSIONS_KEY]: JSON.stringify({
+						'view-f': { 'layout-menu-collapsed': true }
+					})
+				});
+				track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						excludesScope: 'view-e'
+					})
+				);
+				expect(root.classList.contains('layout-menu-collapsed')).toBe(true);
+			});
+
+			it('treats unparseable exclusions JSON as no rules', () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({ v: { 'layout-twin': true } }),
+					[EXCLUSIONS_KEY]: 'not-json-{'
+				});
+				track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						excludesScope: 'view-e'
+					})
+				);
+				expect(root.classList.contains('layout-twin')).toBe(true);
+			});
+		});
+
+		describe('persist', () => {
+			it('does not write blocked classes to primary storage when added', async () => {
+				const root = createRoot();
+				const { storage, data } = createFakeStorage({
+					[EXCLUSIONS_KEY]: JSON.stringify({
+						'view-e': { 'layout-menu-collapsed': true }
+					})
+				});
+				track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						excludesScope: 'view-e',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				root.classList.add('layout-twin');
+				root.classList.add('layout-menu-collapsed');
+				await flush();
+				expect(JSON.parse(data[STORAGE_KEY])).toEqual({
+					v: { 'layout-twin': true }
+				});
+			});
+
+			it('does not write blocked classes to primary storage when removed', async () => {
+				const root = createRoot();
+				root.classList.add('layout-menu-collapsed');
+				const { storage, data } = createFakeStorage({
+					[EXCLUSIONS_KEY]: JSON.stringify({
+						'view-e': { 'layout-menu-collapsed': true }
+					})
+				});
+				track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						excludesScope: 'view-e',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				root.classList.add('layout-twin');
+				root.classList.remove('layout-menu-collapsed');
+				await flush();
+				expect(JSON.parse(data[STORAGE_KEY])).toEqual({
+					v: { 'layout-twin': true }
+				});
+			});
+
+			it('re-reads exclusions on every persist so storage updates between mutations are honored', async () => {
+				const root = createRoot();
+				const { storage, data } = createFakeStorage();
+				track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						excludesScope: 'view-e',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				root.classList.add('layout-menu-collapsed');
+				await flush();
+				expect(JSON.parse(data[STORAGE_KEY])).toEqual({
+					v: { 'layout-menu-collapsed': true }
+				});
+
+				// External writer (e.g. an SPA router) adds an exclusion mid-life.
+				storage.setItem(EXCLUSIONS_KEY, JSON.stringify({ 'view-e': { 'layout-twin': true } }));
+				root.classList.add('layout-twin');
+				await flush();
+				expect(JSON.parse(data[STORAGE_KEY])).toEqual({
+					v: { 'layout-menu-collapsed': true }
+				});
+			});
+		});
+
+		describe('storage seeding from excludes option', () => {
+			it('writes the configured list to the exclusions entry on init', () => {
+				const { storage, data } = createFakeStorage();
+				track(
+					createLayoutState({
+						root: createRoot(),
+						storage,
+						excludesScope: 'view-e',
+						excludes: ['layout-menu-collapsed', 'layout-aside-collapsed']
+					})
+				);
+				expect(JSON.parse(data[EXCLUSIONS_KEY])).toEqual({
+					'view-e': {
+						'layout-menu-collapsed': true,
+						'layout-aside-collapsed': true
+					}
+				});
+			});
+
+			it('overwrites prior rules for the same scope (replace, not merge)', () => {
+				const { storage, data } = createFakeStorage({
+					[EXCLUSIONS_KEY]: JSON.stringify({
+						'view-e': {
+							'layout-twin': true,
+							'layout-aside-collapsed': true
+						}
+					})
+				});
+				track(
+					createLayoutState({
+						root: createRoot(),
+						storage,
+						excludesScope: 'view-e',
+						excludes: ['layout-menu-collapsed']
+					})
+				);
+				expect(JSON.parse(data[EXCLUSIONS_KEY])).toEqual({
+					'view-e': { 'layout-menu-collapsed': true }
+				});
+			});
+
+			it('leaves other scopes intact when seeding this scope', () => {
+				const { storage, data } = createFakeStorage({
+					[EXCLUSIONS_KEY]: JSON.stringify({
+						'view-f': { 'layout-flyout-active': true }
+					})
+				});
+				track(
+					createLayoutState({
+						root: createRoot(),
+						storage,
+						excludesScope: 'view-e',
+						excludes: ['layout-menu-collapsed']
+					})
+				);
+				expect(JSON.parse(data[EXCLUSIONS_KEY])).toEqual({
+					'view-f': { 'layout-flyout-active': true },
+					'view-e': { 'layout-menu-collapsed': true }
+				});
+			});
+
+			it('clears the scope when excludes is an empty array', () => {
+				const { storage, data } = createFakeStorage({
+					[EXCLUSIONS_KEY]: JSON.stringify({
+						'view-e': { 'layout-menu-collapsed': true }
+					})
+				});
+				track(
+					createLayoutState({
+						root: createRoot(),
+						storage,
+						excludesScope: 'view-e',
+						excludes: []
+					})
+				);
+				expect(JSON.parse(data[EXCLUSIONS_KEY])).toEqual({ 'view-e': {} });
+			});
+
+			it('does not touch the exclusions entry when excludes is omitted', () => {
+				const { storage, data } = createFakeStorage({
+					[EXCLUSIONS_KEY]: JSON.stringify({
+						'view-e': { 'layout-menu-collapsed': true }
+					})
+				});
+				track(
+					createLayoutState({
+						root: createRoot(),
+						storage,
+						excludesScope: 'view-e'
+					})
+				);
+				expect(JSON.parse(data[EXCLUSIONS_KEY])).toEqual({
+					'view-e': { 'layout-menu-collapsed': true }
+				});
+			});
+
+			it('does not write to the exclusions entry when excludesScope is omitted', () => {
+				const { storage, data } = createFakeStorage();
+				track(
+					createLayoutState({
+						root: createRoot(),
+						storage,
+						excludes: ['layout-menu-collapsed']
+					})
+				);
+				expect(data[EXCLUSIONS_KEY]).toBeUndefined();
+			});
+
+			it('recovers from malformed prior exclusions JSON by writing a fresh entry', () => {
+				const { storage, data } = createFakeStorage({
+					[EXCLUSIONS_KEY]: 'not-json-{'
+				});
+				track(
+					createLayoutState({
+						root: createRoot(),
+						storage,
+						excludesScope: 'view-e',
+						excludes: ['layout-menu-collapsed']
+					})
+				);
+				expect(JSON.parse(data[EXCLUSIONS_KEY])).toEqual({
+					'view-e': { 'layout-menu-collapsed': true }
+				});
+			});
+		});
+
+		describe('excludesScope option', () => {
+			it('accepts a function that returns the scope', () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({ v: { 'layout-menu-collapsed': true } }),
+					[EXCLUSIONS_KEY]: JSON.stringify({
+						'view-e': { 'layout-menu-collapsed': true }
+					})
+				});
+				track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						excludesScope: () => 'view-e'
+					})
+				);
+				expect(root.classList.contains('layout-menu-collapsed')).toBe(false);
+			});
+
+			it('calls the function each time the scope is needed', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[EXCLUSIONS_KEY]: JSON.stringify({
+						'view-e': { 'layout-menu-collapsed': true },
+						'view-f': { 'layout-twin': true }
+					})
+				});
+				let currentScope = 'view-e';
+				track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						excludesScope: () => currentScope,
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+
+				// Under view-e: 'layout-menu-collapsed' is blocked, 'layout-twin'
+				// is allowed.
+				root.classList.add('layout-twin');
+				root.classList.add('layout-menu-collapsed');
+				await flush();
+				expect(JSON.parse(storage.getItem(STORAGE_KEY) || '{}')).toEqual({
+					v: { 'layout-twin': true }
+				});
+
+				// Switch to view-f: 'layout-twin' is now blocked, 'layout-aside-collapsed'
+				// is allowed. The getter must be re-evaluated so the new scope's
+				// rules apply to subsequent persists.
+				currentScope = 'view-f';
+				root.classList.add('layout-aside-collapsed');
+				root.classList.remove('layout-twin');
+				await flush();
+				expect(JSON.parse(storage.getItem(STORAGE_KEY) || '{}')).toEqual({
+					// layout-twin stays true: its removal was blocked by view-f.
+					v: { 'layout-twin': true, 'layout-aside-collapsed': true }
+				});
+			});
+
+			it('coerces unsafe static scope strings to "default"', () => {
+				const { storage, data } = createFakeStorage();
+				track(
+					createLayoutState({
+						root: createRoot(),
+						storage,
+						excludesScope: '__proto__',
+						excludes: ['layout-menu-collapsed']
+					})
+				);
+				expect(JSON.parse(data[EXCLUSIONS_KEY])).toEqual({
+					default: { 'layout-menu-collapsed': true }
+				});
+			});
+
+			it('coerces unsafe scope strings returned by the function to "default"', () => {
+				const { storage, data } = createFakeStorage();
+				track(
+					createLayoutState({
+						root: createRoot(),
+						storage,
+						excludesScope: () => 'prototype',
+						excludes: ['layout-menu-collapsed']
+					})
+				);
+				expect(JSON.parse(data[EXCLUSIONS_KEY])).toEqual({
+					default: { 'layout-menu-collapsed': true }
+				});
+			});
+
+			it('uses own-property lookups so __proto__-keyed entries cannot poison the blocklist', () => {
+				const root = createRoot();
+				const poisoned =
+					'{"v":{"layout-menu-collapsed":true},"__proto__":{"layout-menu-collapsed":true}}';
+				const { storage } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({ v: { 'layout-menu-collapsed': true } }),
+					[EXCLUSIONS_KEY]: poisoned
+				});
+				track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						excludesScope: 'view-e'
+					})
+				);
+				// 'view-e' has no rules in storage, so the class should restore.
+				expect(root.classList.contains('layout-menu-collapsed')).toBe(true);
+			});
+		});
+
+		describe('shared storageKey, different excludesScope', () => {
+			it('lets two views share persisted state while honoring distinct exclusion scopes', async () => {
+				const rootE = createRoot();
+				const rootF = createRoot();
+				const { storage, data } = createFakeStorage();
+
+				// View E owns flyout state, blocks menu/aside.
+				const viewE = track(
+					createLayoutState({
+						root: rootE,
+						storage,
+						storageKey: 'main-app',
+						excludesScope: 'view-e',
+						excludes: ['layout-menu-collapsed', 'layout-aside-collapsed'],
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				// View F owns menu state, blocks flyout.
+				const viewF = track(
+					createLayoutState({
+						root: rootF,
+						storage,
+						storageKey: 'main-app',
+						excludesScope: 'view-f',
+						excludes: ['layout-flyout-active'],
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+
+				// View E toggles its concern; View F toggles its concern.
+				rootE.classList.add('layout-flyout-active');
+				rootF.classList.add('layout-menu-collapsed');
+				// Each view also attempts to toggle a class the OTHER owns — these
+				// must be filtered out on persist so views can't write through each
+				// other's exclusions.
+				rootE.classList.add('layout-menu-collapsed');
+				rootF.classList.add('layout-flyout-active');
+				await flush();
+
+				expect(JSON.parse(data[STORAGE_KEY])).toEqual({
+					'main-app': {
+						'layout-flyout-active': true,
+						'layout-menu-collapsed': true
+					}
+				});
+				expect(JSON.parse(data[EXCLUSIONS_KEY])).toEqual({
+					'view-e': {
+						'layout-menu-collapsed': true,
+						'layout-aside-collapsed': true
+					},
+					'view-f': { 'layout-flyout-active': true }
+				});
+				void viewE;
+				void viewF;
+			});
+		});
+	});
 });

--- a/js/test/behaviors/layout.test.ts
+++ b/js/test/behaviors/layout.test.ts
@@ -1243,14 +1243,14 @@ describe('createLayoutState', () => {
 						root,
 						storage,
 						storageKey: 'v',
-						excludesScope: 'view-e'
+						excludesKey: 'view-e'
 					})
 				);
 				expect(root.classList.contains('layout-twin')).toBe(true);
 				expect(root.classList.contains('layout-menu-collapsed')).toBe(false);
 			});
 
-			it('applies all persisted classes when no excludesScope is set', () => {
+			it('applies all persisted classes when no excludesKey is set', () => {
 				const root = createRoot();
 				const { storage } = createFakeStorage({
 					[STORAGE_KEY]: JSON.stringify({
@@ -1280,7 +1280,7 @@ describe('createLayoutState', () => {
 						root,
 						storage,
 						storageKey: 'v',
-						excludesScope: 'view-e'
+						excludesKey: 'view-e'
 					})
 				);
 				expect(root.classList.contains('layout-menu-collapsed')).toBe(true);
@@ -1297,7 +1297,7 @@ describe('createLayoutState', () => {
 						root,
 						storage,
 						storageKey: 'v',
-						excludesScope: 'view-e'
+						excludesKey: 'view-e'
 					})
 				);
 				expect(root.classList.contains('layout-twin')).toBe(true);
@@ -1317,7 +1317,7 @@ describe('createLayoutState', () => {
 						root,
 						storage,
 						storageKey: 'v',
-						excludesScope: 'view-e',
+						excludesKey: 'view-e',
 						deferCallbacksUntil: Promise.resolve()
 					})
 				);
@@ -1342,7 +1342,7 @@ describe('createLayoutState', () => {
 						root,
 						storage,
 						storageKey: 'v',
-						excludesScope: 'view-e',
+						excludesKey: 'view-e',
 						deferCallbacksUntil: Promise.resolve()
 					})
 				);
@@ -1362,7 +1362,7 @@ describe('createLayoutState', () => {
 						root,
 						storage,
 						storageKey: 'v',
-						excludesScope: 'view-e',
+						excludesKey: 'view-e',
 						deferCallbacksUntil: Promise.resolve()
 					})
 				);
@@ -1389,7 +1389,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root: createRoot(),
 						storage,
-						excludesScope: 'view-e',
+						excludesKey: 'view-e',
 						excludes: ['layout-menu-collapsed', 'layout-aside-collapsed']
 					})
 				);
@@ -1414,7 +1414,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root: createRoot(),
 						storage,
-						excludesScope: 'view-e',
+						excludesKey: 'view-e',
 						excludes: ['layout-menu-collapsed']
 					})
 				);
@@ -1433,7 +1433,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root: createRoot(),
 						storage,
-						excludesScope: 'view-e',
+						excludesKey: 'view-e',
 						excludes: ['layout-menu-collapsed']
 					})
 				);
@@ -1453,7 +1453,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root: createRoot(),
 						storage,
-						excludesScope: 'view-e',
+						excludesKey: 'view-e',
 						excludes: []
 					})
 				);
@@ -1470,7 +1470,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root: createRoot(),
 						storage,
-						excludesScope: 'view-e'
+						excludesKey: 'view-e'
 					})
 				);
 				expect(JSON.parse(data[EXCLUSIONS_KEY])).toEqual({
@@ -1478,7 +1478,7 @@ describe('createLayoutState', () => {
 				});
 			});
 
-			it('does not write to the exclusions entry when excludesScope is omitted', () => {
+			it('does not write to the exclusions entry when excludesKey is omitted', () => {
 				const { storage, data } = createFakeStorage();
 				track(
 					createLayoutState({
@@ -1498,7 +1498,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root: createRoot(),
 						storage,
-						excludesScope: 'view-e',
+						excludesKey: 'view-e',
 						excludes: ['layout-menu-collapsed']
 					})
 				);
@@ -1508,7 +1508,7 @@ describe('createLayoutState', () => {
 			});
 		});
 
-		describe('excludesScope option', () => {
+		describe('excludesKey option', () => {
 			it('accepts a function that returns the scope', () => {
 				const root = createRoot();
 				const { storage } = createFakeStorage({
@@ -1522,7 +1522,7 @@ describe('createLayoutState', () => {
 						root,
 						storage,
 						storageKey: 'v',
-						excludesScope: () => 'view-e'
+						excludesKey: () => 'view-e'
 					})
 				);
 				expect(root.classList.contains('layout-menu-collapsed')).toBe(false);
@@ -1542,7 +1542,7 @@ describe('createLayoutState', () => {
 						root,
 						storage,
 						storageKey: 'v',
-						excludesScope: () => currentScope,
+						excludesKey: () => currentScope,
 						deferCallbacksUntil: Promise.resolve()
 					})
 				);
@@ -1575,7 +1575,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root: createRoot(),
 						storage,
-						excludesScope: '__proto__',
+						excludesKey: '__proto__',
 						excludes: ['layout-menu-collapsed']
 					})
 				);
@@ -1590,7 +1590,7 @@ describe('createLayoutState', () => {
 					createLayoutState({
 						root: createRoot(),
 						storage,
-						excludesScope: () => 'prototype',
+						excludesKey: () => 'prototype',
 						excludes: ['layout-menu-collapsed']
 					})
 				);
@@ -1612,7 +1612,7 @@ describe('createLayoutState', () => {
 						root,
 						storage,
 						storageKey: 'v',
-						excludesScope: 'view-e'
+						excludesKey: 'view-e'
 					})
 				);
 				// 'view-e' has no rules in storage, so the class should restore.
@@ -1620,7 +1620,7 @@ describe('createLayoutState', () => {
 			});
 		});
 
-		describe('shared storageKey, different excludesScope', () => {
+		describe('shared storageKey, different excludesKey', () => {
 			it('lets two views share persisted state while honoring distinct exclusion scopes', async () => {
 				const rootE = createRoot();
 				const rootF = createRoot();
@@ -1632,7 +1632,7 @@ describe('createLayoutState', () => {
 						root: rootE,
 						storage,
 						storageKey: 'main-app',
-						excludesScope: 'view-e',
+						excludesKey: 'view-e',
 						excludes: ['layout-menu-collapsed', 'layout-aside-collapsed'],
 						deferCallbacksUntil: Promise.resolve()
 					})
@@ -1643,7 +1643,7 @@ describe('createLayoutState', () => {
 						root: rootF,
 						storage,
 						storageKey: 'main-app',
-						excludesScope: 'view-f',
+						excludesKey: 'view-f',
 						excludes: ['layout-flyout-active'],
 						deferCallbacksUntil: Promise.resolve()
 					})
@@ -1690,7 +1690,7 @@ describe('createLayoutState', () => {
 						root,
 						storage,
 						storageKey: 'v',
-						excludesScope: 'view-e',
+						excludesKey: 'view-e',
 						deferCallbacksUntil: Promise.resolve()
 					})
 				);
@@ -1727,7 +1727,7 @@ describe('createLayoutState', () => {
 						root,
 						storage,
 						storageKey: 'v',
-						excludesScope: 'view-e',
+						excludesKey: 'view-e',
 						deferCallbacksUntil: Promise.resolve()
 					})
 				);
@@ -1751,7 +1751,7 @@ describe('createLayoutState', () => {
 						root,
 						storage,
 						storageKey: 'v',
-						excludesScope: 'view-e',
+						excludesKey: 'view-e',
 						deferCallbacksUntil: Promise.resolve()
 					})
 				);
@@ -1787,7 +1787,7 @@ describe('createLayoutState', () => {
 						root,
 						storage,
 						storageKey: 'v',
-						excludesScope: 'view-e',
+						excludesKey: 'view-e',
 						deferCallbacksUntil: Promise.resolve()
 					})
 				);

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -530,17 +530,29 @@ Calling `createLayoutState()` from a module bundle restores classes, but **not b
 
 ### Inline restore script in `<head>`
 
-Place this synchronous IIFE in `<head>` before the bundle. It reads the same `localStorage` key that `createLayoutState` uses and applies the saved classes to `<html>` during parse:
+Place this synchronous IIFE in `<head>` before the bundle to restore persisted `layout-*` classes before first paint. Set `storageKey` to match the value passed to `createLayoutState()`. Leave `excludesKey` empty unless you use the [exclusions API](#excluding-classes-per-view-advanced) below.
 
 ```html-no-example
 <head>
 	<script>
 		(function () {
 			try {
+				var storageKey = 'my-storage-key';
+				var excludesKey = '';
+
 				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
-				var view = state['my-storage-key'] || {};
+				var view = state[storageKey] || {};
+				var excluded = {};
+
+				if (excludesKey) {
+					var ex = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
+					var sx = Object.prototype.hasOwnProperty.call(ex, excludesKey) ? ex[excludesKey] : null;
+					if (sx && typeof sx === 'object') excluded = sx;
+				}
+
 				var html = document.documentElement;
 				for (var c in view) {
+					if (Object.prototype.hasOwnProperty.call(excluded, c)) continue;
 					if (view[c]) html.classList.add(c);
 					else html.classList.remove(c);
 				}
@@ -551,11 +563,11 @@ Place this synchronous IIFE in `<head>` before the bundle. It reads the same `lo
 </head>
 ```
 
-Atlas ships ready-made helpers for this — see [Display helpers gated on JS restoration](#display-helpers-gated-on-js-restoration). The sentinel is a data attribute rather than a `layout-*` class, so `createLayoutState` does not persist it.
+Atlas ships ready-made helpers — see [Display helpers gated on JS restoration](#display-helpers-gated-on-js-restoration). Those helpers use a data attribute, not a `layout-*` class, so `createLayoutState` does not persist them.
 
 ### Excluding classes per view (advanced)
 
-When a view shares `storageKey` with others but does not own every `layout-*` class — for example an editor view with no left nav — list those classes in `excludes`. They will not be restored, persisted, or dispatched to subscribers for that view.
+Use `excludes` when a view shares `storageKey` with others but should ignore some `layout-*` classes — for example an editor view with no left nav. Excluded classes are not restored, persisted, or sent to subscribers.
 
 ```typescript
 const layoutState = createLayoutState({
@@ -565,48 +577,9 @@ const layoutState = createLayoutState({
 });
 ```
 
-| Option           | Effect                                                                                                                                                |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `excludesKey`  | Names this view's blocklist inside a second `localStorage` entry, `atlas-layout-exclusions`. Distinct from `storageKey`.                              |
-| `excludes`       | Classes blocked for this view. Construction writes the list to `atlas-layout-exclusions[excludesKey]`, replacing any prior list. Pass `[]` to clear. |
+`excludesKey` names this view's list inside a second `localStorage` entry (`atlas-layout-exclusions`); `excludes` is the list of `layout-*` class names to write there on construction. Pass `[]` to clear; omit `excludes` to consume rules written by another view.
 
-Exclusions apply symmetrically:
-
-1. **Restore** — excluded classes are not applied to `<html>` during initial restore.
-2. **Persist** — adding or removing an excluded class on `<html>` is not written to `storageKey`.
-3. **Subscribers** — `subscribe()` callbacks for an excluded class never fire, including the immediate replay at subscribe time.
-
-Other views can reuse the same `storageKey` with a different `excludesKey`, or omit `excludesKey` entirely. Each key's exclusions stay isolated.
-
-For pre-paint restore to honor exclusions, the inline IIFE must read `atlas-layout-exclusions` too:
-
-```html-no-example
-<head>
-	<script>
-		(function () {
-			try {
-				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
-				var view = state['my-storage-key'] || {};
-				var key = 'editor-view';
-				var blocked = {};
-				if (key) {
-					var ex = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
-					var sx = Object.prototype.hasOwnProperty.call(ex, key) ? ex[key] : null;
-					if (sx && typeof sx === 'object') blocked = sx;
-				}
-				var html = document.documentElement;
-				for (var c in view) {
-					if (Object.prototype.hasOwnProperty.call(blocked, c)) continue;
-					if (view[c]) html.classList.add(c);
-					else html.classList.remove(c);
-				}
-			} catch (e) {}
-		})();
-	</script>
-</head>
-```
-
-Exclusion rules are re-read on every persist and dispatch, so updates take effect without recreating the instance. Supplying `excludesKey` without `excludes` makes the instance a read-only consumer of rules written elsewhere.
+To honor exclusions before first paint, set `excludesKey` in the [inline restore script above](#inline-restore-script-in-head) to the same value.
 
 ### Content Security Policy
 

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -553,6 +553,61 @@ Place this synchronous IIFE in `<head>` before the bundle. It reads the same `lo
 
 Atlas ships ready-made helpers for this — see [Display helpers gated on JS restoration](#display-helpers-gated-on-js-restoration). The sentinel is a data attribute rather than a `layout-*` class, so `createLayoutState` does not persist it.
 
+### Excluding classes per view (advanced)
+
+When a view shares `storageKey` with others but does not own every `layout-*` class — for example an editor view with no left nav — list those classes in `excludes`. They will not be restored, persisted, or dispatched to subscribers for that view.
+
+```typescript
+const layoutState = createLayoutState({
+	storageKey: 'docs-shared',
+	excludesScope: 'editor-view',
+	excludes: ['layout-menu-collapsed', 'layout-aside-collapsed']
+});
+```
+
+| Option           | Effect                                                                                                                                                |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `excludesScope`  | Names this view's blocklist inside a second `localStorage` entry, `atlas-layout-exclusions`. Distinct from `storageKey`.                              |
+| `excludes`       | Classes blocked for this view. Construction writes the list to `atlas-layout-exclusions[excludesScope]`, replacing any prior list. Pass `[]` to clear. |
+
+Exclusions apply symmetrically:
+
+1. **Restore** — excluded classes are not applied to `<html>` during initial restore.
+2. **Persist** — adding or removing an excluded class on `<html>` is not written to `storageKey`.
+3. **Subscribers** — `subscribe()` callbacks for an excluded class never fire, including the immediate replay at subscribe time.
+
+Other views can reuse the same `storageKey` with a different `excludesScope`, or omit `excludesScope` entirely. Each scope's exclusions stay isolated.
+
+For pre-paint restore to honor exclusions, the inline IIFE must read `atlas-layout-exclusions` too:
+
+```html-no-example
+<head>
+	<script>
+		(function () {
+			try {
+				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
+				var view = state['my-storage-key'] || {};
+				var scope = 'editor-view';
+				var blocked = {};
+				if (scope) {
+					var ex = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
+					var sx = Object.prototype.hasOwnProperty.call(ex, scope) ? ex[scope] : null;
+					if (sx && typeof sx === 'object') blocked = sx;
+				}
+				var html = document.documentElement;
+				for (var c in view) {
+					if (Object.prototype.hasOwnProperty.call(blocked, c)) continue;
+					if (view[c]) html.classList.add(c);
+					else html.classList.remove(c);
+				}
+			} catch (e) {}
+		})();
+	</script>
+</head>
+```
+
+Exclusion rules are re-read on every persist and dispatch, so updates take effect without recreating the instance. Supplying `excludesScope` without `excludes` makes the instance a read-only consumer of rules written elsewhere.
+
 ### Content Security Policy
 
 Inline `<script>` requires `'unsafe-inline'` or a `'sha256-...'` hash in `script-src`. Atlas places the snippet **before** the CSP `<meta>` tag so the policy applies only to later elements; alternatively, add the script body's SHA-256 hash to `script-src`.

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -7,7 +7,7 @@ classPrefixes:
   - layout
 hero: true
 layoutStorageKey: atlas-layout-page
-layoutExcludesScope: atlas-layout-page-view
+layoutExcludesKey: atlas-layout-page-view
 ---
 
 # Layout
@@ -560,15 +560,15 @@ When a view shares `storageKey` with others but does not own every `layout-*` cl
 ```typescript
 const layoutState = createLayoutState({
 	storageKey: 'docs-shared',
-	excludesScope: 'editor-view',
+	excludesKey: 'editor-view',
 	excludes: ['layout-menu-collapsed', 'layout-aside-collapsed']
 });
 ```
 
 | Option           | Effect                                                                                                                                                |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `excludesScope`  | Names this view's blocklist inside a second `localStorage` entry, `atlas-layout-exclusions`. Distinct from `storageKey`.                              |
-| `excludes`       | Classes blocked for this view. Construction writes the list to `atlas-layout-exclusions[excludesScope]`, replacing any prior list. Pass `[]` to clear. |
+| `excludesKey`  | Names this view's blocklist inside a second `localStorage` entry, `atlas-layout-exclusions`. Distinct from `storageKey`.                              |
+| `excludes`       | Classes blocked for this view. Construction writes the list to `atlas-layout-exclusions[excludesKey]`, replacing any prior list. Pass `[]` to clear. |
 
 Exclusions apply symmetrically:
 
@@ -576,7 +576,7 @@ Exclusions apply symmetrically:
 2. **Persist** — adding or removing an excluded class on `<html>` is not written to `storageKey`.
 3. **Subscribers** — `subscribe()` callbacks for an excluded class never fire, including the immediate replay at subscribe time.
 
-Other views can reuse the same `storageKey` with a different `excludesScope`, or omit `excludesScope` entirely. Each scope's exclusions stay isolated.
+Other views can reuse the same `storageKey` with a different `excludesKey`, or omit `excludesKey` entirely. Each key's exclusions stay isolated.
 
 For pre-paint restore to honor exclusions, the inline IIFE must read `atlas-layout-exclusions` too:
 
@@ -587,11 +587,11 @@ For pre-paint restore to honor exclusions, the inline IIFE must read `atlas-layo
 			try {
 				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
 				var view = state['my-storage-key'] || {};
-				var scope = 'editor-view';
+				var key = 'editor-view';
 				var blocked = {};
-				if (scope) {
+				if (key) {
 					var ex = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
-					var sx = Object.prototype.hasOwnProperty.call(ex, scope) ? ex[scope] : null;
+					var sx = Object.prototype.hasOwnProperty.call(ex, key) ? ex[key] : null;
 					if (sx && typeof sx === 'object') blocked = sx;
 				}
 				var html = document.documentElement;
@@ -606,7 +606,7 @@ For pre-paint restore to honor exclusions, the inline IIFE must read `atlas-layo
 </head>
 ```
 
-Exclusion rules are re-read on every persist and dispatch, so updates take effect without recreating the instance. Supplying `excludesScope` without `excludes` makes the instance a read-only consumer of rules written elsewhere.
+Exclusion rules are re-read on every persist and dispatch, so updates take effect without recreating the instance. Supplying `excludesKey` without `excludes` makes the instance a read-only consumer of rules written elsewhere.
 
 ### Content Security Policy
 

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -7,6 +7,7 @@ classPrefixes:
   - layout
 hero: true
 layoutStorageKey: atlas-layout-page
+layoutExcludesScope: atlas-layout-page-view
 ---
 
 # Layout

--- a/site/src/scaffold/scripts/layout-page.ts
+++ b/site/src/scaffold/scripts/layout-page.ts
@@ -1,4 +1,4 @@
-import { createLayoutState } from '@microsoft/atlas-js/src/index';
+import { createLayoutState, setLayoutExclusions } from '@microsoft/atlas-js/src/index';
 
 const layoutsClasses = [
 	'layout-single',
@@ -38,10 +38,32 @@ export function initLayoutPageControls() {
 	// demo page reloads. Subscribers below sync each demo button's UI to the
 	// restored state, then re-fire on subsequent toggles so click handlers
 	// don't need to update aria attributes themselves.
+	//
+	// `excludesScope` opts this view into a secondary, persisted blocklist
+	// stored under `localStorage['atlas-layout-exclusions']`. Other views
+	// that share `storageKey: 'atlas-layout-page'` can supply a different
+	// `excludesScope` (or none) so they read the same shared preferences but
+	// skip the classes they don't own. Because the rules live in storage,
+	// the inline pre-paint IIFE in `standard.html` honors them too — no
+	// flash of the wrong layout state during hard reloads or SPA hops into
+	// a view with different ownership.
 	const layoutState = createLayoutState({
 		storageKey: 'atlas-layout-page',
+		excludesScope: 'atlas-layout-page-view',
 		useViewTransitionOnRestore: true
 	});
+
+	// Example: an SPA router landing on a "flyout-only" sibling view would
+	// seed the blocklist before render so menu/aside state from other views
+	// can't bleed in:
+	//
+	//   setLayoutExclusions('flyout-only-view', [
+	//       'layout-menu-collapsed',
+	//       'layout-aside-collapsed'
+	//   ]);
+	//
+	// The demo page owns every class it persists, so it clears its scope.
+	setLayoutExclusions('atlas-layout-page-view', []);
 
 	for (const layoutClass of layoutsClasses) {
 		layoutState.subscribe(layoutClass, 'always', ({ isApplied }) => {

--- a/site/src/scaffold/scripts/layout-page.ts
+++ b/site/src/scaffold/scripts/layout-page.ts
@@ -39,29 +39,29 @@ export function initLayoutPageControls() {
 	// restored state, then re-fire on subsequent toggles so click handlers
 	// don't need to update aria attributes themselves.
 	//
-	// `excludesScope` opts this view into a secondary, persisted blocklist
+	// `excludesKey` opts this view into a secondary, persisted blocklist
 	// stored under `localStorage['atlas-layout-exclusions']`. Other views
 	// that share `storageKey: 'atlas-layout-page'` can declare a different
-	// `excludesScope` (or none) so they read the same shared preferences
+	// `excludesKey` (or none) so they read the same shared preferences
 	// but skip the classes they don't own. Pair with `excludes` to have
-	// the library seed/refresh the scope's blocklist on construction;
+	// the library seed/refresh the key's blocklist on construction;
 	// because the rules then live in storage, the inline pre-paint IIFE
 	// in `standard.html` honors them on the next page load — no flash of
 	// the wrong layout state.
 	//
 	// The demo page owns every class it persists, so it seeds an empty
 	// blocklist. A "flyout-only" sibling view sharing this `storageKey`
-	// would declare its own scope and exclude the classes it doesn't
+	// would declare its own key and exclude the classes it doesn't
 	// manage, e.g.:
 	//
 	//   createLayoutState({
 	//       storageKey: 'atlas-layout-page',
-	//       excludesScope: 'flyout-only-view',
+	//       excludesKey: 'flyout-only-view',
 	//       excludes: ['layout-menu-collapsed', 'layout-aside-collapsed']
 	//   });
 	const layoutState = createLayoutState({
 		storageKey: 'atlas-layout-page',
-		excludesScope: 'atlas-layout-page-view',
+		excludesKey: 'atlas-layout-page-view',
 		excludes: [],
 		useViewTransitionOnRestore: true
 	});

--- a/site/src/scaffold/scripts/layout-page.ts
+++ b/site/src/scaffold/scripts/layout-page.ts
@@ -8,7 +8,7 @@ const layoutsClasses = [
 	'layout-sidecar-right'
 ];
 
-// A function that removes all layout classes and sets the new one
+// Remove all layout classes and set the new one.
 function setLayoutClass(layoutToSet: string) {
 	for (const layoutClass of layoutsClasses) {
 		document.documentElement.classList.remove(layoutClass);
@@ -16,7 +16,7 @@ function setLayoutClass(layoutToSet: string) {
 	document.documentElement.classList.add(layoutToSet);
 }
 
-// A function that removes all layout classes and sets the new one
+// Return the layout class currently applied to <html>, or throw if none.
 function getCurrentLayoutClass() {
 	for (const layoutClass of layoutsClasses) {
 		if (document.documentElement.classList.contains(layoutClass)) {
@@ -27,38 +27,15 @@ function getCurrentLayoutClass() {
 }
 
 export function initLayoutPageControls() {
-	// Only the layout demo page contains the layout-set buttons.
-	// On every other site page this function should be a no-op so we don't
-	// persist or restore layout-* classes that don't belong to it.
+	// Demo-page-only; bail on other pages so we don't persist their `layout-*` classes.
 	if (!document.querySelector('[data-set-layout]')) {
 		return;
 	}
 
-	// Persist `layout-*` classes on <html> and replay them when the layout
-	// demo page reloads. Subscribers below sync each demo button's UI to the
-	// restored state, then re-fire on subsequent toggles so click handlers
-	// don't need to update aria attributes themselves.
-	//
-	// `excludesKey` opts this view into a secondary, persisted blocklist
-	// stored under `localStorage['atlas-layout-exclusions']`. Other views
-	// that share `storageKey: 'atlas-layout-page'` can declare a different
-	// `excludesKey` (or none) so they read the same shared preferences
-	// but skip the classes they don't own. Pair with `excludes` to have
-	// the library seed/refresh the key's blocklist on construction;
-	// because the rules then live in storage, the inline pre-paint IIFE
-	// in `standard.html` honors them on the next page load — no flash of
-	// the wrong layout state.
-	//
-	// The demo page owns every class it persists, so it seeds an empty
-	// blocklist. A "flyout-only" sibling view sharing this `storageKey`
-	// would declare its own key and exclude the classes it doesn't
-	// manage, e.g.:
-	//
-	//   createLayoutState({
-	//       storageKey: 'atlas-layout-page',
-	//       excludesKey: 'flyout-only-view',
-	//       excludes: ['layout-menu-collapsed', 'layout-aside-collapsed']
-	//   });
+	// `excludesKey` + `excludes: []` seeds an empty blocklist under
+	// `atlas-layout-exclusions['atlas-layout-page-view']`. A sibling view that
+	// shares `storageKey: 'atlas-layout-page'` can declare its own key to skip
+	// classes it doesn't own — see `site/src/components/layout.md` for details.
 	const layoutState = createLayoutState({
 		storageKey: 'atlas-layout-page',
 		excludesKey: 'atlas-layout-page-view',

--- a/site/src/scaffold/scripts/layout-page.ts
+++ b/site/src/scaffold/scripts/layout-page.ts
@@ -1,4 +1,4 @@
-import { createLayoutState, setLayoutExclusions } from '@microsoft/atlas-js/src/index';
+import { createLayoutState } from '@microsoft/atlas-js/src/index';
 
 const layoutsClasses = [
 	'layout-single',
@@ -41,29 +41,30 @@ export function initLayoutPageControls() {
 	//
 	// `excludesScope` opts this view into a secondary, persisted blocklist
 	// stored under `localStorage['atlas-layout-exclusions']`. Other views
-	// that share `storageKey: 'atlas-layout-page'` can supply a different
-	// `excludesScope` (or none) so they read the same shared preferences but
-	// skip the classes they don't own. Because the rules live in storage,
-	// the inline pre-paint IIFE in `standard.html` honors them too — no
-	// flash of the wrong layout state during hard reloads or SPA hops into
-	// a view with different ownership.
+	// that share `storageKey: 'atlas-layout-page'` can declare a different
+	// `excludesScope` (or none) so they read the same shared preferences
+	// but skip the classes they don't own. Pair with `excludes` to have
+	// the library seed/refresh the scope's blocklist on construction;
+	// because the rules then live in storage, the inline pre-paint IIFE
+	// in `standard.html` honors them on the next page load — no flash of
+	// the wrong layout state.
+	//
+	// The demo page owns every class it persists, so it seeds an empty
+	// blocklist. A "flyout-only" sibling view sharing this `storageKey`
+	// would declare its own scope and exclude the classes it doesn't
+	// manage, e.g.:
+	//
+	//   createLayoutState({
+	//       storageKey: 'atlas-layout-page',
+	//       excludesScope: 'flyout-only-view',
+	//       excludes: ['layout-menu-collapsed', 'layout-aside-collapsed']
+	//   });
 	const layoutState = createLayoutState({
 		storageKey: 'atlas-layout-page',
 		excludesScope: 'atlas-layout-page-view',
+		excludes: [],
 		useViewTransitionOnRestore: true
 	});
-
-	// Example: an SPA router landing on a "flyout-only" sibling view would
-	// seed the blocklist before render so menu/aside state from other views
-	// can't bleed in:
-	//
-	//   setLayoutExclusions('flyout-only-view', [
-	//       'layout-menu-collapsed',
-	//       'layout-aside-collapsed'
-	//   ]);
-	//
-	// The demo page owns every class it persists, so it clears its scope.
-	setLayoutExclusions('atlas-layout-page-view', []);
 
 	for (const layoutClass of layoutsClasses) {
 		layoutState.subscribe(layoutClass, 'always', ({ isApplied }) => {

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -11,9 +11,9 @@
 					var v = s['{{{layoutStorageKey}}}'] || {};
 					var k = '{{{layoutExcludesKey}}}';
 					var blocked = {};
-						if (k) {
+					if (k) {
 						var x = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
-							var sx = Object.prototype.hasOwnProperty.call(x, k) ? x[k] : null;
+						var sx = Object.prototype.hasOwnProperty.call(x, k) ? x[k] : null;
 						if (sx && typeof sx === 'object') {
 							blocked = sx;
 						}

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -9,11 +9,11 @@
 			(function () {
 					var s = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
 					var v = s['{{{layoutStorageKey}}}'] || {};
-					var scope = '{{{layoutExcludesScope}}}';
+					var k = '{{{layoutExcludesKey}}}';
 					var blocked = {};
-					if (scope) {
+						if (k) {
 						var x = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
-						var sx = Object.prototype.hasOwnProperty.call(x, scope) ? x[scope] : null;
+							var sx = Object.prototype.hasOwnProperty.call(x, k) ? x[k] : null;
 						if (sx && typeof sx === 'object') {
 							blocked = sx;
 						}

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -9,8 +9,18 @@
 			(function () {
 					var s = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
 					var v = s['{{{layoutStorageKey}}}'] || {};
+					var scope = '{{{layoutExcludesScope}}}';
+					var blocked = {};
+					if (scope) {
+						var x = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
+						var sx = Object.prototype.hasOwnProperty.call(x, scope) ? x[scope] : null;
+						if (sx && typeof sx === 'object') {
+							blocked = sx;
+						}
+					}
 					var html = document.documentElement;
 					for (var c in v) {
+						if (Object.prototype.hasOwnProperty.call(blocked, c)) continue;
 						if (v[c]) html.classList.add(c);
 						else html.classList.remove(c);
 					}

--- a/site/src/scaffold/token.html
+++ b/site/src/scaffold/token.html
@@ -15,9 +15,9 @@
 					var v = s['{{{layoutStorageKey}}}'] || {};
 					var k = '{{{layoutExcludesKey}}}';
 					var blocked = {};
-						if (k) {
+					if (k) {
 						var x = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
-							var sx = Object.prototype.hasOwnProperty.call(x, k) ? x[k] : null;
+						var sx = Object.prototype.hasOwnProperty.call(x, k) ? x[k] : null;
 						if (sx && typeof sx === 'object') {
 							blocked = sx;
 						}

--- a/site/src/scaffold/token.html
+++ b/site/src/scaffold/token.html
@@ -13,11 +13,11 @@
 			(function () {
 					var s = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
 					var v = s['{{{layoutStorageKey}}}'] || {};
-					var scope = '{{{layoutExcludesScope}}}';
+					var k = '{{{layoutExcludesKey}}}';
 					var blocked = {};
-					if (scope) {
+						if (k) {
 						var x = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
-						var sx = Object.prototype.hasOwnProperty.call(x, scope) ? x[scope] : null;
+							var sx = Object.prototype.hasOwnProperty.call(x, k) ? x[k] : null;
 						if (sx && typeof sx === 'object') {
 							blocked = sx;
 						}

--- a/site/src/scaffold/token.html
+++ b/site/src/scaffold/token.html
@@ -13,8 +13,18 @@
 			(function () {
 					var s = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
 					var v = s['{{{layoutStorageKey}}}'] || {};
+					var scope = '{{{layoutExcludesScope}}}';
+					var blocked = {};
+					if (scope) {
+						var x = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
+						var sx = Object.prototype.hasOwnProperty.call(x, scope) ? x[scope] : null;
+						if (sx && typeof sx === 'object') {
+							blocked = sx;
+						}
+					}
 					var html = document.documentElement;
 					for (var c in v) {
+						if (Object.prototype.hasOwnProperty.call(blocked, c)) continue;
 						if (v[c]) html.classList.add(c);
 						else html.classList.remove(c);
 					}


### PR DESCRIPTION
Link: [preview](http://localhost:1111/)

Two new optional LayoutStateOptions fields let views that share a storageKey exclude specific layout-* classes from restore, persist, and subscriber dispatch. Non-breaking — omit both for prior behavior.

API

 - excludesKey — string or function returning a string. Scope key inside new localStorage entry atlas-layout-exclusions. Omit to disable.
 - excludes — string[]. Classes this view blocks. Seeded into atlas-layout-exclusions[scope] on init. Requires excludesScope. Pass [] to clear; omit to consume read-only.

Excluded classes are skipped in restore, persist (add/remove), and subscriber dispatch. Each path re-reads exclusions per invocation. The pre-paint IIFE in standard.html / token.html also honors them, with hasOwnProperty.call() guarding against prototype poisoning.

Trade-off: first visit has no entry yet, so pre-paint cannot filter until the bundle seeds rules. Matches the primary preferences bucket.

## Testing

1. Step one
2. Step two
   Expected result:

## Additional information

[Optional]

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [x] Did your pull request add anything to the /js/ folder? Consider adding unit tests.
- [x] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.