### PR TITLE
improve layout state SPA lifecycle (suspend/resume/dispose)

### DIFF
--- a/.changeset/layout-state-excludes.md
+++ b/.changeset/layout-state-excludes.md
@@ -2,4 +2,4 @@
 '@microsoft/atlas-js': minor
 ---
 
-Add `excludesKey` and `excludes` options to `createLayoutState` so views that share a `storageKey` can opt specific `layout-*` classes out of restore, persist, and subscriber dispatch. Rules are persisted under a new `localStorage` entry, `atlas-layout-exclusions`, and honored by the inline pre-paint script.
+Add `excludesKey` and `excludes` options to `createLayoutState` so views that share a `storageKey` can prevent specific `layout-*` classes from being restored, persisted, or sent to subscribers. Rules persist under a new `localStorage` entry, `atlas-layout-exclusions`, and are honored by the inline pre-paint script.

--- a/.changeset/layout-state-excludes.md
+++ b/.changeset/layout-state-excludes.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-js': minor
+---
+
+Add `excludesKey` and `excludes` options to `createLayoutState` so views that share a `storageKey` can opt specific `layout-*` classes out of restore, persist, and subscriber dispatch. Rules are persisted under a new `localStorage` entry, `atlas-layout-exclusions`, and honored by the inline pre-paint script.

--- a/.changeset/layout-state-suspend-resume.md
+++ b/.changeset/layout-state-suspend-resume.md
@@ -1,0 +1,9 @@
+---
+'@microsoft/atlas-js': major
+---
+
+Replace `LayoutStateInstance.stop()` with `suspend()`, `resume()`, and `dispose()` so a single long-lived layout state instance can serve every route in a client-side-routed app. `suspend()` synchronously disconnects the observer and clears `data-layout-restored`; `resume()` re-reads the `storageKey` / `excludesKey` / `excludes` getters, re-restores persisted state, and replays matching subscribers against the freshly-restored state; `dispose()` is a hard teardown that clears subscriptions and pending queues. After `dispose()`, `subscribe` / `suspend` / `resume` throw, `getViewState` / `getState` still work (they read from storage), and previously-returned unsubscribe functions remain safe no-ops.
+
+The `excludes` option now accepts a getter (`string[] | (() => string[])`) so SPA route changes can supply different exclusion lists without recreating the instance — the getter is re-read on every `resume()`.
+
+**Migrating from `stop()`:** Replace each `state.stop()` call with `state.suspend()` (for paired router-event integration) or `state.dispose()` (for full teardown / test cleanup). Note that `suspend()` additionally removes `data-layout-restored`; if you were removing the attribute manually around `stop()`, you can drop that line.

--- a/.changeset/layout-state-suspend-resume.md
+++ b/.changeset/layout-state-suspend-resume.md
@@ -2,8 +2,12 @@
 '@microsoft/atlas-js': major
 ---
 
-Replace `LayoutStateInstance.stop()` with `suspend()`, `resume()`, and `dispose()` so a single long-lived layout state instance can serve every route in a client-side-routed app. `suspend()` synchronously disconnects the observer and clears `data-layout-restored`; `resume()` re-reads the `storageKey` / `excludesKey` / `excludes` getters, re-restores persisted state, and replays matching subscribers against the freshly-restored state; `dispose()` is a hard teardown that clears subscriptions and pending queues. After `dispose()`, `subscribe` / `suspend` / `resume` throw, `getViewState` / `getState` still work (they read from storage), and previously-returned unsubscribe functions remain safe no-ops.
+Replace `LayoutStateInstance.stop()` with `suspend()`, `resume()`, and `dispose()` so a single long-lived layout state instance can serve every route in a client-side-routed app:
 
-The `excludes` option now accepts a getter (`string[] | (() => string[])`) so SPA route changes can supply different exclusion lists without recreating the instance — the getter is re-read on every `resume()`.
+- `suspend()` — synchronously disconnects the observer and clears `data-layout-restored`. Subscriptions are preserved.
+- `resume()` — re-reads the `storageKey` / `excludesKey` / `excludes` getters, re-restores persisted state, and replays matching subscribers against the freshly-restored state.
+- `dispose()` — hard teardown that clears subscriptions and pending queues. Afterward, `subscribe()` / `suspend()` / `resume()` throw, `getViewState()` / `getState()` still work (they read from storage), and previously-returned unsubscribe functions remain safe no-ops.
 
