### PR TITLE
Add zero-dep theme behavior and render-blocking theme guard

### DIFF
--- a/.changeset/theme-state-behavior.md
+++ b/.changeset/theme-state-behavior.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-js': minor
+'@microsoft/atlas-site': minor
+---
+
+Add `createThemeState`, a zero-dependency theme behavior to `@microsoft/atlas-js` that resolves, applies, and persists the active `theme-*` class, falls back to the system `prefers-color-scheme`, and wires up `[data-theme-cycle]` controls. The documentation site now uses it (replacing the bespoke site-only theming module) and ships a render-blocking inline `#theme-preference` guard in `<head>` to prevent a wrong-theme flash when scripts are deferred. See the new `components/theme.md` page.

--- a/js/src/behaviors/theme.ts
+++ b/js/src/behaviors/theme.ts
@@ -1,0 +1,262 @@
+/* -------------------------------------------------------------------------- */
+/* Theme state                                                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Resolves, applies, and persists the active `theme-*` class on the document
+ * root. Zero-dependency: the set of themes is supplied by the caller rather
+ * than read from `@microsoft/atlas-css`, so this stays usable by any consumer
+ * and keeps `@microsoft/atlas-js` free of cross-package imports.
+ *
+ * The instance is live on return — the preferred theme has already been
+ * resolved and its class applied to `<html>`, and (unless disabled)
+ * click-to-cycle controls are wired up.
+ *
+ * ### Preventing the flash before first paint
+ *
+ * Like `createLayoutState`, calling this from a module bundle applies the
+ * theme **after** the HTML is parsed, so a deferred bundle briefly renders the
+ * markup theme before the persisted one takes over. Pair it with the inline
+ * `<head>` guard documented in `site/src/components/theme.md`, which applies
+ * the persisted/system theme before first paint. The two read the same
+ * `storageKey` and `classPrefix`, so they always agree.
+ *
+ * ### SPA integration
+ *
+ * Create the instance once at boot. Call `resume()` after a navigation that
+ * rewrites `<html>`'s class list to re-apply the persisted theme. Subscribers
+ * registered once at boot stay live across navigations.
+ */
+export interface ThemeStateOptions {
+	/**
+	 * Ordered list of theme names. The order drives `cycle()`. The first entry
+	 * is the default when nothing is stored and no system preference applies.
+	 * Defaults to `['light', 'dark', 'high-contrast']`.
+	 */
+	themes?: string[];
+	/** `localStorage` key the active theme is persisted under. Default `'theme'`. */
+	storageKey?: string;
+	/** Prefix joined to the theme name to form the document class. Default `'theme-'`. */
+	classPrefix?: string;
+	/** Theme used when nothing is stored and no system preference applies. Default `themes[0]`. */
+	defaultTheme?: string;
+	/**
+	 * When `true` (default) and no theme is stored, a `prefers-color-scheme: dark`
+	 * match resolves to `systemDarkTheme` if that theme exists.
+	 */
+	useSystemPreference?: boolean;
+	/** Theme chosen for a dark system preference. Default `'dark'`. Ignored if absent from `themes`. */
+	systemDarkTheme?: string;
+	/**
+	 * Delegated click target that advances to the next theme. Default
+	 * `'[data-theme-cycle]'`. Pass `null` to skip wiring controls.
+	 */
+	controlSelector?: string | null;
+	/** Element the `theme-*` class is applied to. Default `document.documentElement`. */
+	root?: HTMLElement;
+	/** Storage backing persistence. Default `window.localStorage`. */
+	storage?: Storage;
+}
+
+/** Notified with the new theme name whenever the active theme changes. */
+export type ThemeCallback = (theme: string) => void;
+
+export interface ThemeStateInstance {
+	/** The currently applied theme name. */
+	getTheme(): string;
+	/** The ordered list of known theme names. */
+	getThemes(): string[];
+	/**
+	 * Resolve the theme that *would* be applied from storage, then system
+	 * preference, then the default — without applying or persisting it.
+	 */
+	getPreferredTheme(): string;
+	/**
+	 * Apply `theme` to the root element and notify subscribers. Persists the
+	 * choice unless `persist` is `false` (used for non-sticky overrides such as
+	 * a `?theme=` query argument). Unknown themes are ignored.
+	 */
+	setTheme(theme: string, persist?: boolean): void;
+	/** Advance to the next theme in `themes` (wrapping), persist it, and return it. */
+	cycle(): string;
+	/**
+	 * Re-resolve the preferred theme and re-apply its class without persisting.
+	 * Use after an SPA navigation that rewrote `<html>`'s class list.
+	 */
+	resume(): void;
+	/**
+	 * Subscribe to theme changes. The callback fires immediately with the
+	 * current theme, then on every subsequent change. Returns an unsubscribe
+	 * function that is always safe to call.
+	 */
+	subscribe(callback: ThemeCallback): () => void;
+	/** Remove the control listener and clear all subscriptions. Idempotent. */
+	dispose(): void;
+}
+
+const DEFAULT_THEMES = ['light', 'dark', 'high-contrast'];
+
+/**
+ * Create a live theme controller. See {@link ThemeStateOptions} for behavior.
+ *
+ * ```ts
+ * const theme = createThemeState({ themes: ['light', 'dark', 'high-contrast'] });
+ * theme.subscribe(name => console.log('theme is now', name));
+ * // clicking any [data-theme-cycle] element advances the theme
+ * ```
+ */
+export function createThemeState(options: ThemeStateOptions = {}): ThemeStateInstance {
+	const {
+		themes: themesOption,
+		storageKey = 'theme',
+		classPrefix = 'theme-',
+		useSystemPreference = true,
+		systemDarkTheme = 'dark',
+		controlSelector = '[data-theme-cycle]',
+		root = document.documentElement,
+		storage = window.localStorage
+	} = options;
+
+	const themes =
+		Array.isArray(themesOption) && themesOption.length > 0 ? themesOption.slice() : DEFAULT_THEMES;
+	const defaultTheme =
+		options.defaultTheme && isKnown(options.defaultTheme) ? options.defaultTheme : themes[0];
+
+	const subscriptions = new Set<ThemeCallback>();
+	let current = defaultTheme;
+	let disposed = false;
+
+	function isKnown(theme: string): boolean {
+		return themes.indexOf(theme) !== -1;
+	}
+
+	function readStored(): string | null {
+		try {
+			return storage.getItem(storageKey);
+		} catch {
+			return null;
+		}
+	}
+
+	function writeStored(theme: string): void {
+		try {
+			storage.setItem(storageKey, theme);
+		} catch {
+			// Storage unavailable (private mode, quota). In-memory state still applies.
+		}
+	}
+
+	function prefersDark(): boolean {
+		return (
+			typeof window.matchMedia === 'function' &&
+			window.matchMedia('(prefers-color-scheme: dark)').matches
+		);
+	}
+
+	function getPreferredTheme(): string {
+		const stored = readStored();
+		if (stored && isKnown(stored)) {
+			return stored;
+		}
+		if (useSystemPreference && prefersDark() && isKnown(systemDarkTheme)) {
+			return systemDarkTheme;
+		}
+		return defaultTheme;
+	}
+
+	function applyClass(theme: string): void {
+		const classList = root.classList;
+		for (const name of themes) {
+			classList.remove(classPrefix + name);
+		}
+		classList.add(classPrefix + theme);
+	}
+
+	function notify(theme: string): void {
+		for (const callback of subscriptions) {
+			try {
+				callback(theme);
+			} catch (err) {
+				// eslint-disable-next-line no-console
+				console.error('createThemeState: subscriber threw', err);
+			}
+		}
+	}
+
+	function setTheme(theme: string, persist = true): void {
+		if (!isKnown(theme)) {
+			return;
+		}
+		const changed = theme !== current;
+		current = theme;
+		applyClass(theme);
+		if (persist) {
+			writeStored(theme);
+		}
+		if (changed) {
+			notify(theme);
+		}
+	}
+
+	function cycle(): string {
+		const index = themes.indexOf(current);
+		const next = themes[(index + 1) % themes.length];
+		setTheme(next);
+		return next;
+	}
+
+	function resume(): void {
+		// Re-resolve from storage/system; do not persist (no user action occurred).
+		setTheme(getPreferredTheme(), false);
+	}
+
+	function subscribe(callback: ThemeCallback): () => void {
+		subscriptions.add(callback);
+		try {
+			callback(current);
+		} catch (err) {
+			// eslint-disable-next-line no-console
+			console.error('createThemeState: subscriber threw', err);
+		}
+		return () => {
+			subscriptions.delete(callback);
+		};
+	}
+
+	const handleClick = (event: Event): void => {
+		const target = event.target;
+		if (target instanceof Element && controlSelector && target.closest(controlSelector)) {
+			cycle();
+		}
+	};
+
+	const ownerDocument = root.ownerDocument ?? document;
+	if (controlSelector) {
+		ownerDocument.addEventListener('click', handleClick);
+	}
+
+	function dispose(): void {
+		if (disposed) {
+			return;
+		}
+		disposed = true;
+		if (controlSelector) {
+			ownerDocument.removeEventListener('click', handleClick);
+		}
+		subscriptions.clear();
+	}
+
+	// Apply the resolved theme immediately so the instance is live on return.
+	setTheme(getPreferredTheme(), false);
+
+	return {
+		getTheme: () => current,
+		getThemes: () => themes.slice(),
+		getPreferredTheme,
+		setTheme,
+		cycle,
+		resume,
+		subscribe,
+		dispose
+	};
+}

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -5,3 +5,4 @@ export * from './elements/form-behavior';
 export * from './elements/tab-container/index';
 export * from './utilities/util';
 export * from './behaviors/layout';
