### PR TITLE
Move Sass builds off deprecated APIs

### DIFF
--- a/css/tokens/index.js
+++ b/css/tokens/index.js
@@ -2,7 +2,31 @@ const { readFile, writeFile, mkdir, rm } = require('fs/promises');
 const path = require('path');
 const os = require('os');
 const { quicktype, InputData, jsonInputForTargetLanguage } = require('quicktype-core');
+const sass = require('sass');
 const { exporter } = require('sass-export');
+
+// sass-export@2.1.2 is unmaintained and compiles token values with the
+// deprecated legacy `sass.renderSync` API, wrapping each value in the global
+// `inspect()` built-in. Both are deprecated (legacy-js-api is removed in Dart
+// Sass 2.0, global-builtin in 3.0) and flood the build with warnings. It
+// resolves the same cached `sass` module we require here, so we route its
+// single legacy call through the modern `compileString` API and silence the
+// global-builtin deprecation, which originates in sass-export's own wrapper
+// rather than any Atlas source. The stripped token files contain no
+// `@use`/`@import`, so no load paths are needed, and sass-export only reads
+// `.css` off the returned object.
+const legacyRenderSync = sass.renderSync.bind(sass);
+sass.renderSync = options => {
+	if (options && typeof options.data === 'string') {
+		const { css } = sass.compileString(options.data, {
+			loadPaths: options.includePaths,
+			style: options.outputStyle,
+			silenceDeprecations: ['global-builtin']
+		});
+		return { css };
+	}
+	return legacyRenderSync(options);
+};
 
 createTokens();
 

--- a/site/.sassrc
+++ b/site/.sassrc
@@ -1,5 +1,5 @@
 {
-	"includePaths": [
+	"loadPaths": [
 		"../node_modules"
 	],
 	"quietDeps": true


### PR DESCRIPTION
## What

Eliminates the Dart Sass deprecation warnings emitted during `npm start` and the site/token builds:

- **`[legacy-js-api]`** — [deprecated, removed in Dart Sass 2.0](https://sass-lang.com/documentation/breaking-changes/legacy-js-api/)
- **`[global-builtin]`** — deprecated, removed in Dart Sass 3.0

### 1. `site/.sassrc` — `includePaths` → `loadPaths`

`@parcel/transformer-sass` selects the legacy `sass.render` API whenever the `.sassrc` contains a legacy option such as `includePaths`. Renaming to the modern-API equivalent `loadPaths` switches the transformer to `compileString`. Same `node_modules` resolution, no behavior change.

### 2. `css/tokens/index.js` — route `sass-export` through the modern API

The token build depends on the unmaintained `sass-export@2.1.2` (last released 2022), which compiles every token value with the legacy `sass.renderSync` (~590 warnings per build). No newer version exists. Since `sass-export` resolves the same cached `sass` module, we route its single legacy call through the modern `compileString` API via a small, documented shim.

### 3. `css/tokens/index.js` — silence `global-builtin` from sass-export's wrapper

`sass-export` also wraps every token value in the global `inspect()` built-in (`content:"#{inspect(…)}"`), triggering 41 `global-builtin` warnings. This originates entirely in the dependency's own wrapper, **not** Atlas source — the main `build:css` is clean and `css/src` uses no deprecated globals. Since we can't change the dependency, we silence just that one deprecation in the same `compileString` shim.

## Verification

| Command | `legacy-js-api` | `global-builtin` |
| --- | --- | --- |
| `npm run build:tokens` | 590 → **0** | 41 → **0** |
| `npm run build:css` | 0 → 0 | 0 → 0 |
| `npm run build:site` (full) | ~592 → **0** | 0 → 0 |

Builds succeed with no errors and **token output (`tokens.json` / `tokens.ts`) is byte-identical**.

## No changeset

Both files (`css/tokens/index.js`, `site/.sassrc`) are internal build tooling. Published CSS and token output are unchanged, so no consumer-facing version bump is warranted.
