### PR TITLE
Updating card component's border-radius default value

### DIFF
--- a/.changeset/upset-bushes-bathe.md
+++ b/.changeset/upset-bushes-bathe.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Updating card component's border radius default value.

--- a/css/src/components/card.scss
+++ b/css/src/components/card.scss
@@ -4,7 +4,7 @@
 $card-color: tokens.$text !default;
 $card-shadow: tokens.$box-shadow-light;
 $card-padding: tokens.$spacer-5;
-$card-border-radius: tokens.$border-radius-sm;
+$card-border-radius: tokens.$border-radius-xl;
 $card-row-gap: tokens.$spacer-3 !default;
 $card-column-gap: tokens.$spacer-5 !default;
 


### PR DESCRIPTION
Link: [preview](http://localhost:1111/components/card.html)

Updating card component's border-radius to be 8px by default.

## Testing

1. `git pull; git checkout olga/cards-border-update; npm start`
2. Visit cards page. Make sure border-radius is 8px 

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Did your pull request add anything to the /js/ folder? Consider adding unit tests.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
- [ ] Does your pull request change any transforms? Did you test they work on right to left?