+export * from './behaviors/theme';

--- a/js/test/behaviors/theme.test.ts
+++ b/js/test/behaviors/theme.test.ts
@@ -1,0 +1,483 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createThemeState, ThemeStateInstance } from '../../src/behaviors/theme';
+
+/* -------------------------------------------------------------------------- */
+/* Test helpers                                                               */
+/* -------------------------------------------------------------------------- */
+
+const liveInstances: ThemeStateInstance[] = [];
+
+function track(instance: ThemeStateInstance): ThemeStateInstance {
+	liveInstances.push(instance);
+	return instance;
+}
+
+function createFakeStorage(seed: Record<string, string> = {}) {
+	const data: Record<string, string> = { ...seed };
+	const storage = {
+		getItem(key: string): string | null {
+			return Object.prototype.hasOwnProperty.call(data, key) ? data[key] : null;
+		},
+		setItem(key: string, value: string): void {
+			data[key] = String(value);
+		},
+		removeItem(key: string): void {
+			delete data[key];
+		}
+	} as unknown as Storage;
+	return { storage, data };
+}
+
+function createRoot(...initialClasses: string[]): HTMLElement {
+	const el = document.createElement('html');
+	for (const cls of initialClasses) {
+		el.classList.add(cls);
+	}
+	document.body.appendChild(el);
+	return el;
+}
+
+/** Stub `window.matchMedia` so `prefers-color-scheme: dark` resolves to `dark`. */
+function stubPrefersDark(dark: boolean): void {
+	window.matchMedia = ((query: string) => ({
+		matches: dark && query === '(prefers-color-scheme: dark)',
+		media: query,
+		addEventListener() {},
+		removeEventListener() {}
+	})) as unknown as typeof window.matchMedia;
+}
+
+const originalMatchMedia = window.matchMedia;
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+	// jsdom does not implement matchMedia; default to no system preference.
+	stubPrefersDark(false);
+});
+
+afterEach(() => {
+	for (const instance of liveInstances.splice(0)) {
+		instance.dispose();
+	}
+	document.body.innerHTML = '';
+	window.matchMedia = originalMatchMedia;
+	vi.restoreAllMocks();
+});
+
+/* -------------------------------------------------------------------------- */
+/* Resolution on construction                                                 */
+/* -------------------------------------------------------------------------- */
+
+describe('createThemeState construction', () => {
+	it('applies the default theme class when nothing is stored [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+
+		expect(theme.getTheme()).toBe('light');
+		expect(root.classList.contains('theme-light')).toBe(true);
+	});
+
+	it('resolves a persisted theme and applies its class [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage({ theme: 'dark' });
+		const theme = track(createThemeState({ root, storage }));
+
+		expect(theme.getTheme()).toBe('dark');
+		expect(root.classList.contains('theme-dark')).toBe(true);
+		expect(root.classList.contains('theme-light')).toBe(false);
+	});
+
+	it('falls back to system dark preference when nothing is stored [ai generated]', () => {
+		stubPrefersDark(true);
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+
+		expect(theme.getTheme()).toBe('dark');
+		expect(root.classList.contains('theme-dark')).toBe(true);
+	});
+
+	it('ignores an unknown persisted value and uses the default [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage({ theme: 'solarized' });
+		const theme = track(createThemeState({ root, storage }));
+
+		expect(theme.getTheme()).toBe('light');
+	});
+
+	it('does not persist the resolved theme on construction [ai generated]', () => {
+		const root = createRoot();
+		const { storage, data } = createFakeStorage();
+		track(createThemeState({ root, storage }));
+
+		expect(data.theme).toBeUndefined();
+	});
+
+	it('honors a custom defaultTheme [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage, defaultTheme: 'high-contrast' }));
+
+		expect(theme.getTheme()).toBe('high-contrast');
+		expect(root.classList.contains('theme-high-contrast')).toBe(true);
+	});
+
+	it('ignores an unknown defaultTheme and uses the first theme [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage, defaultTheme: 'nope' }));
+
+		expect(theme.getTheme()).toBe('light');
+	});
+
+	it('skips system preference resolution when useSystemPreference is false [ai generated]', () => {
+		stubPrefersDark(true);
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage, useSystemPreference: false }));
+
+		expect(theme.getTheme()).toBe('light');
+	});
+});
+
+/* -------------------------------------------------------------------------- */
+/* setTheme / cycle                                                           */
+/* -------------------------------------------------------------------------- */
+
+describe('createThemeState setTheme and cycle', () => {
+	it('applies the new theme class and removes the previous one [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+
+		theme.setTheme('high-contrast');
+
+		expect(root.classList.contains('theme-high-contrast')).toBe(true);
+		expect(root.classList.contains('theme-light')).toBe(false);
+	});
+
+	it('persists the theme by default [ai generated]', () => {
+		const root = createRoot();
+		const { storage, data } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+
+		theme.setTheme('dark');
+
+		expect(data.theme).toBe('dark');
+	});
+
+	it('does not persist when persist is false [ai generated]', () => {
+		const root = createRoot();
+		const { storage, data } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+
+		theme.setTheme('dark', false);
+
+		expect(theme.getTheme()).toBe('dark');
+		expect(data.theme).toBeUndefined();
+	});
+
+	it('ignores an unknown theme [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+
+		theme.setTheme('chartreuse');
+
+		expect(theme.getTheme()).toBe('light');
+		expect(root.classList.contains('theme-light')).toBe(true);
+	});
+
+	it('cycles through the themes in order and wraps around [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+
+		expect(theme.cycle()).toBe('dark');
+		expect(theme.cycle()).toBe('high-contrast');
+		expect(theme.cycle()).toBe('light');
+	});
+
+	it('persists the theme chosen by cycle [ai generated]', () => {
+		const root = createRoot();
+		const { storage, data } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+
+		theme.cycle();
+
+		expect(data.theme).toBe('dark');
+	});
+});
+
+/* -------------------------------------------------------------------------- */
+/* Controls                                                                   */
+/* -------------------------------------------------------------------------- */
+
+describe('createThemeState controls', () => {
+	it('cycles when a [data-theme-cycle] element is clicked [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+
+		const button = document.createElement('button');
+		button.setAttribute('data-theme-cycle', '');
+		document.body.appendChild(button);
+
+		button.click();
+
+		expect(theme.getTheme()).toBe('dark');
+	});
+
+	it('cycles when a descendant of the control is clicked [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+
+		const button = document.createElement('button');
+		button.setAttribute('data-theme-cycle', '');
+		const icon = document.createElement('span');
+		button.appendChild(icon);
+		document.body.appendChild(button);
+
+		icon.click();
+
+		expect(theme.getTheme()).toBe('dark');
+	});
+
+	it('ignores clicks outside any control [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+
+		const other = document.createElement('button');
+		document.body.appendChild(other);
+		other.click();
+
+		expect(theme.getTheme()).toBe('light');
+	});
+
+	it('does not wire controls when controlSelector is null [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage, controlSelector: null }));
+
+		const button = document.createElement('button');
+		button.setAttribute('data-theme-cycle', '');
+		document.body.appendChild(button);
+		button.click();
+
+		expect(theme.getTheme()).toBe('light');
+	});
+
+	it('supports a custom controlSelector [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage, controlSelector: '.theme-toggle' }));
+
+		const button = document.createElement('button');
+		button.className = 'theme-toggle';
+		document.body.appendChild(button);
+		button.click();
+
+		expect(theme.getTheme()).toBe('dark');
+	});
+});
+
+/* -------------------------------------------------------------------------- */
+/* subscribe                                                                  */
+/* -------------------------------------------------------------------------- */
+
+describe('createThemeState subscribe', () => {
+	it('fires immediately with the current theme [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage({ theme: 'dark' });
+		const theme = track(createThemeState({ root, storage }));
+
+		const seen: string[] = [];
+		theme.subscribe(name => seen.push(name));
+
+		expect(seen).toEqual(['dark']);
+	});
+
+	it('fires on subsequent theme changes [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+
+		const seen: string[] = [];
+		theme.subscribe(name => seen.push(name));
+		theme.setTheme('dark');
+		theme.cycle();
+
+		expect(seen).toEqual(['light', 'dark', 'high-contrast']);
+	});
+
+	it('does not fire again when set to the already-active theme [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+
+		const seen: string[] = [];
+		theme.subscribe(name => seen.push(name));
+		theme.setTheme('light');
+
+		expect(seen).toEqual(['light']);
+	});
+
+	it('stops firing after unsubscribe [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+
+		const seen: string[] = [];
+		const unsubscribe = theme.subscribe(name => seen.push(name));
+		unsubscribe();
+		theme.setTheme('dark');
+
+		expect(seen).toEqual(['light']);
+	});
+
+	it('keeps notifying other subscribers when one throws [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		const seen: string[] = [];
+		theme.subscribe(() => {
+			throw new Error('boom');
+		});
+		theme.subscribe(name => seen.push(name));
+		theme.setTheme('dark');
+
+		expect(seen).toEqual(['light', 'dark']);
+	});
+});
+
+/* -------------------------------------------------------------------------- */
+/* resume / dispose / misc                                                    */
+/* -------------------------------------------------------------------------- */
+
+describe('createThemeState resume and dispose', () => {
+	it('re-applies the persisted theme after the class list is wiped [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+		theme.setTheme('dark');
+
+		root.className = '';
+		theme.resume();
+
+		expect(root.classList.contains('theme-dark')).toBe(true);
+		expect(theme.getTheme()).toBe('dark');
+	});
+
+	it('does not persist on resume [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage({ theme: 'high-contrast' });
+		const theme = track(createThemeState({ root, storage }));
+		const setItem = vi.spyOn(storage, 'setItem');
+
+		theme.resume();
+
+		expect(theme.getTheme()).toBe('high-contrast');
+		expect(setItem).not.toHaveBeenCalled();
+	});
+
+	it('stops responding to control clicks after dispose [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = createThemeState({ root, storage });
+
+		const button = document.createElement('button');
+		button.setAttribute('data-theme-cycle', '');
+		document.body.appendChild(button);
+
+		theme.dispose();
+		button.click();
+
+		expect(theme.getTheme()).toBe('light');
+	});
+
+	it('is safe to dispose more than once [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = createThemeState({ root, storage });
+
+		expect(() => {
+			theme.dispose();
+			theme.dispose();
+		}).not.toThrow();
+	});
+});
+
+describe('createThemeState configuration', () => {
+	it('supports a custom theme list and drives cycle order from it [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage, themes: ['day', 'night'] }));
+
+		expect(theme.getTheme()).toBe('day');
+		expect(theme.cycle()).toBe('night');
+		expect(theme.cycle()).toBe('day');
+	});
+
+	it('falls back to the default theme list when given an empty array [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage, themes: [] }));
+
+		expect(theme.getThemes()).toEqual(['light', 'dark', 'high-contrast']);
+	});
+
+	it('supports a custom classPrefix and storageKey [ai generated]', () => {
+		const root = createRoot();
+		const { storage, data } = createFakeStorage();
+		const theme = track(
+			createThemeState({ root, storage, classPrefix: 'is-theme-', storageKey: 'atlas-theme' })
+		);
+
+		theme.setTheme('dark');
+
+		expect(root.classList.contains('is-theme-dark')).toBe(true);
+		expect(data['atlas-theme']).toBe('dark');
+	});
+
+	it('uses a custom systemDarkTheme for a dark system preference [ai generated]', () => {
+		stubPrefersDark(true);
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(
+			createThemeState({
+				root,
+				storage,
+				themes: ['light', 'midnight'],
+				systemDarkTheme: 'midnight'
+			})
+		);
+
+		expect(theme.getTheme()).toBe('midnight');
+	});
+
+	it('getThemes returns a copy that cannot mutate internal state [ai generated]', () => {
+		const root = createRoot();
+		const { storage } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+
+		theme.getThemes().push('injected');
+
+		expect(theme.getThemes()).toEqual(['light', 'dark', 'high-contrast']);
+	});
+
+	it('getPreferredTheme reports the stored theme without applying it [ai generated]', () => {
+		const root = createRoot();
+		const { storage, data } = createFakeStorage();
+		const theme = track(createThemeState({ root, storage }));
+		data.theme = 'high-contrast';
+
+		expect(theme.getPreferredTheme()).toBe('high-contrast');
+		// Not applied until something calls setTheme/resume.
+		expect(theme.getTheme()).toBe('light');
+	});
+});