-**Migrating from `stop()`:** Replace each `state.stop()` call with `state.suspend()` (for paired router-event integration) or `state.dispose()` (for full teardown / test cleanup). Note that `suspend()` additionally removes `data-layout-restored`; if you were removing the attribute manually around `stop()`, you can drop that line.
+The `excludes` option now also accepts a getter (`string[] | (() => string[])`), re-read on every persist and every `resume()`, so SPA route changes can supply different exclusion lists without recreating the instance.
+
+**Migrating from `stop()`:** Replace each `state.stop()` call with `state.suspend()` when you will call `state.resume()` on the matching router event, or with `state.dispose()` for full teardown or test cleanup. `suspend()` also removes `data-layout-restored`, so drop any manual clearing you did around `stop()`.

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -59,8 +59,9 @@ export function initLayout() {
 /**
  * Persists `layout-*` class state per `storageKey`. Instance is live on return.
  *
- * Subscribers fire on class transitions, with an immediate replay if the current
- * state already matches. Initial replay waits for `deferCallbacksUntil`.
+ * A subscriber fires when its watched class enters the requested state; if the
+ * class is already in that state, the callback is queued for an initial replay
+ * once `deferCallbacksUntil` resolves.
  *
  * `data-layout-restored="true"` is always set after the initial flush — even on
  * setup or callback failure — so CSS gated on it cannot leave content hidden.
@@ -87,12 +88,12 @@ export function initLayout() {
  *
  * Subscribers registered once at boot stay live across every navigation — no
  * re-registration required. `resume()` re-fires matching subscribers against
- * the freshly-restored state, so subscriber callbacks **must be idempotent**
- * and should look up DOM each time (don't capture stale element references).
+ * the freshly-restored state, so callbacks **must be idempotent** and should
+ * look up the DOM each time (don't capture stale element references).
  *
  * **Order matters.** Call `suspend()` BEFORE any DOM mutation that touches
  * `<html>`'s class list, and `resume()` AFTER. `suspend()` disconnects the
- * observer synchronously so mutations during the navigation window cannot
+ * observer synchronously, so mutations during the navigation window cannot
  * leak into the persisted state.
  */
 
@@ -133,11 +134,11 @@ export interface LayoutStateOptions {
 	 */
 	excludesKey?: string | (() => string);
 	/**
-	 * Classes to write into `atlas-layout-exclusions[excludesKey]` on
-	 * construction and on every `resume()`. Requires `excludesKey`. Empty
-	 * array clears the blocklist; omission leaves any persisted entry
-	 * untouched. Getter is re-read per write so SPA route changes can supply
-	 * different exclusions.
+	 * Classes to store under the current `excludesKey` in
+	 * `atlas-layout-exclusions`, written on construction and on every
+	 * `resume()`. Requires `excludesKey`. An empty array clears the list;
+	 * omission leaves any persisted entry untouched. The getter is re-read
+	 * per write, so SPA route changes can supply different exclusions.
 	 */
 	excludes?: string[] | (() => string[]);
 	/** Delays initial subscriber callbacks. Defaults to next microtask. */
@@ -164,16 +165,16 @@ export interface LayoutStateInstance {
 		callback: LayoutCallback,
 		options?: LayoutSubscribeOptions
 	): () => void;
-	/** Current bucket state. Safe to call after `dispose()`. */
+	/** State stored under the current `storageKey`. Safe to call after `dispose()`. */
 	getViewState(): LayoutStateView;
-	/** All bucket state. Safe to call after `dispose()`. */
+	/** State for all `storageKey` buckets. Safe to call after `dispose()`. */
 	getState(): LayoutStatePersisted;
 	/**
-	 * Pause observation and clear `data-layout-restored` so until-restored
-	 * CSS gates re-engage. Subscriptions are preserved. `MutationObserver`
-	 * is disconnected synchronously, so it is safe to call immediately
-	 * before a DOM swap that overwrites `<html>`'s class list. Idempotent.
-	 * Throws if disposed.
+	 * Pause observation and clear `data-layout-restored` so CSS that waits for
+	 * layout restoration re-engages. Subscriptions are preserved. The
+	 * `MutationObserver` is disconnected synchronously, so this is safe to call
+	 * immediately before a DOM swap that overwrites `<html>`'s class list.
+	 * Idempotent. Throws if disposed.
 	 */
 	suspend(): void;
 	/**
@@ -234,8 +235,13 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 	const DISPOSED_MESSAGE =
 		'LayoutStateInstance has been disposed; create a new instance with createLayoutState()';
 
-	// Coerce prototype keys to avoid poisoning the persisted state map.
-	function sanitizeKey(raw: string): string {
+	// Coerce prototype keys, and nullish getter results, to avoid poisoning the
+	// persisted state map or writing a literal "undefined" / "null" bucket when
+	// a route getter resolves to nothing.
+	function sanitizeKey(raw: string | null | undefined): string {
+		if (raw == null) {
+			return 'default';
+		}
 		return sanitizeExclusionsKey(raw);
 	}
 
@@ -244,12 +250,17 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		return sanitizeKey(raw);
 	}
 
-	// Null disables exclusions.
+	// Null disables exclusions — both when the option is omitted and when a
+	// getter resolves to nullish for the current route, so a route with no
+	// scope reads and writes no exclusions instead of a junk bucket.
 	function getExcludesKey(): string | null {
 		if (excludesKeyOption === undefined) {
 			return null;
 		}
 		const raw = typeof excludesKeyOption === 'function' ? excludesKeyOption() : excludesKeyOption;
+		if (raw == null) {
+			return null;
+		}
 		return sanitizeKey(raw);
 	}
 
@@ -360,8 +371,8 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 			pendingCallbacks = [];
 			return;
 		}
-		// Suspended before the deferred flush resolved: keep the queue
-		// dangling (resume() will overwrite it from current state) and
+		// Suspended before the deferred flush resolved: leave the queued
+		// callbacks unflushed (resume() replaces them from current state) and
 		// leave the attribute cleared so until-restored CSS stays engaged.
 		if (suspended) {
 			return;
@@ -696,8 +707,8 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		observer?.disconnect();
 		observer = null;
 		clearRestored();
-		// Drop in-flight batched VTs; their target state is about to be
-		// replaced by whatever resume() restores.
+		// Drop in-flight batched view transitions; resume() will restore the
+		// route's current layout state in their place.
 		pendingTransitionFns = [];
 	}
 

--- a/js/src/behaviors/layout.ts
+++ b/js/src/behaviors/layout.ts
@@ -68,6 +68,32 @@ export function initLayout() {
  *
  * View transitions coalesce same-microtask callbacks and skip while another is
  * animating, avoiding `InvalidStateError` aborts.
+ *
+ * ### SPA integration
+ *
+ * Create the instance once at boot. Pair `suspend()` with `resume()` around
+ * navigations that mutate `<html>`'s class list:
+ *
+ * ```ts
+ * const layoutState = createLayoutState({
+ *   storageKey:  () => currentRoute.layoutKey,     // getter, re-read on resume
+ *   excludesKey: () => currentRoute.excludesKey,
+ *   excludes:    () => currentRoute.excludes
+ * });
+ *
+ * router.on('beforeNavigate', () => layoutState.suspend());
+ * router.on('afterNavigate',  () => layoutState.resume());
+ * ```
+ *
+ * Subscribers registered once at boot stay live across every navigation — no
+ * re-registration required. `resume()` re-fires matching subscribers against
+ * the freshly-restored state, so subscriber callbacks **must be idempotent**
+ * and should look up DOM each time (don't capture stale element references).
+ *
+ * **Order matters.** Call `suspend()` BEFORE any DOM mutation that touches
+ * `<html>`'s class list, and `resume()` AFTER. `suspend()` disconnects the
+ * observer synchronously so mutations during the navigation window cannot
+ * leak into the persisted state.
  */
 
 export type LayoutClassWhen = 'added' | 'removed' | 'always';
@@ -108,10 +134,12 @@ export interface LayoutStateOptions {
 	excludesKey?: string | (() => string);
 	/**
 	 * Classes to write into `atlas-layout-exclusions[excludesKey]` on
-	 * construction. Requires `excludesKey`. Empty array clears the blocklist;
-	 * omission leaves any persisted entry untouched.
+	 * construction and on every `resume()`. Requires `excludesKey`. Empty
+	 * array clears the blocklist; omission leaves any persisted entry
+	 * untouched. Getter is re-read per write so SPA route changes can supply
+	 * different exclusions.
 	 */
-	excludes?: string[];
+	excludes?: string[] | (() => string[]);
 	/** Delays initial subscriber callbacks. Defaults to next microtask. */
 	deferCallbacksUntil?: Promise<unknown>;
 	/** Wrap initial restoration in `document.startViewTransition` if available. */
@@ -126,7 +154,9 @@ export interface LayoutSubscribeOptions {
 export interface LayoutStateInstance {
 	/**
 	 * Subscribe to `className` transitions. Replays once if the current state
-	 * matches (queued behind `deferCallbacksUntil`). Returns an unsubscribe fn.
+	 * matches (queued behind `deferCallbacksUntil`). Returns an unsubscribe fn
+	 * which is always safe to call (including after `dispose()`). Throws if
+	 * the instance has been disposed.
 	 */
 	subscribe(
 		className: string,
@@ -134,12 +164,35 @@ export interface LayoutStateInstance {
 		callback: LayoutCallback,
 		options?: LayoutSubscribeOptions
 	): () => void;
-	/** Current bucket state. */
+	/** Current bucket state. Safe to call after `dispose()`. */
 	getViewState(): LayoutStateView;
-	/** All bucket state. */
+	/** All bucket state. Safe to call after `dispose()`. */
 	getState(): LayoutStatePersisted;
-	/** Stop observing; subscriptions remain registered. */
-	stop(): void;
+	/**
+	 * Pause observation and clear `data-layout-restored` so until-restored
+	 * CSS gates re-engage. Subscriptions are preserved. `MutationObserver`
+	 * is disconnected synchronously, so it is safe to call immediately
+	 * before a DOM swap that overwrites `<html>`'s class list. Idempotent.
+	 * Throws if disposed.
+	 */
+	suspend(): void;
+	/**
+	 * Resume observation. Re-reads `storageKey`, `excludesKey`, and
+	 * `excludes` getters, re-writes any configured exclusions, re-restores
+	 * persisted state, replays matching subscribers against the new state,
+	 * and re-sets `data-layout-restored`. No-op when not currently
+	 * suspended. Throws if disposed.
+	 */
+	resume(): void;
+	/**
+	 * Permanently tear down: disconnect the observer, clear all
+	 * subscriptions and pending queues, and remove `data-layout-restored`.
+	 * After dispose, `subscribe()`, `suspend()`, and `resume()` throw;
+	 * `getViewState()` and `getState()` still work (they read from
+	 * `storage`); previously-returned unsubscribe functions remain safe
+	 * no-ops. Idempotent.
+	 */
+	dispose(): void;
 }
 
 export interface LayoutSubscription {
@@ -178,6 +231,8 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 	const CLASS_PREFIX = 'layout-';
 	const STORAGE_KEY = 'atlas-layout-preferences';
 	const RESTORED_ATTRIBUTE = 'data-layout-restored';
+	const DISPOSED_MESSAGE =
+		'LayoutStateInstance has been disposed; create a new instance with createLayoutState()';
 
 	// Coerce prototype keys to avoid poisoning the persisted state map.
 	function sanitizeKey(raw: string): string {
@@ -198,9 +253,18 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		return sanitizeKey(raw);
 	}
 
+	// Re-read per call so SPA route changes pick up a new exclusion list.
+	function getConfiguredExcludes(): string[] | undefined {
+		if (excludesOption === undefined) {
+			return undefined;
+		}
+		return typeof excludesOption === 'function' ? excludesOption() : excludesOption;
+	}
+
 	// Seed exclusions so the next pre-paint IIFE sees them.
 	function writeConfiguredExclusions(): void {
-		if (excludesOption === undefined) {
+		const excludes = getConfiguredExcludes();
+		if (excludes === undefined) {
 			return;
 		}
 		const key = getExcludesKey();
@@ -220,7 +284,7 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 			}
 		}
 		const next: { [className: string]: true } = {};
-		for (const c of excludesOption) {
+		for (const c of excludes) {
 			next[c] = true;
 		}
 		state[key] = next;
@@ -259,17 +323,17 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		return new Set(Object.keys(scoped));
 	}
 
-	writeConfiguredExclusions();
-
 	const subscriptions = new Set<LayoutSubscription>();
 	let observer: MutationObserver | null = null;
 	let callbacksReady = false;
-	const pendingCallbacks: (() => void)[] = [];
+	let pendingCallbacks: (() => void)[] = [];
+	let suspended = false;
+	let disposed = false;
 
 	// Per-instance gate: coalesce same-microtask callbacks; run sync while active
 	// to avoid `InvalidStateError`.
 	let activeTransitionCount = 0;
-	const pendingTransitionFns: (() => void)[] = [];
+	let pendingTransitionFns: (() => void)[] = [];
 	let transitionMicrotaskQueued = false;
 
 	function dispatch(invoke: () => void): void {
@@ -285,11 +349,33 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		targetRoot.setAttribute(RESTORED_ATTRIBUTE, 'true');
 	}
 
+	function clearRestored(): void {
+		targetRoot.removeAttribute(RESTORED_ATTRIBUTE);
+	}
+
 	function flushPendingCallbacks(): void {
+		// Disposed before the deferred flush resolved: drop the queue and
+		// leave the attribute cleared.
+		if (disposed) {
+			pendingCallbacks = [];
+			return;
+		}
+		// Suspended before the deferred flush resolved: keep the queue
+		// dangling (resume() will overwrite it from current state) and
+		// leave the attribute cleared so until-restored CSS stays engaged.
+		if (suspended) {
+			return;
+		}
 		callbacksReady = true;
-		const queued = pendingCallbacks.splice(0);
+		const queued = pendingCallbacks;
+		pendingCallbacks = [];
 		try {
 			for (const invoke of queued) {
+				// Re-check between callbacks so a callback that calls dispose()
+				// stops draining the rest.
+				if (disposed) {
+					return;
+				}
 				try {
 					invoke();
 				} catch (err) {
@@ -299,7 +385,9 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 				}
 			}
 		} finally {
-			markRestored();
+			if (!disposed) {
+				markRestored();
+			}
 		}
 	}
 
@@ -346,7 +434,13 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		transitionMicrotaskQueued = true;
 		queueMicrotask(() => {
 			transitionMicrotaskQueued = false;
-			const batch = pendingTransitionFns.splice(0);
+			// Suspended or disposed during the microtask window: the queue
+			// was cleared, nothing to do.
+			if (disposed || suspended) {
+				return;
+			}
+			const batch = pendingTransitionFns;
+			pendingTransitionFns = [];
 			if (batch.length === 0) {
 				return;
 			}
@@ -449,12 +543,35 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		}
 	}
 
+	function replayMatchingSubscribers(): void {
+		const excluded = getExcludedClasses();
+		const eventStorageKey = getStorageKey();
+		for (const sub of subscriptions) {
+			if (excluded.has(sub.className)) {
+				continue;
+			}
+			const applied = isClassApplied(sub.className);
+			if (!matches(sub, applied)) {
+				continue;
+			}
+			const { callback, useViewTransition, className } = sub;
+			dispatch(() => {
+				startOptionalViewTransition(useViewTransition, () => {
+					callback({ className, isApplied: applied, storageKey: eventStorageKey });
+				});
+			});
+		}
+	}
+
 	function subscribe(
 		className: string,
 		when: LayoutClassWhen,
 		callback: LayoutCallback,
 		subscribeOptions: LayoutSubscribeOptions = {}
 	): () => void {
+		if (disposed) {
+			throw new Error(DISPOSED_MESSAGE);
+		}
 		const sub: LayoutSubscription = {
 			className,
 			when,
@@ -534,10 +651,111 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		saveState(state);
 	}
 
-	function stop(): void {
+	function mutationCallback(mutations: MutationRecord[]): void {
+		// Belt + suspenders: disconnect should prevent us reaching here, but
+		// a callback that disposed mid-batch should stop further processing.
+		if (disposed) {
+			return;
+		}
+		for (const mutation of mutations) {
+			if (disposed) {
+				return;
+			}
+			const oldClasses = (mutation.oldValue ?? '').split(/\s+/);
+			const newClasses = Array.from((mutation.target as Element).classList);
+			const { added, removed } = diffClasses(newClasses, oldClasses);
+
+			persistChanges(added, removed);
+
+			for (const c of added) {
+				fireMatching(c, true);
+			}
+			for (const c of removed) {
+				fireMatching(c, false);
+			}
+		}
+	}
+
+	function attachObserver(): void {
+		observer = new MutationObserver(mutationCallback);
+		observer.observe(targetRoot, {
+			attributes: true,
+			attributeFilter: ['class'],
+			attributeOldValue: true
+		});
+	}
+
+	function suspend(): void {
+		if (disposed) {
+			throw new Error(DISPOSED_MESSAGE);
+		}
+		if (suspended) {
+			return;
+		}
+		suspended = true;
 		observer?.disconnect();
 		observer = null;
+		clearRestored();
+		// Drop in-flight batched VTs; their target state is about to be
+		// replaced by whatever resume() restores.
+		pendingTransitionFns = [];
 	}
+
+	function resume(): void {
+		if (disposed) {
+			throw new Error(DISPOSED_MESSAGE);
+		}
+		if (!suspended) {
+			return;
+		}
+		suspended = false;
+
+		// Re-write exclusions FIRST so restore + replay see the right list.
+		writeConfiguredExclusions();
+
+		// Re-restore persisted state to the root. Use the sync transition
+		// path so the restore can't be aborted by a subsequent batch.
+		startOptionalViewTransition(useViewTransitionOnRestore, restoreInitialState, {
+			sync: true
+		});
+
+		// Reset the dispatch gate and clear any leftover queue so resume
+		// behaves like a fresh creation for subscriber-replay purposes.
+		callbacksReady = false;
+		pendingCallbacks = [];
+
+		// Queue replays for every subscriber whose current state matches.
+		replayMatchingSubscribers();
+
+		// Re-attach the observer AFTER restore so the restore itself doesn't
+		// echo back through persistChanges.
+		attachObserver();
+
+		// Drain on next microtask, same as initial creation.
+		Promise.resolve().then(flushPendingCallbacks, err => {
+			if (disposed) {
+				return;
+			}
+			// eslint-disable-next-line no-console
+			console.error('createLayoutState: resume flush rejected; flushing anyway', err);
+			flushPendingCallbacks();
+		});
+	}
+
+	function dispose(): void {
+		if (disposed) {
+			return;
+		}
+		disposed = true;
+		observer?.disconnect();
+		observer = null;
+		clearRestored();
+		subscriptions.clear();
+		pendingCallbacks = [];
+		pendingTransitionFns = [];
+	}
+
+	writeConfiguredExclusions();
 
 	// Mark restored even on setup failure so CSS gates can't strand content.
 	try {
@@ -545,30 +763,12 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 			sync: true
 		});
 
-		observer = new MutationObserver(mutations => {
-			for (const mutation of mutations) {
-				const oldClasses = (mutation.oldValue ?? '').split(/\s+/);
-				const newClasses = Array.from((mutation.target as Element).classList);
-				const { added, removed } = diffClasses(newClasses, oldClasses);
-
-				persistChanges(added, removed);
-
-				for (const c of added) {
-					fireMatching(c, true);
-				}
-				for (const c of removed) {
-					fireMatching(c, false);
-				}
-			}
-		});
-
-		observer.observe(targetRoot, {
-			attributes: true,
-			attributeFilter: ['class'],
-			attributeOldValue: true
-		});
+		attachObserver();
 
 		deferCallbacksUntil.then(flushPendingCallbacks, err => {
+			if (disposed) {
+				return;
+			}
 			// eslint-disable-next-line no-console
 			console.error(
 				'createLayoutState: deferCallbacksUntil rejected; flushing pending callbacks anyway',
@@ -587,6 +787,8 @@ export function createLayoutState(options: LayoutStateOptions = {}): LayoutState
 		subscribe,
 		getViewState,
 		getState: loadState,
-		stop
+		suspend,
+		resume,
+		dispose
 	};
 }

--- a/js/test/behaviors/layout.test.ts
+++ b/js/test/behaviors/layout.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { createLayoutState, LayoutStateInstance } from '../../src/behaviors/layout';
 
 const STORAGE_KEY = 'atlas-layout-preferences';
+const EXCLUSIONS_STORAGE_KEY = 'atlas-layout-exclusions';
 
 /* -------------------------------------------------------------------------- */
 /* Test helpers                                                               */
@@ -131,11 +132,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	// Disconnect any LayoutStateInstance MutationObservers before the next
-	// test starts mutating the DOM. `stop()` is idempotent.
+	// Dispose any LayoutStateInstance MutationObservers before the next
+	// test starts mutating the DOM. `dispose()` is idempotent.
 	while (liveInstances.length) {
 		try {
-			liveInstances.pop()?.stop();
+			liveInstances.pop()?.dispose();
 		} catch {
 			// Best-effort: never let teardown failures mask the real assertion.
 		}
@@ -863,43 +864,551 @@ describe('createLayoutState', () => {
 		});
 	});
 
-	describe('stop()', () => {
-		it('stops processing further mutations [ai generated]', async () => {
-			const root = createRoot();
-			const { storage } = createFakeStorage();
-			const state = track(
-				createLayoutState({
-					root,
-					storage,
-					storageKey: 'v',
-					deferCallbacksUntil: Promise.resolve()
-				})
-			);
-			const cb = vi.fn();
-			// 'added' avoids the immediate replay (class is absent).
-			state.subscribe('layout-twin', 'added', cb);
-			await flush();
-			state.stop();
-			root.classList.add('layout-twin');
-			await flush();
-			expect(cb).not.toHaveBeenCalled();
-			expect(state.getViewState()).toEqual({});
+	describe('suspend() / resume() / dispose()', () => {
+		describe('suspend()', () => {
+			it('stops processing further mutations [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage();
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				const cb = vi.fn();
+				state.subscribe('layout-twin', 'added', cb);
+				await flush();
+				state.suspend();
+				root.classList.add('layout-twin');
+				await flush();
+				expect(cb).not.toHaveBeenCalled();
+				expect(state.getViewState()).toEqual({});
+			});
+
+			it('removes the data-layout-restored attribute from the root [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage();
+				const state = track(
+					createLayoutState({ root, storage, deferCallbacksUntil: Promise.resolve() })
+				);
+				await flush();
+				expect(root.getAttribute('data-layout-restored')).toBe('true');
+				state.suspend();
+				expect(root.hasAttribute('data-layout-restored')).toBe(false);
+			});
+
+			it('is idempotent (calling twice does not throw) [ai generated]', () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage();
+				const state = track(
+					createLayoutState({ root, storage, deferCallbacksUntil: Promise.resolve() })
+				);
+				expect(() => {
+					state.suspend();
+					state.suspend();
+				}).not.toThrow();
+			});
+
+			it('preserves subscriptions for replay by resume() [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({ v: { 'layout-twin': true } })
+				});
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				const cb = vi.fn();
+				state.subscribe('layout-twin', 'always', cb);
+				await flush();
+				cb.mockClear();
+				state.suspend();
+				state.resume();
+				await flush();
+				// Subscription persisted across suspend/resume and replayed.
+				expect(cb).toHaveBeenCalledWith(
+					expect.objectContaining({ className: 'layout-twin', isApplied: true })
+				);
+			});
+
+			it('suspend() throws when called after dispose() [ai generated]', () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage();
+				const state = track(
+					createLayoutState({ root, storage, deferCallbacksUntil: Promise.resolve() })
+				);
+				state.dispose();
+				expect(() => state.suspend()).toThrow(/disposed/);
+			});
 		});
 
-		it('is safe to call multiple times [ai generated]', () => {
-			const root = createRoot();
-			const { storage } = createFakeStorage();
-			const state = track(
-				createLayoutState({
-					root,
-					storage,
-					deferCallbacksUntil: Promise.resolve()
-				})
-			);
-			expect(() => {
-				state.stop();
-				state.stop();
-			}).not.toThrow();
+		describe('resume()', () => {
+			it('is a no-op when called on a non-suspended instance [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({ default: { 'layout-twin': true } })
+				});
+				const state = track(
+					createLayoutState({ root, storage, deferCallbacksUntil: Promise.resolve() })
+				);
+				const cb = vi.fn();
+				state.subscribe('layout-twin', 'always', cb);
+				await flush();
+				cb.mockClear();
+				state.resume();
+				await flush();
+				// No-op: subscriber not re-fired.
+				expect(cb).not.toHaveBeenCalled();
+			});
+
+			it('re-attaches the observer so subsequent class changes fire callbacks [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage();
+				const state = track(
+					createLayoutState({ root, storage, deferCallbacksUntil: Promise.resolve() })
+				);
+				const cb = vi.fn();
+				state.subscribe('layout-twin', 'added', cb);
+				await flush();
+				state.suspend();
+				state.resume();
+				await flush();
+				cb.mockClear();
+				root.classList.add('layout-twin');
+				await flush();
+				expect(cb).toHaveBeenCalledWith(
+					expect.objectContaining({ className: 'layout-twin', isApplied: true })
+				);
+			});
+
+			it('re-restores persisted state from the current storageKey bucket [ai generated]', async () => {
+				const root = createRoot();
+				const { storage, data } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({
+						pageA: { 'layout-twin': true },
+						pageB: { 'layout-holy-grail': true }
+					})
+				});
+				let key = 'pageA';
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: () => key,
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				await flush();
+				expect(root.classList.contains('layout-twin')).toBe(true);
+				expect(root.classList.contains('layout-holy-grail')).toBe(false);
+
+				state.suspend();
+				// Simulate SPA DOM swap: replace <html>'s class list with the
+				// destination page's server-rendered classes (none in this case).
+				root.className = '';
+				key = 'pageB';
+				state.resume();
+				await flush();
+
+				expect(root.classList.contains('layout-twin')).toBe(false);
+				expect(root.classList.contains('layout-holy-grail')).toBe(true);
+				// And the old bucket is untouched.
+				const persisted = JSON.parse(data[STORAGE_KEY]) as Record<string, Record<string, boolean>>;
+				expect(persisted.pageA).toEqual({ 'layout-twin': true });
+			});
+
+			it('re-reads the excludesKey getter so a route change picks up new exclusions [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({ shared: { 'layout-twin': true } }),
+					[EXCLUSIONS_STORAGE_KEY]: JSON.stringify({
+						pageA: {},
+						pageB: { 'layout-twin': true }
+					})
+				});
+				let excludesKey = 'pageA';
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'shared',
+						excludesKey: () => excludesKey,
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				await flush();
+				expect(root.classList.contains('layout-twin')).toBe(true);
+
+				state.suspend();
+				root.className = '';
+				excludesKey = 'pageB';
+				state.resume();
+				await flush();
+
+				// pageB excludes 'layout-twin' so restore skipped it.
+				expect(root.classList.contains('layout-twin')).toBe(false);
+			});
+
+			it('re-reads the excludes getter and re-writes to the current excludesKey bucket [ai generated]', async () => {
+				const root = createRoot();
+				const { storage, data } = createFakeStorage();
+				let exclusionList: string[] = ['layout-twin'];
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						excludesKey: 'view',
+						excludes: () => exclusionList,
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				await flush();
+				const seeded = JSON.parse(data[EXCLUSIONS_STORAGE_KEY]) as Record<
+					string,
+					Record<string, true>
+				>;
+				expect(seeded.view).toEqual({ 'layout-twin': true });
+
+				exclusionList = ['layout-holy-grail'];
+				state.suspend();
+				state.resume();
+				await flush();
+
+				const reseeded = JSON.parse(data[EXCLUSIONS_STORAGE_KEY]) as Record<
+					string,
+					Record<string, true>
+				>;
+				expect(reseeded.view).toEqual({
+					'layout-holy-grail': true
+				});
+			});
+
+			it('re-fires matching subscribers against the freshly restored state [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({
+						pageA: { 'layout-menu-collapsed': true },
+						pageB: { 'layout-menu-collapsed': false }
+					})
+				});
+				let key = 'pageA';
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: () => key,
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				const cb = vi.fn();
+				state.subscribe('layout-menu-collapsed', 'always', cb);
+				await flush();
+				expect(cb).toHaveBeenLastCalledWith(
+					expect.objectContaining({ isApplied: true, storageKey: 'pageA' })
+				);
+				cb.mockClear();
+
+				state.suspend();
+				root.className = '';
+				key = 'pageB';
+				state.resume();
+				await flush();
+
+				expect(cb).toHaveBeenCalledWith(
+					expect.objectContaining({ isApplied: false, storageKey: 'pageB' })
+				);
+			});
+
+			it('re-sets data-layout-restored after the resume flush [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage();
+				const state = track(
+					createLayoutState({ root, storage, deferCallbacksUntil: Promise.resolve() })
+				);
+				await flush();
+				state.suspend();
+				expect(root.hasAttribute('data-layout-restored')).toBe(false);
+				state.resume();
+				await flush();
+				expect(root.getAttribute('data-layout-restored')).toBe('true');
+			});
+
+			it('resume() throws when called after dispose() [ai generated]', () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage();
+				const state = track(
+					createLayoutState({ root, storage, deferCallbacksUntil: Promise.resolve() })
+				);
+				state.dispose();
+				expect(() => state.resume()).toThrow(/disposed/);
+			});
+
+			it('correctly replays subscribers when suspend() runs before the initial flush [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({ v: { 'layout-twin': true } })
+				});
+				let resolveDefer: () => void = () => undefined;
+				const defer = new Promise<void>(r => {
+					resolveDefer = r;
+				});
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						deferCallbacksUntil: defer
+					})
+				);
+				const cb = vi.fn();
+				state.subscribe('layout-twin', 'always', cb);
+				// Suspend BEFORE the initial deferred flush has resolved.
+				state.suspend();
+				resolveDefer();
+				await flush();
+				// Initial flush was suppressed; attribute stays cleared.
+				expect(root.hasAttribute('data-layout-restored')).toBe(false);
+				expect(cb).not.toHaveBeenCalled();
+
+				state.resume();
+				await flush();
+				// Resume re-queues and flushes correctly.
+				expect(cb).toHaveBeenCalledWith(
+					expect.objectContaining({ className: 'layout-twin', isApplied: true })
+				);
+				expect(root.getAttribute('data-layout-restored')).toBe('true');
+			});
+		});
+
+		describe('dispose()', () => {
+			it('disconnects the observer so subsequent class changes do not fire callbacks [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage();
+				const state = track(
+					createLayoutState({ root, storage, deferCallbacksUntil: Promise.resolve() })
+				);
+				const cb = vi.fn();
+				state.subscribe('layout-twin', 'added', cb);
+				await flush();
+				state.dispose();
+				root.classList.add('layout-twin');
+				await flush();
+				expect(cb).not.toHaveBeenCalled();
+			});
+
+			it('removes the data-layout-restored attribute [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage();
+				const state = track(
+					createLayoutState({ root, storage, deferCallbacksUntil: Promise.resolve() })
+				);
+				await flush();
+				expect(root.getAttribute('data-layout-restored')).toBe('true');
+				state.dispose();
+				expect(root.hasAttribute('data-layout-restored')).toBe(false);
+			});
+
+			it('is idempotent [ai generated]', () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage();
+				const state = track(
+					createLayoutState({ root, storage, deferCallbacksUntil: Promise.resolve() })
+				);
+				expect(() => {
+					state.dispose();
+					state.dispose();
+				}).not.toThrow();
+			});
+
+			it('causes subscribe() to throw [ai generated]', () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage();
+				const state = track(
+					createLayoutState({ root, storage, deferCallbacksUntil: Promise.resolve() })
+				);
+				state.dispose();
+				expect(() => state.subscribe('layout-twin', 'always', () => undefined)).toThrow(/disposed/);
+			});
+
+			it('keeps getViewState() and getState() working (they read from storage) [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({ v: { 'layout-twin': true } })
+				});
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				await flush();
+				state.dispose();
+				expect(state.getViewState()).toEqual({ 'layout-twin': true });
+				expect(state.getState()).toEqual({ v: { 'layout-twin': true } });
+			});
+
+			it('makes previously-returned unsubscribe functions safe no-ops [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage();
+				const state = track(
+					createLayoutState({ root, storage, deferCallbacksUntil: Promise.resolve() })
+				);
+				const unsubscribe = state.subscribe('layout-twin', 'always', () => undefined);
+				await flush();
+				state.dispose();
+				expect(() => unsubscribe()).not.toThrow();
+			});
+
+			it('clears pending callbacks queued before the initial flush (markRestored not called) [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({ v: { 'layout-twin': true } })
+				});
+				let resolveDefer: () => void = () => undefined;
+				const defer = new Promise<void>(r => {
+					resolveDefer = r;
+				});
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						deferCallbacksUntil: defer
+					})
+				);
+				const cb = vi.fn();
+				state.subscribe('layout-twin', 'always', cb);
+				// Dispose BEFORE the initial flush resolves.
+				state.dispose();
+				resolveDefer();
+				await flush();
+				expect(cb).not.toHaveBeenCalled();
+				expect(root.hasAttribute('data-layout-restored')).toBe(false);
+			});
+
+			it('stops draining when a subscriber callback disposes mid-flush [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({
+						v: { 'layout-twin': true, 'layout-holy-grail': true }
+					})
+				});
+				let resolveDefer: () => void = () => undefined;
+				const defer = new Promise<void>(r => {
+					resolveDefer = r;
+				});
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						deferCallbacksUntil: defer
+					})
+				);
+				const cbA = vi.fn(() => state.dispose());
+				const cbB = vi.fn();
+				state.subscribe('layout-twin', 'always', cbA);
+				state.subscribe('layout-holy-grail', 'always', cbB);
+				resolveDefer();
+				await flush();
+				expect(cbA).toHaveBeenCalledTimes(1);
+				// cbB queued behind cbA; the disposed check between callbacks prevents it.
+				expect(cbB).not.toHaveBeenCalled();
+				expect(root.hasAttribute('data-layout-restored')).toBe(false);
+			});
+
+			it('suppresses the deferCallbacksUntil rejection handler [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage();
+				const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+				try {
+					const defer = Promise.reject(new Error('boom'));
+					const state = track(
+						createLayoutState({
+							root,
+							storage,
+							deferCallbacksUntil: defer
+						})
+					);
+					state.dispose();
+					await flush();
+					// The rejection-side console.error is gated on `disposed`.
+					expect(errSpy).not.toHaveBeenCalledWith(
+						expect.stringContaining('deferCallbacksUntil rejected'),
+						expect.anything()
+					);
+					expect(root.hasAttribute('data-layout-restored')).toBe(false);
+				} finally {
+					errSpy.mockRestore();
+				}
+			});
+		});
+
+		describe('SPA integration scenario', () => {
+			it('survives a full suspend-swap-resume cycle without losing subscribers [ai generated]', async () => {
+				const root = createRoot();
+				const { storage } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({
+						pageA: { 'layout-menu-collapsed': true },
+						pageB: { 'layout-menu-collapsed': false }
+					})
+				});
+				let routeKey = 'pageA';
+				const state = track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: () => routeKey,
+						deferCallbacksUntil: Promise.resolve()
+					})
+				);
+				// Boot-time subscriber registered ONCE — must survive every nav.
+				const cb = vi.fn();
+				state.subscribe('layout-menu-collapsed', 'always', cb);
+				await flush();
+				expect(cb).toHaveBeenLastCalledWith(
+					expect.objectContaining({ isApplied: true, storageKey: 'pageA' })
+				);
+
+				// Simulate navigation A -> B
+				state.suspend();
+				root.className = ''; // DOM swap wipes <html>'s classes
+				routeKey = 'pageB';
+				state.resume();
+				await flush();
+				expect(cb).toHaveBeenLastCalledWith(
+					expect.objectContaining({ isApplied: false, storageKey: 'pageB' })
+				);
+
+				// User toggles on pageB — should fire and persist to pageB bucket.
+				cb.mockClear();
+				root.classList.add('layout-menu-collapsed');
+				await flush();
+				expect(cb).toHaveBeenCalledWith(
+					expect.objectContaining({ isApplied: true, storageKey: 'pageB' })
+				);
+				expect(state.getViewState()).toEqual({ 'layout-menu-collapsed': true });
+
+				// Simulate navigation B -> A
+				cb.mockClear();
+				state.suspend();
+				root.className = '';
+				routeKey = 'pageA';
+				state.resume();
+				await flush();
+				// pageA's persisted state still has layout-menu-collapsed=true.
+				expect(cb).toHaveBeenCalledWith(
+					expect.objectContaining({ isApplied: true, storageKey: 'pageA' })
+				);
+			});
 		});
 	});
 

