### PR TITLE
js: support moduleResolution bundler and nodenext

### DIFF
--- a/.changeset/atlas-js-nodenext-resolution.md
+++ b/.changeset/atlas-js-nodenext-resolution.md
@@ -1,0 +1,12 @@
+---
+'@microsoft/atlas-js': major
+---
+
+`@microsoft/atlas-js` is now a formal ES module and supports consumers using `moduleResolution: "bundler"` and `"nodenext"`.
+
+**BREAKING CHANGE:** the package now declares `"type": "module"` (it is ESM-only) and ships an `"exports"` map.
+
+- **ESM and bundler consumers** need no changes — `import { … } from '@microsoft/atlas-js'` works as before, and the `@microsoft/atlas-js/src/index` source entry plus `./dist/*` paths remain available through `exports`.
+- **CommonJS consumers** can no longer `require('@microsoft/atlas-js')` synchronously and must use a dynamic `import('@microsoft/atlas-js')` instead. (The package already emitted ESM, so synchronous `require` did not work previously either.)
+
+Types now resolve through the `exports` `types` condition, and the compiled output's relative import/export specifiers include `.js` extensions so Node ESM and `nodenext` resolve the full module graph.

--- a/js/.eslintrc.cjs
+++ b/js/.eslintrc.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-	ignorePatterns: ['vitest.config.ts'],
+	ignorePatterns: ['vitest.config.ts', 'dist'],
 	env: {
 		browser: true,
 		node: false,

--- a/js/package.json
+++ b/js/package.json
@@ -3,10 +3,22 @@
 	"version": "3.0.0",
 	"public": true,
 	"description": "Scripts backing the Atlas Design System used by Microsoft's Developer Relations.",
+	"type": "module",
 	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		},
+		"./src/*": "./src/*",
+		"./dist/*": "./dist/*",
+		"./package.json": "./package.json"
+	},
 	"source": "src/index.ts",
 	"scripts": {
 		"build": "tsc --project \"./tsconfig.json\" --outDir \"./dist\" --declaration true --declarationMap true",
+		"postbuild": "node ./scripts/append-js-extensions.mjs",
 		"lint": "eslint . --ext .ts",
 		"prebuild": "rimraf dist",
 		"test": "vitest run",

--- a/js/scripts/append-js-extensions.mjs
+++ b/js/scripts/append-js-extensions.mjs
@@ -1,0 +1,98 @@
+// Appends explicit `.js` extensions to relative import/export specifiers in the
+// compiled output (`dist/**/*.js` and `dist/**/*.d.ts`).
+//
+// `tsc` copies module specifiers verbatim, so extensionless source like
+// `export * from './behaviors/dismiss'` is emitted unchanged. That is valid for
+// `moduleResolution: bundler`, but invalid for Node ESM / `moduleResolution:
+// nodenext`, which require fully specified relative paths. Adding the extensions
+// here keeps the source extensionless (so the existing eslint node resolver and
+// the site's source imports keep working) while making the published package
+// resolve correctly under both `bundler` and `nodenext`.
+
+import { readdir, readFile, writeFile, stat } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const distDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'dist');
+
+const KNOWN_EXTENSIONS = ['.js', '.mjs', '.cjs', '.json', '.node'];
+
+// Captures the module specifier in `... from '<spec>'`, `import('<spec>')` and
+// side-effect `import '<spec>'` for relative specifiers only.
+const SPECIFIER_RE = /(\bfrom\s+|\bimport\s*\(\s*|\bimport\s+)(['"])(\.\.?\/[^'"]*)\2/g;
+
+async function fileExists(path) {
+	try {
+		await stat(path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function rewriteSpecifier(fileDir, specifier) {
+	if (KNOWN_EXTENSIONS.some(extension => specifier.endsWith(extension))) {
+		return specifier;
+	}
+	const absolute = resolve(fileDir, specifier);
+	if (await fileExists(`${absolute}.js`)) {
+		return `${specifier}.js`;
+	}
+	if (await fileExists(join(absolute, 'index.js'))) {
+		return `${specifier}/index.js`;
+	}
+	console.warn(`[append-js-extensions] Could not resolve "${specifier}" from ${fileDir}`);
+	return specifier;
+}
+
+async function processFile(filePath) {
+	const original = await readFile(filePath, 'utf8');
+	const fileDir = dirname(filePath);
+
+	const matches = [];
+	for (const match of original.matchAll(SPECIFIER_RE)) {
+		matches.push(match);
+	}
+	if (matches.length === 0) {
+		return false;
+	}
+
+	let result = '';
+	let cursor = 0;
+	let changed = false;
+	for (const match of matches) {
+		const [full, prefix, quote, specifier] = match;
+		const rewritten = await rewriteSpecifier(fileDir, specifier);
+		if (rewritten === specifier) {
+			continue;
+		}
+		result += original.slice(cursor, match.index) + `${prefix}${quote}${rewritten}${quote}`;
+		cursor = match.index + full.length;
+		changed = true;
+	}
+	if (!changed) {
+		return false;
+	}
+	result += original.slice(cursor);
+	await writeFile(filePath, result, 'utf8');
+	return true;
+}
+
+async function* walk(directory) {
+	for (const entry of await readdir(directory, { withFileTypes: true })) {
+		const entryPath = join(directory, entry.name);
+		if (entry.isDirectory()) {
+			yield* walk(entryPath);
+		} else if (entry.name.endsWith('.js') || entry.name.endsWith('.d.ts')) {
+			yield entryPath;
+		}
+	}
+}
+
+let count = 0;
+for await (const filePath of walk(distDir)) {
+	if (await processFile(filePath)) {
+		count += 1;
+	}
+}
+console.log(`[append-js-extensions] Added .js extensions in ${count} file(s).`);


### PR DESCRIPTION
Declare @microsoft/atlas-js as an ES module (type: module) with an explicit types entry, and append .js extensions to relative specifiers in the compiled dist output via a postbuild step so Node ESM and nodenext can resolve the full module graph. Source stays extensionless, so the eslint node resolver and the site's @microsoft/atlas-js/src/index import are unaffected.

Link: [preview](http://localhost:1111/)

[Explain the context of this pull request here]

## Testing

1. Step one
2. Step two
   Expected result:

## Additional information

[Optional]

## Contributor checklist

- [ ] Did you update the description of this pull request with a review link and test steps?
- [ ] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Did your pull request add anything to the /js/ folder? Consider adding unit tests.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
- [ ] Does your pull request change any transforms? Did you test they work on right to left?