--- a/site/src/components/theme.md
+++ b/site/src/components/theme.md
@@ -1,0 +1,116 @@
+---
+title: Theme
+description: Switching and persisting themes in the Atlas Design System
+template: standard
+classType: Component
+classPrefixes:
+  - theme
+hero: true
+---
+
+# Theme
+
+Atlas ships three themes out of the box — `light`, `dark`, and `high-contrast` — each expressed as a single class on the document root: `theme-light`, `theme-dark`, or `theme-high-contrast`. Swapping that one class re-themes the entire page. You can add unlimited custom themes via the [color tokens](~/src/tokens/colors.md).
+
+```html-no-example
+<html class="theme-dark">
+	<!-- every Atlas color token now resolves to its dark value -->
+</html>
+```
+
+Use the theme switcher in the toolbar above to cycle this page through the three themes.
+
+## Persisting the theme across page loads
+
+`@microsoft/atlas-js` exports `createThemeState`, a zero-dependency behavior that resolves the active theme (from `localStorage`, then the system `prefers-color-scheme`, then a default), applies the `theme-*` class to `<html>`, persists the user's choice, and wires up click-to-cycle controls. See the [atlas-js README](https://github.com/microsoft/atlas-design/tree/main/js#readme) for the full API.
+
+Because the package is zero-dependency, it does **not** read the theme list from `@microsoft/atlas-css`. Pass your themes in — typically the keys of the Atlas color tokens — so the behavior cycles through exactly the themes your stylesheet ships.
+
+```typescript
+import { createThemeState } from '@microsoft/atlas-js';
+
+const theme = createThemeState({
+	themes: ['light', 'dark', 'high-contrast'],
+	storageKey: 'theme'
+});
+
+// Keep a toggle button's label in sync. Fires immediately with the current
+// theme, then on every later change.
+theme.subscribe(name => {
+	const button = document.querySelector('[data-theme-cycle]');
+	button?.setAttribute('aria-label', `Theme: ${name}`);
+});
+```
+
+### Cycle controls
+
+By default `createThemeState` listens for clicks on any element matching `[data-theme-cycle]` and advances to the next theme in the list, wrapping around at the end. No extra wiring is needed — just add the attribute to a button.
+
+```html-no-example
+<button data-theme-cycle aria-label="Change theme">
+	<span class="icon" aria-hidden="true"><!-- icon --></span>
+</button>
+```
+
+Pass `controlSelector: '.my-selector'` to use a different hook, or `controlSelector: null` to manage controls yourself and drive the theme with `setTheme()` / `cycle()`.
+
+### Options
+
+| Option                | Default                              | Description                                                                                           |
+| --------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `themes`              | `['light', 'dark', 'high-contrast']` | Ordered theme names. The order drives `cycle()`; the first is the fallback default.                   |
+| `storageKey`          | `'theme'`                            | `localStorage` key the active theme is persisted under.                                               |
+| `classPrefix`         | `'theme-'`                           | Prefix joined to the theme name to form the document class.                                           |
+| `defaultTheme`        | `themes[0]`                          | Theme used when nothing is stored and no system preference applies.                                   |
+| `useSystemPreference` | `true`                               | When `true`, a `prefers-color-scheme: dark` match resolves to `systemDarkTheme` when stored is empty. |
+| `systemDarkTheme`     | `'dark'`                             | Theme chosen for a dark system preference. Ignored if absent from `themes`.                           |
+| `controlSelector`     | `'[data-theme-cycle]'`               | Delegated click target that cycles the theme. Pass `null` to skip wiring controls.                    |
+| `root`                | `document.documentElement`           | Element the `theme-*` class is applied to.                                                            |
+| `storage`             | `window.localStorage`                | Storage backing persistence.                                                                          |
+
+## Preventing the theme flash before first paint
+
+Calling `createThemeState()` from a module bundle applies the theme **after** the HTML is parsed. Because module scripts are deferred, the browser briefly paints the markup-default theme (`theme-light`) before the persisted theme takes over — a visible flash for anyone on dark or high-contrast.
+
+Fix it the same way Atlas fixes the [layout flash](~/src/components/layout.md#inline-restore-script-in-head): run a small synchronous IIFE in `<head>`, before the bundle, that applies the persisted (or system) theme before first paint. Keep it dependency-free and wrapped in `try/catch` so a storage exception can never block rendering.
+
+```html-no-example
+<head>
+	<!-- Apply the persisted/system theme before first paint to prevent a wrong-theme flash. -->
+	<script id="theme-preference">
+		(function () {
+			try {
+				var themes = ['light', 'dark', 'high-contrast'];
+				var stored = localStorage.getItem('theme');
+				var theme =
+					themes.indexOf(stored) !== -1
+						? stored
+						: matchMedia('(prefers-color-scheme: dark)').matches
+							? 'dark'
+							: 'light';
+				var html = document.documentElement;
+				for (var i = 0; i < themes.length; i++) {
+					html.classList.remove('theme-' + themes[i]);
+				}
+				html.classList.add('theme-' + theme);
+			} catch (e) {}
+		})();
+	</script>
+	<script type="module" src="/your-bundle.js"></script>
+</head>
+```
+
+The inline guard and `createThemeState` read the same `storageKey` and `classPrefix`, so they always agree. The inline script intentionally handles **only** the flash-prone cases — persisted theme and system dark preference. Richer resolution, such as a `?theme=` query-string override or custom controls, stays in the bundle where `createThemeState` (and any glue around it) runs on load. This split is what lets the page scripts be safely deferred.
+
+<div class="notification notification-warning margin-block-md">
+	<div class="notification-content">
+		<p class="notification-title">Custom themes need a matching array</p>
+		<p class="margin-top-none">
+			The <code>themes</code> array in the inline guard is hardcoded to the three built-in themes
+			(<code>light</code>, <code>dark</code>, <code>high-contrast</code>). If you add custom themes,
+			update this array to match the list you pass to <code>createThemeState</code> — otherwise a
+			stored custom theme won't be recognized before first paint and the guard falls back to the
+			default, reintroducing the flash. Keep the two lists in sync.
+		</p>
+	</div>
+</div>

--- a/site/src/scaffold/homepage.html
+++ b/site/src/scaffold/homepage.html
@@ -14,6 +14,27 @@
 		/>
 		<link rel="stylesheet" href="~/src/scaffold/index.scss" />
 		<link rel="stylesheet" href="~/src/scaffold/styles/homepage.scss" />
+		<!-- Apply the persisted/system theme before first paint to prevent a wrong-theme flash. -->
+		<!-- Full theme resolution (?theme= overrides, controls) is handled by createThemeState on load. -->
+		<script id="theme-preference">
+			(function () {
+				try {
+					var themes = ['light', 'dark', 'high-contrast'];
+					var stored = localStorage.getItem('theme');
+					var theme =
+						themes.indexOf(stored) !== -1
+							? stored
+							: matchMedia('(prefers-color-scheme: dark)').matches
+								? 'dark'
+								: 'light';
+					var html = document.documentElement;
+					for (var i = 0; i < themes.length; i++) {
+						html.classList.remove('theme-' + themes[i]);
+					}
+					html.classList.add('theme-' + theme);
+				} catch (e) {}
+			})();
+		</script>
 		<script type="module" src="~/src/scaffold/index.ts"></script>
 		<link rel="icon" href="~/src/atlas-light.svg" type="image/svg+xml" />
 	</head>

--- a/site/src/scaffold/scripts/theming.ts
+++ b/site/src/scaffold/scripts/theming.ts
@@ -1,167 +1,45 @@
-import { prefersColorSchemeDarkQuery } from './match-media';
-import { localStorage } from './protected-storage';
+import { createThemeState, ThemeStateInstance } from '@microsoft/atlas-js/src/index';
 import { parseQueryString } from './query-string';
 import { atlasTokens } from './tokens';
 
 /**
- * The globally available descriptor of the current theme. It is updated each time setTheme is called.
+ * Theme names are derived from the Atlas CSS tokens so the site always offers
+ * exactly the themes the stylesheet ships. The zero-dependency
+ * `createThemeState` behavior in `@microsoft/atlas-js` owns persistence,
+ * system-preference resolution, class application, and the `[data-theme-cycle]`
+ * controls — this file is just the site-specific glue around it.
  */
-export let currentTheme: ThemeType = 'light';
-export type ThemeType = keyof ThemeTypeMap;
+const themes = Object.keys(atlasTokens.themes.tokens.$themes);
 
-function isTheme(value: string): value is ThemeType {
-	if (value === 'light' || value === 'dark' || value === 'high-contrast') {
-		return true;
-	}
-	return false;
-}
-
-/**
- * Simple string name for each theme.
- */
-export const themes = Object.keys(atlasTokens.themes.tokens.$themes);
-/**
- * Data structure for easy access to theme names and css classes.
- */
-export const themeInfo = themes.reduce((themeInfo, themeName) => {
-	themeInfo[themeName as keyof ThemeTypeMap] = {
-		documentClass: `theme-${themeName}`,
-		name: themeName
-	};
-	return themeInfo;
-}, {} as ThemeTypeMap);
-/**
- * CSS classes related to theming.
- * Used to remove all classes before adding them next one.
- */
-export const cssClasses = themes.map(theme => themeInfo[theme as keyof ThemeTypeMap].documentClass);
-export interface ThemeTypeInfo {
-	documentClass: string;
-	name: string;
-}
-
-export interface ThemeTypeMap {
-	light: ThemeTypeInfo;
-	dark: ThemeTypeInfo;
-	'high-contrast': ThemeTypeInfo;
-}
-
-/**
- * The setTheme functions is used during page.evaulate in screenshots.
- */
 declare global {
 	interface Window {
-		setTheme: typeof setTheme;
+		/** Applies a theme without persisting it. Used by `page.evaluate` in screenshots. */
+		setTheme: (theme: string) => void;
 	}
 }
+
+let themeState: ThemeStateInstance | undefined;
 
 /**
- * Using the current theme key, get the next one in the cycle.
- * @param current The current theme's name.
- * @returns The next theme's name.
- */
-export function cycleKeys(current: keyof ThemeTypeMap): keyof ThemeTypeMap {
-	const i = themes.findIndex(item => item === current) || 0;
-	const next = i < 2 ? i + 1 : 0;
-	// eslint-disable-next-line security/detect-object-injection
-	return themes[next] as keyof ThemeTypeMap;
-}
-
-/**
- * Add class to apply the next theme, and remove previously applied classes.
- * @param appliedTheme The name of the theme we want to apply.
- */
-export function setThemeClass(appliedTheme: ThemeType) {
-	const htmlClassList = document.documentElement.classList;
-	for (const docClass of cssClasses) {
-		htmlClassList.remove(docClass);
-	}
-
-	if (isTheme(appliedTheme)) {
-		// eslint-disable-next-line security/detect-object-injection
-		htmlClassList.add(themeInfo[appliedTheme].documentClass);
-	}
-}
-
-export function setGlobalThemeValue(appliedTheme: ThemeType) {
-	return (currentTheme = appliedTheme);
-}
-
-export function storeTheme(theme: ThemeType) {
-	localStorage.setItem('theme', theme);
-}
-
-export function getPreferredTheme(prefersDarkTheme = false): ThemeType {
-	// check for user selection
-	const theme = localStorage.getItem('theme') as string;
-	if (/^light|dark|high-contrast$/.test(theme)) {
-		return theme as ThemeType;
-	}
-
-	// check for system dark preference
-	if (prefersDarkTheme) {
-		return 'dark';
-	}
-
-	// default to light
-	return 'light';
-}
-
-/**
- * SetTheme is the public way of changing the visual theme. It ensures we use the correct EventBus instance, while allow the user of the function to remain free of such implementation detail..
+ * Initialize theme handling for the documentation site.
  *
- * @param theme The ThemeType to apply to the current window.
+ * The blocking `#theme-preference` script in `<head>` (see
+ * `site/src/components/theme.md`) has already applied the persisted/system
+ * theme before first paint; `createThemeState` re-resolves the same value
+ * (a no-op in the common case) and wires up the cycle controls. After that we
+ * layer on the site-only `?theme=` override used for forcing a theme on load.
  */
-export function setTheme(appliedTheme: ThemeType) {
-	const previousTheme = currentTheme;
-	if (previousTheme === appliedTheme) {
-		return;
-	}
-	setGlobalThemeValue(appliedTheme);
-	setThemeClass(appliedTheme);
-}
+export function initTheme(): ThemeStateInstance {
+	themeState = createThemeState({ themes, storageKey: 'theme' });
 
-/**
- * Initialize Theme related functionality
- */
-export function initTheme() {
-	const theme = getInitialTheme();
-	setTheme(theme);
-	initThemeControls();
-
-	// For use in screenshots
-	window.setTheme = setTheme;
-}
-
-export function getInitialTheme(
-	prefersDarkTheme: boolean = prefersColorSchemeDarkQuery.matches
-): ThemeType {
-	const args = parseQueryString();
-
-	// Themes can be forced with query string arguments.
-	if (args.theme === 'light' || args.theme === 'dark' || args.theme === 'high-contrast') {
-		return args.theme as ThemeType;
+	// Themes can be forced — without persisting — via a `?theme=` query argument.
+	const { theme } = parseQueryString();
+	if (theme && themes.indexOf(theme) !== -1) {
+		themeState.setTheme(theme, false);
 	}
 
-	return getPreferredTheme(prefersDarkTheme);
-}
+	// Exposed for screenshot tooling, which drives the theme via page.evaluate.
+	window.setTheme = (name: string) => themeState?.setTheme(name, false);
 
-/**
- * Listens for clicks on elements with data-theme-cycle attributes.
- * Cycles through list of themes one after the other.
- */
-export function initThemeControls(): void {
-	window.addEventListener('click', ({ target }: Event) => {
-		const button =
-			target instanceof Element && (target.closest('[data-theme-cycle]') as HTMLElement);
-
-		if (!button) {
-			return;
-		}
-
-		const themeToApply = cycleKeys(currentTheme);
-
-		storeTheme(themeToApply);
-		setTheme(themeToApply);
-	});
+	return themeState;
 }

--- a/site/src/scaffold/standard.html
+++ b/site/src/scaffold/standard.html
@@ -5,6 +5,27 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
 		<title>{{title}} | Atlas Design | Microsoft</title>
+		<!-- Apply the persisted/system theme before first paint to prevent a wrong-theme flash. -->
+		<!-- Full theme resolution (?theme= overrides, controls) is handled by createThemeState on load. -->
+		<script id="theme-preference">
+			(function () {
+				try {
+					var themes = ['light', 'dark', 'high-contrast'];
+					var stored = localStorage.getItem('theme');
+					var theme =
+						themes.indexOf(stored) !== -1
+							? stored
+							: matchMedia('(prefers-color-scheme: dark)').matches
+								? 'dark'
+								: 'light';
+					var html = document.documentElement;
+					for (var i = 0; i < themes.length; i++) {
+						html.classList.remove('theme-' + themes[i]);
+					}
+					html.classList.add('theme-' + theme);
+				} catch (e) {}
+			})();
+		</script>
 		<script>
 			(function () {
 					var s = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');

--- a/site/src/scaffold/token.html
+++ b/site/src/scaffold/token.html
@@ -9,6 +9,27 @@
 		<meta property="og:type" content="website" />
 		<meta name="color-scheme" content="light dark" />
 		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-src 'self' https://www.figma.com/; img-src data: 'self' https://github.com/ https://badge.fury.io/ https://*.cloudfront.net https://via.placeholder.com https://docs.microsoft.com https://learn.microsoft.com; style-src 'self' 'unsafe-inline'" >
+		<!-- Apply the persisted/system theme before first paint to prevent a wrong-theme flash. -->
+		<!-- Full theme resolution (?theme= overrides, controls) is handled by createThemeState on load. -->
+		<script id="theme-preference">
+			(function () {
+				try {
+					var themes = ['light', 'dark', 'high-contrast'];
+					var stored = localStorage.getItem('theme');
+					var theme =
+						themes.indexOf(stored) !== -1
+							? stored
+							: matchMedia('(prefers-color-scheme: dark)').matches
+								? 'dark'
+								: 'light';
+					var html = document.documentElement;
+					for (var i = 0; i < themes.length; i++) {
+						html.classList.remove('theme-' + themes[i]);
+					}
+					html.classList.add('theme-' + theme);
+				} catch (e) {}
+			})();
+		</script>
 		<script>
 			(function () {
 					var s = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');


### PR DESCRIPTION
## Summary

Mirrors docs-ui PR [1175046](https://ceapex.visualstudio.com/Engineering/_git/docs-ui/pullrequest/1175046) ("Add render-blocking theme guard to prevent theme flash") in Atlas, and moves theme-switching logic out of the site-only `theming.ts` into the published, **zero-dependency** `@microsoft/atlas-js` package.

### What changed

**New zero-dep behavior — `createThemeState` (`js/src/behaviors/theme.ts`)**
- Manages theme resolution, persistence, cycling, and subscription.
- The theme list is passed as config (default `['light','dark','high-contrast']`) — **not** imported from `@microsoft/atlas-css`, preserving the package's zero-dependency guarantee.
- Mirrors the conventions of the existing `createLayoutState` behavior.
- Exported from `js/src/index.ts`.

**Render-blocking theme guard**
- Added a `#theme-preference` inline IIFE to the `<head>` of the `standard`, `token`, and `homepage` scaffolds.
- Reads `localStorage('theme')`, validates against the known themes, falls back to `prefers-color-scheme: dark`, and applies the `theme-*` class to `<html>` before first paint — eliminating the wrong-theme flash that occurred while the deferred module bundle loaded.

**Slimmed site glue (`site/src/scaffold/scripts/theming.ts`)**
- Now a thin wrapper over `createThemeState`: derives the theme list from the Atlas tokens, keeps the non-persistent `?theme=` override, and continues to expose `window.setTheme` (used by visual-diff tests).

**Docs — `site/src/components/theme.md`**
- Documents the behavior, its options, cycle controls, and the inline guard snippet.
- Includes a `.notification notification-warning` callout noting that the hardcoded theme array in the inline guard must be updated when using custom themes.

**Changeset**
- Minor bump for `@microsoft/atlas-js` and `@microsoft/atlas-site`.

### Testing
- 34 new `[ai generated]`-tagged unit tests in `js/test/behaviors/theme.test.ts` (98% statement / 98% branch / 100% function coverage on the new module).
- `npm run lint`, `npm run build`, and `npm run test` all green for atlas-js; site lint + `tsc --noEmit` pass.