--- a/js/test/behaviors/layout.test.ts
+++ b/js/test/behaviors/layout.test.ts
@@ -899,7 +899,7 @@ describe('createLayoutState', () => {
 				expect(root.hasAttribute('data-layout-restored')).toBe(false);
 			});
 
-			it('is idempotent (calling twice does not throw) [ai generated]', () => {
+			it('suspend() is idempotent [ai generated]', () => {
 				const root = createRoot();
 				const { storage } = createFakeStorage();
 				const state = track(
@@ -1340,7 +1340,7 @@ describe('createLayoutState', () => {
 					);
 					state.dispose();
 					await flush();
-					// The rejection-side console.error is gated on `disposed`.
+					// The console.error in the rejection handler is skipped after disposal.
 					expect(errSpy).not.toHaveBeenCalledWith(
 						expect.stringContaining('deferCallbacksUntil rejected'),
 						expect.anything()
@@ -1370,7 +1370,7 @@ describe('createLayoutState', () => {
 						deferCallbacksUntil: Promise.resolve()
 					})
 				);
-				// Boot-time subscriber registered ONCE — must survive every nav.
+				// Registered once at boot; should still fire after every navigation.
 				const cb = vi.fn();
 				state.subscribe('layout-menu-collapsed', 'always', cb);
 				await flush();
@@ -1696,6 +1696,28 @@ describe('createLayoutState', () => {
 			expect(JSON.parse(data[STORAGE_KEY])).toEqual({
 				default: { 'layout-twin': true }
 			});
+		});
+
+		it('coerces a nullish storageKey returned by the function to "default" [ai generated]', async () => {
+			const root = createRoot();
+			const { storage, data } = createFakeStorage();
+			const state = track(
+				createLayoutState({
+					root,
+					storage,
+					// Simulate a route getter that resolves to nothing — a runtime
+					// type violation, since the option is declared `() => string`.
+					storageKey: () => undefined as unknown as string,
+					deferCallbacksUntil: Promise.resolve()
+				})
+			);
+			root.classList.add('layout-twin');
+			await flush();
+			// State lands in the "default" bucket, never a literal "undefined" key.
+			expect(state.getViewState()).toEqual({ 'layout-twin': true });
+			const persisted = JSON.parse(data[STORAGE_KEY]) as Record<string, unknown>;
+			expect(persisted).toEqual({ default: { 'layout-twin': true } });
+			expect(Object.prototype.hasOwnProperty.call(persisted, 'undefined')).toBe(false);
 		});
 
 		it('lets two instances with the same storageKey share persisted state [ai generated]', async () => {
@@ -2106,6 +2128,28 @@ describe('createLayoutState', () => {
 				expect(JSON.parse(data[EXCLUSIONS_KEY])).toEqual({
 					default: { 'layout-menu-collapsed': true }
 				});
+			});
+
+			it('treats a nullish excludesKey getter as no exclusion scope (skips lookup and write)', () => {
+				const root = createRoot();
+				const { storage, data } = createFakeStorage({
+					[STORAGE_KEY]: JSON.stringify({ v: { 'layout-menu-collapsed': true } })
+				});
+				track(
+					createLayoutState({
+						root,
+						storage,
+						storageKey: 'v',
+						// Route getter resolves to nothing (runtime type violation).
+						excludesKey: () => undefined as unknown as string,
+						excludes: ['layout-menu-collapsed']
+					})
+				);
+				// Exclusions are disabled for this route, so the persisted class
+				// still restores...
+				expect(root.classList.contains('layout-menu-collapsed')).toBe(true);
+				// ...and nothing is written under a literal "undefined" bucket.
+				expect(data[EXCLUSIONS_KEY]).toBeUndefined();
 			});
 
 			it('uses own-property lookups so __proto__-keyed entries cannot poison the blocklist', () => {

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -577,9 +577,40 @@ const layoutState = createLayoutState({
 });
 ```
 
-`excludesKey` names this view's list inside a second `localStorage` entry (`atlas-layout-exclusions`); `excludes` is the list of `layout-*` class names to write there on construction. Pass `[]` to clear; omit `excludes` to consume rules written by another view.
+`excludesKey` names this view's list inside a second `localStorage` entry (`atlas-layout-exclusions`); `excludes` is the list of `layout-*` class names to write there on construction. Pass `[]` to clear; omit `excludes` to consume rules written by another view. Pass a function (`excludes: () => currentList`) to follow a runtime-varying exclusion list — the getter is re-read on every persist and every `resume()`, so route changes can supply different lists without recreating the instance.
 
 To honor exclusions before first paint, set `excludesKey` in the [inline restore script above](#inline-restore-script-in-head) to the same value.
+
+### Integrating with a client-side router
+
+If your site swaps page content via client-side navigation (e.g. fetching new HTML and replacing the `<html>` class list without a hard reload), pair `suspend()` with `resume()` around each navigation so a single long-lived instance can serve every route. Subscribers registered once at boot stay live — no re-registration needed.
+
+```typescript
+const layoutState = createLayoutState({
+	storageKey: () => currentRoute.layoutKey,
+	excludesKey: () => currentRoute.excludesKey,
+	excludes: () => currentRoute.excludes,
+	useViewTransitionOnRestore: false
+});
+
+// Subscribers added once at boot survive every navigation.
+layoutState.subscribe('layout-menu-collapsed', 'always', ({ isApplied }) => {
+	const button = document.querySelector<HTMLButtonElement>('[data-menu-collapse-toggle]');
+	button?.setAttribute('aria-expanded', String(!isApplied));
+});
+
+router.on('beforeNavigate', () => layoutState.suspend());
+router.on('afterNavigate', () => layoutState.resume());
+```
+
+`suspend()` disconnects the `MutationObserver` synchronously and removes `data-layout-restored` so [until-restored helpers](#display-helpers-gated-on-js-restoration) re-engage during the navigation. `resume()` re-reads the `storageKey` / `excludesKey` / `excludes` getters, re-restores persisted state for the new route's bucket, replays matching subscribers against the freshly-restored state, re-attaches the observer, and re-sets `data-layout-restored`.
+
+Two rules to follow:
+
+1. **Call `suspend()` BEFORE any DOM mutation that touches `<html>`'s class list.** The observer is disconnected synchronously inside `suspend()`, so class changes during the navigation window cannot leak into the persisted state. Reversing the order will write the destination page's server-rendered classes into the previous route's storage bucket.
+2. **Keep subscriber callbacks idempotent.** `resume()` re-fires every matching subscriber on every navigation. Callbacks should look up DOM each time they run (don't capture stale element references from page A and use them on page B), and should treat being called repeatedly with the same state as a no-op.
+
+`dispose()` is also available for full teardown — useful in tests or when unmounting a widget that owned the layout state. After `dispose()`, `subscribe()` / `suspend()` / `resume()` throw; `getViewState()` / `getState()` still work (they read from `localStorage`); previously-returned `unsubscribe` functions remain safe no-ops. Most SPAs won't need it.
 
 ### Content Security Policy
 

--- a/site/src/components/layout.md
+++ b/site/src/components/layout.md
@@ -577,7 +577,7 @@ const layoutState = createLayoutState({
 });
 ```
 
-`excludesKey` names this view's list inside a second `localStorage` entry (`atlas-layout-exclusions`); `excludes` is the list of `layout-*` class names to write there on construction. Pass `[]` to clear; omit `excludes` to consume rules written by another view. Pass a function (`excludes: () => currentList`) to follow a runtime-varying exclusion list — the getter is re-read on every persist and every `resume()`, so route changes can supply different lists without recreating the instance.
+`excludesKey` names this view's list inside a second `localStorage` entry (`atlas-layout-exclusions`); `excludes` is the list of `layout-*` class names to write there on construction. Pass `[]` to clear this view's list; omit `excludes` to read the existing list under `excludesKey` without overwriting it. Pass a getter (`excludes: () => currentList`) to follow a runtime-varying exclusion list — it is re-read on every persist and every `resume()`, so route changes can supply different lists without recreating the instance.
 
 To honor exclusions before first paint, set `excludesKey` in the [inline restore script above](#inline-restore-script-in-head) to the same value.
 
@@ -607,10 +607,10 @@ router.on('afterNavigate', () => layoutState.resume());
 
 Two rules to follow:
 
-1. **Call `suspend()` BEFORE any DOM mutation that touches `<html>`'s class list.** The observer is disconnected synchronously inside `suspend()`, so class changes during the navigation window cannot leak into the persisted state. Reversing the order will write the destination page's server-rendered classes into the previous route's storage bucket.
-2. **Keep subscriber callbacks idempotent.** `resume()` re-fires every matching subscriber on every navigation. Callbacks should look up DOM each time they run (don't capture stale element references from page A and use them on page B), and should treat being called repeatedly with the same state as a no-op.
+1. **Call `suspend()` BEFORE any DOM mutation that touches `<html>`'s class list.** Reversing the order writes the destination page's server-rendered classes into the previous route's storage bucket.
+2. **Keep subscriber callbacks idempotent.** `resume()` re-fires every matching subscriber on every navigation, so look up the DOM on each run (don't reuse element references across routes) and treat repeated calls with the same state as a no-op.
 
-`dispose()` is also available for full teardown — useful in tests or when unmounting a widget that owned the layout state. After `dispose()`, `subscribe()` / `suspend()` / `resume()` throw; `getViewState()` / `getState()` still work (they read from `localStorage`); previously-returned `unsubscribe` functions remain safe no-ops. Most SPAs won't need it.
+`dispose()` fully tears down the instance — useful in tests or when unmounting a widget that owns the layout state. Afterward, `subscribe()` / `suspend()` / `resume()` throw, while `getViewState()` / `getState()` still read from `localStorage`. Most SPAs won't need it.
 
 ### Content Security Policy
 


### PR DESCRIPTION
# Layout state — SPA lifecycle (suspend/resume/dispose) + persisted exclusions

## Summary

Two additions to `createLayoutState`:

1. **Persisted exclusions** — `excludesKey` / `excludes` opt specific `layout-*` classes out of restore, persist, and subscriber dispatch. Stored in `atlas-layout-exclusions` (honored by the inline pre-paint script too).
2. **`suspend()` / `resume()` / `dispose()`, replacing `stop()`** — one long-lived instance serves every route in a client-side-routed app, with subscribers registered once at boot.

## Why

`stop()` only disconnected the observer — subscriptions stayed registered but dead. The required workaround (recreate the instance on every navigation) orphaned boot-time subscribers, leaned on brittle `let` re-exports, and leaked old instances. The new lifecycle keeps one instance alive; `resume()` re-reads the route getters and replays subscribers.

## Consumer pattern

```typescript
const layoutState = createLayoutState({
  storageKey:  () => currentRoute.layoutKey,
  excludesKey: () => currentRoute.excludesKey,
  excludes:    () => currentRoute.excludes
});

// Registered once at boot; survives every navigation.
layoutState.subscribe('layout-menu-collapsed', 'always', ({ isApplied }) => {
  document.querySelector('[data-menu-collapse-toggle]')
    ?.setAttribute('aria-expanded', String(!isApplied));
});

router.on('beforeNavigate', () => layoutState.suspend());
router.on('afterNavigate',  () => layoutState.resume());
```

## Two rules

1. **`suspend()` before any `<html>` class-list mutation** (`resume()` after). Reversing it writes the destination page's classes into the previous route's bucket.
2. **Keep subscriber callbacks idempotent** — `resume()` re-fires them every navigation; re-query the DOM and tolerate repeat calls.

## API

| Method | Behavior |
| --- | --- |
| ~~`stop()`~~ | **Removed** (breaking). |
| `suspend()` | Disconnect observer synchronously, clear `data-layout-restored`, keep subscriptions. Idempotent; throws if disposed. |
| `resume()` | Re-read getters, restore current bucket, replay subscribers, reconnect observer. No-op unless suspended. |
| `dispose()` | Full teardown. Afterward mutating methods throw; `getViewState()` / `getState()` still read storage. |
| `excludes` | Now also accepts `() => string[]`, re-read on persist and `resume()`. |

**Migration:** `stop()` → `suspend()` (with a paired `resume()`) or `dispose()` (teardown / tests). Drop any manual `data-layout-restored` clearing.

## Tests & verification

25 new tests (suspend/resume/dispose + an A → B → A SPA scenario), **100 / 100** passing. `lint:js`, `build:js`, and `build:site` all clean.

