### PR TITLE
Relax engines to support any Node 24 / npm 11

### DIFF
--- a/.changeset/relax-engines-node-24.md
+++ b/.changeset/relax-engines-node-24.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-css': patch
+'@microsoft/atlas-js': patch
+---
+
+Relaxed the `engines` field to allow any Node 24 / npm 11 release (`^24.0.0` / `^11.0.0`) instead of pinning a single exact version. This stops `EBADENGINE` warnings for downstream consumers running other patch versions of Node 24.

--- a/css/package.json
+++ b/css/package.json
@@ -52,8 +52,8 @@
 		"url": "https://github.com/microsoft/atlas-design"
 	},
 	"engines": {
-		"node": "24.15.0",
-		"npm": "11.12.1"
+		"node": "^24.0.0",
+		"npm": "^11.0.0"
 	},
 	"publishConfig": {
 		"registry": "https://registry.npmjs.org"

--- a/extension/package.json
+++ b/extension/package.json
@@ -13,8 +13,8 @@
 	"icon": "icons/atlas-icon-512.png",
 	"engines": {
 		"vscode": "^1.71.0",
-		"node": "24.15.0",
-		"npm": "11.12.1"
+		"node": "^24.0.0",
+		"npm": "^11.0.0"
 	},
 	"categories": [
 		"Other"

--- a/integration/package.json
+++ b/integration/package.json
@@ -4,8 +4,8 @@
 	"private": true,
 	"description": "",
 	"engines": {
-		"node": "24.15.0",
-		"npm": "11.12.1"
+		"node": "^24.0.0",
+		"npm": "^11.0.0"
 	},
 	"scripts": {
 		"codegen": "playwright codegen localhost:1111",

--- a/js/package.json
+++ b/js/package.json
@@ -19,8 +19,8 @@
 		"url": "https://github.com/microsoft/atlas-design"
 	},
 	"engines": {
-		"node": "24.15.0",
-		"npm": "11.12.1"
+		"node": "^24.0.0",
+		"npm": "^11.0.0"
 	},
 	"publishConfig": {
 		"registry": "https://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
 	"private": true,
 	"homepage": "https://github.com/microsoft/atlas-design",
 	"engines": {
-		"node": "24.15.0",
-		"npm": "11.12.1"
+		"node": "^24.0.0",
+		"npm": "^11.0.0"
 	},
 	"scripts": {
 		"build:css": "npm run build --workspace=@microsoft/atlas-css",

--- a/plugins/parcel-optimizer-inline-script-restore/package.json
+++ b/plugins/parcel-optimizer-inline-script-restore/package.json
@@ -9,8 +9,8 @@
 	},
 	"main": "lib/index.js",
 	"engines": {
-		"node": "24.15.0",
-		"npm": "11.12.1",
+		"node": "^24.0.0",
+		"npm": "^11.0.0",
 		"parcel": "2.16.3"
 	},
 	"dependencies": {

--- a/plugins/parcel-transformer-markdown-html/package.json
+++ b/plugins/parcel-transformer-markdown-html/package.json
@@ -9,8 +9,8 @@
 	},
 	"main": "lib/index.js",
 	"engines": {
-		"node": "24.15.0",
-		"npm": "11.12.1",
+		"node": "^24.0.0",
+		"npm": "^11.0.0",
 		"parcel": "2.16.3"
 	},
 	"dependencies": {

--- a/plugins/stylelint-config-atlas/package.json
+++ b/plugins/stylelint-config-atlas/package.json
@@ -17,8 +17,8 @@
 		"index.js"
 	],
 	"engines": {
-		"node": "24.15.0",
-		"npm": "11.12.1"
+		"node": "^24.0.0",
+		"npm": "^11.0.0"
 	},
 	"dependencies": {
 		"postcss-scss": "^4.0.9",

--- a/site/package.json
+++ b/site/package.json
@@ -4,8 +4,8 @@
 	"license": "MIT",
 	"private": true,
 	"engines": {
-		"node": "24.15.0",
-		"npm": "11.12.1"
+		"node": "^24.0.0",
+		"npm": "^11.0.0"
 	},
 	"targets": {
 		"default": {


### PR DESCRIPTION
Loosens the pinned engines field across all packages from exact 24.15.0 / 11.12.1 to ^24.0.0 / ^11.0.0. Eliminates EBADENGINE warnings for downstream consumers running other patch versions of Node 24. The `.nvmrc` still pins the exact dev version, so contributors stay in sync.