### PR TITLE
add table-cell-max-width class

### DIFF
--- a/css/src/components/table.scss
+++ b/css/src/components/table.scss
@@ -101,6 +101,12 @@ $table-caption-spacing: tokens.$letter-spacing-medium !default;
 		}
 	}
 
+	&.table-cell-max-width {
+		td {
+			max-width: 40rem;
+		}
+	}
+
 	&.table-sm {
 		th,
 		td {

--- a/css/src/components/table.scss
+++ b/css/src/components/table.scss
@@ -5,6 +5,10 @@ $table-cell-vertical-padding: tokens.$spacer-5 !default;
 $table-cell-horizontal-padding: tokens.$spacer-6 !default;
 $table-cell-padding-compact: tokens.$spacer-3 !default;
 $table-cell-padding-loose: tokens.$spacer-8 !default;
+$table-cell-max-width: min(10rem, 60vw) !default;
+$table-cell-max-width-tablet: 18rem !default;
+$table-cell-max-width-desktop: 24rem !default;
+$table-cell-max-width-widescreen: 30rem !default;
 
 $table-caption-padding: tokens.$spacer-6 !default;
 $table-caption-size: tokens.$font-size-9 !default;
@@ -103,7 +107,19 @@ $table-caption-spacing: tokens.$letter-spacing-medium !default;
 
 	&.table-cell-max-width {
 		td {
-			max-width: 40rem;
+			max-width: $table-cell-max-width;
+
+			@include mixins.tablet {
+				max-width: $table-cell-max-width-tablet;
+			}
+
+			@include mixins.desktop {
+				max-width: $table-cell-max-width-desktop;
+			}
+
+			@include mixins.widescreen {
+				max-width: $table-cell-max-width-widescreen;
+			}
 		}
 	}
 

--- a/site/lib/markdown-renderer.js
+++ b/site/lib/markdown-renderer.js
@@ -116,7 +116,7 @@ const markedOptions = {
 	table(header, body) {
 		return `
 			<div class="markdown table-wrapper margin-top-sm inner-focus" data-focusable-if-scrollable>
-				<table class="table">
+				<table class="table table-cell-max-width">
 					<thead>${header}</thead>
 					<tbody>${body}</tbody>
 				</table>

--- a/site/src/components/table.md
+++ b/site/src/components/table.md
@@ -300,6 +300,32 @@ _`table-sm`_/_`table-lg`_ makes table more or less condensed than the default.
 	</tbody>
 </table>
 
+### Cell max width
+
+_`table-cell-max-width`_ applies a 40rem max width to data cells so long values wrap instead of stretching the table.
+
+<table class="table table-cell-max-width margin-top-sm">
+	<thead>
+		<tr>
+			<th>Heading cell</th>
+			<th>Heading cell</th>
+			<th>Heading cell</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>Cell</td>
+			<td>Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell/Cell</td>
+			<td>Cell</td>
+		</tr>
+		<tr>
+			<td>Cell</td>
+			<td>Cell/Cell/Cell/CellCell/Cell/Cell/CellCell/Cell/Cell/CellCell/Cell/Cell/CellCell/Cell/Cell/CellCell/Cell/Cell/CellCell/Ce</td>
+			<td>Cell</td>
+		</tr>
+	</tbody>
+</table>
+
 ### Stacked on mobile
 
 _`table-stacked-mobile`_ stacks table cells on mobile screen sizes. Please use it wisely due to its unusual appearance, it is not the default behavior for the tables.


### PR DESCRIPTION
Link: [preview](http://localhost:1111/)

Some conceptual content(https://learn.microsoft.com/en-us/azure/templates/microsoft.sql/allversions) includes long resource-like strings that can make table columns overly wide.
This change provides a scoped, explicit solution instead of changing all tables globally.

## Testing

1. Npm run start
2. Go [Tables local host](http://localhost:1111/components/table)
3. Check the screenshot, the part "Cell max width"
   Expected result:
<img width="1186" height="1240" alt="Screenshot (640)" src="https://github.com/user-attachments/assets/8271bd33-ed23-4c93-8671-172b08acc7b6" />



