### PR TITLE
Adding thicker border atomic and border radius reset atomics

### DIFF
--- a/.changeset/twelve-drinks-rush.md
+++ b/.changeset/twelve-drinks-rush.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-site': minor
+'@microsoft/atlas-css': minor
+---
+
+Adding thicker border atomic - `border-xl`, and border radius reset atomics - `border-{side}-radius-none`.

--- a/css/src/atomics/border.scss
+++ b/css/src/atomics/border.scss
@@ -14,6 +14,10 @@
 	border: tokens.$border-width-lg solid tokens.$border !important;
 }
 
+.border-xl {
+	border: tokens.$border-width-xl solid tokens.$border !important;
+}
+
 .border-none {
 	border: none !important;
 }
@@ -31,6 +35,10 @@
 
 	.border-#{$border-key}-lg {
 		border-#{$direction}: tokens.$border-width-lg solid tokens.$border !important;
+	}
+
+	.border-#{$border-key}-xl {
+		border-#{$direction}: tokens.$border-width-xl solid tokens.$border !important;
 	}
 
 	.border-#{$border-key}-none {
@@ -51,6 +59,10 @@
 		border: tokens.$border-width-lg solid tokens.$border !important;
 	}
 
+	.border-xl-tablet {
+		border: tokens.$border-width-xl solid tokens.$border !important;
+	}
+
 	.border-none-tablet {
 		border: none !important;
 	}
@@ -68,6 +80,10 @@
 
 		.border-#{$border-key}-lg-tablet {
 			border-#{$direction}: tokens.$border-width-lg solid tokens.$border !important;
+		}
+
+		.border-#{$border-key}-xl-tablet {
+			border-#{$direction}: tokens.$border-width-xl solid tokens.$border !important;
 		}
 
 		.border-#{$border-key}-none-tablet {
@@ -96,6 +112,22 @@
 
 .border-radius-rounded {
 	border-radius: tokens.$border-radius-rounded !important;
+}
+
+.border-top-left-radius-none {
+	border-start-start-radius: 0 !important;
+}
+
+.border-top-right-radius-none {
+	border-start-end-radius: 0 !important;
+}
+
+.border-bottom-left-radius-none {
+	border-end-start-radius: 0 !important;
+}
+
+.border-bottom-right-radius-none {
+	border-end-end-radius: 0 !important;
 }
 
 .border-radius-none {

--- a/css/src/tokens/border.scss
+++ b/css/src/tokens/border.scss
@@ -2,8 +2,9 @@
  * @sass-export-section="border"
  */
 $border-width: 1px !default;
-$border-width-md: 0.125rem !default;
-$border-width-lg: 0.25rem !default;
+$border-width-md: 0.125rem !default; // 2px
+$border-width-lg: 0.25rem !default; // 4px
+$border-width-xl: 0.5rem !default; // 8px
 
 $border-radius-sm: 0.125rem !default; // 2px
 $border-radius: 0.25rem !default; // 4px

--- a/site/src/atomics/border.md
+++ b/site/src/atomics/border.md
@@ -64,14 +64,18 @@ Here is an example of applying border to specific side of the element:
 
 There are a few classes available to set border radius:
 
-| class                   | size       |
-| ----------------------- | ---------- |
-| `border-radius-sm`      | `0.125rem` |
-| `border-radius`         | `0.25rem`  |
-| `border-radius-lg`      | `0.375rem` |
-| `border-radius-xl`      | `0.5rem`   |
-| `border-radius-rounded` | `290486px` |
-| `border-radius-none`    | `0px`      |
+| class                             | size       |
+| --------------------------------- | ---------- |
+| `border-radius-sm`                | `0.125rem` |
+| `border-radius`                   | `0.25rem`  |
+| `border-radius-lg`                | `0.375rem` |
+| `border-radius-xl`                | `0.5rem`   |
+| `border-radius-rounded`           | `290486px` |
+| `border-top-left-radius-none`     | `0px`      |
+| `border-top-right-radius-none`    | `0px`      |
+| `border-bottom-left-radius-none`  | `0px`      |
+| `border-bottom-right-radius-none` | `0px`      |
+| `border-radius-none`              | `0px`      |
 
 ```html
 <div class="border border-radius-sm padding-sm">
@@ -89,11 +93,16 @@ There are a few classes available to set border radius:
 <div class="border border-radius-rounded padding-sm margin-top-xs">
 	<p>Rounded</p>
 </div>
+<div
+	class="border border-radius-xl border-bottom-left-radius-none border-bottom-right-radius-none padding-sm margin-top-xs"
+>
+	<p>Border radius reset on bottom</p>
+</div>
 ```
 
 ### Size
 
-Additionally `-md` and `-lg` may be added for a thicker border.
+Additionally `-md`, `-lg` and `-xl` may be added for a thicker border.
 
 ```html
 <div class="border-md padding-sm">
@@ -107,6 +116,12 @@ Additionally `-md` and `-lg` may be added for a thicker border.
 </div>
 <div class="border-lg-tablet padding-sm margin-top-xs">
 	<p>Large border on tablet+</p>
+</div>
+<div class="border-xl padding-sm margin-top-xs">
+	<p>Extra large border</p>
+</div>
+<div class="border-xl-tablet padding-sm margin-top-xs">
+	<p>Extra large border on tablet+</p>
 </div>
 ```
 

--- a/site/src/atomics/border.md
+++ b/site/src/atomics/border.md
@@ -10,19 +10,18 @@ classPrefixes:
 
 # Border Atomics
 
-Various classes can be used to apply borders to the elements. Applying the `border` class to the element will add a 1px border to it.
+Applying the `border` atomic to the element will add a 1px border to it.
 
-Mixing the `directions`, `visibility` and `screensize` values will give you more specificity.
+`border-none` removes border from the element.
 
-| modifiers | direction                        | screensize | visibility |
-| --------- | -------------------------------- | ---------- | ---------- |
-| values    | `top`, `right`, `bottom`, `left` | `tablet`   | `none`     |
+Various atomics available to modify different options.
 
-Should be applied in this order:
-
-```css
-border-{direction}-{screensize}-{visibility}
-```
+| modifier                | value                                                       | screensize | visibility |
+| ----------------------- | ----------------------------------------------------------- | ---------- | ---------- |
+| [direction](#direction) | `top`, `right`, `bottom`, `left`                            | `tablet`   | `none`     |
+| [size](#size)           | `md`, `lg`, `xl`                                            | `tablet`   | N\A        |
+| [radius](#radius)       | `sm`, `lg`, `xl`, `rounded`, `none`, `{corner}-none`        | N\A        | N\A        |
+| [colors](#colors)       | `primary`, `danger`, `warning`, `success`, `info`, `accent` | N\A        | N\A        |
 
 ## Usage
 
@@ -34,75 +33,47 @@ Here is an example of `border` class usage:
 </div>
 ```
 
-Here is an example of applying border to specific side of the element:
+### Direction
+
+To apply border to the specific side of the element the directional atomics are available:
+
+| direction                        | screensize | visibility |
+| -------------------------------- | ---------- | ---------- |
+| `top`, `right`, `bottom`, `left` | `tablet`   | `none`     |
+
+Should be applied in this order:
+
+```css
+border-{direction}-{screensize}-{visibility}
+```
 
 ```html
 <div class="border-top padding-sm">
 	<p>Border top</p>
 </div>
-```
 
-```html
-<div class="border-right padding-sm">
+<div class="border-right padding-sm margin-top-sm">
 	<p>Border right</p>
 </div>
-```
 
-```html
-<div class="border-left padding-sm">
+<div class="border-left padding-sm margin-top-sm">
 	<p>Border left</p>
 </div>
-```
 
-```html
-<div class="border-bottom padding-sm">
+<div class="border-bottom padding-sm margin-top-sm">
 	<p>Border bottom</p>
-</div>
-```
-
-### Radius
-
-There are a few classes available to set border radius:
-
-| class                             | size       |
-| --------------------------------- | ---------- |
-| `border-radius-sm`                | `0.125rem` |
-| `border-radius`                   | `0.25rem`  |
-| `border-radius-lg`                | `0.375rem` |
-| `border-radius-xl`                | `0.5rem`   |
-| `border-radius-rounded`           | `290486px` |
-| `border-top-left-radius-none`     | `0px`      |
-| `border-top-right-radius-none`    | `0px`      |
-| `border-bottom-left-radius-none`  | `0px`      |
-| `border-bottom-right-radius-none` | `0px`      |
-| `border-radius-none`              | `0px`      |
-
-```html
-<div class="border border-radius-sm padding-sm">
-	<p>Small radius</p>
-</div>
-<div class="border border-radius padding-sm margin-top-xs">
-	<p>Default radius</p>
-</div>
-<div class="border border-radius-lg padding-sm margin-top-xs">
-	<p>Large radius</p>
-</div>
-<div class="border border-radius-xl padding-sm margin-top-xs">
-	<p>Extra large radius</p>
-</div>
-<div class="border border-radius-rounded padding-sm margin-top-xs">
-	<p>Rounded</p>
-</div>
-<div
-	class="border border-radius-xl border-bottom-left-radius-none border-bottom-right-radius-none padding-sm margin-top-xs"
->
-	<p>Border radius reset on bottom</p>
 </div>
 ```
 
 ### Size
 
-Additionally `-md`, `-lg` and `-xl` may be added for a thicker border.
+Border thickness can be adjusted with following atomics:
+
+| name        | size       | screensize |
+| ----------- | ---------- | ---------- |
+| `border-md` | `0.125rem` | `tablet`   |
+| `border-lg` | `0.25rem`  | `tablet`   |
+| `border-xl` | `0.5rem`   | `tablet`   |
 
 ```html
 <div class="border-md padding-sm">
@@ -125,16 +96,65 @@ Additionally `-md`, `-lg` and `-xl` may be added for a thicker border.
 </div>
 ```
 
+### Radius
+
+To add/modify border radius the following atomics are available:
+
+| name                    | size       | screensize | visibility |
+| ----------------------- | ---------- | ---------- | ---------- |
+| `border-radius-sm`      | `0.125rem` | N\A        | N\A        |
+| `border-radius`         | `0.25rem`  | N\A        | `none`     |
+| `border-radius-lg`      | `0.375rem` | N\A        | N\A        |
+| `border-radius-xl`      | `0.5rem`   | N\A        | N\A        |
+| `border-radius-rounded` | `290486px` | N\A        | N\A        |
+
+```html
+<div class="border border-radius-sm padding-sm">
+	<p>Small radius</p>
+</div>
+<div class="border border-radius padding-sm margin-top-xs">
+	<p>Default radius</p>
+</div>
+<div class="border border-radius-lg padding-sm margin-top-xs">
+	<p>Large radius</p>
+</div>
+<div class="border border-radius-xl padding-sm margin-top-xs">
+	<p>Extra large radius</p>
+</div>
+<div class="border border-radius-rounded padding-sm margin-top-xs">
+	<p>Rounded</p>
+</div>
+```
+
+#### Radius resets
+
+Border radius can be removed from the element by using the `border-radius-none` atomic. If radius needs to be reset on specific corner only, following atomics available as well:
+
+| name                              | screensize |
+| --------------------------------- | ---------- |
+| `border-top-left-radius-none`     | N\A        |
+| `border-top-right-radius-none`    | N\A        |
+| `border-bottom-left-radius-none`  | N\A        |
+| `border-bottom-right-radius-none` | N\A        |
+
+```html
+<div
+	class="border border-radius-xl border-bottom-left-radius-none border-bottom-right-radius-none padding-sm"
+>
+	<p>Border radius reset on bottom</p>
+</div>
+```
+
 ### Colors
 
-The color of a border can be modified using the following classes.
+The color of a border can be modified using the following atomics.
 
 | modifiers | color name                                                  | screensize |
 | --------- | ----------------------------------------------------------- | ---------- |
-| colors    | `primary`, `danger`, `warning`, `success`, `info`, `accent` | n/a        |
+| colors    | `primary`, `danger`, `warning`, `success`, `info`, `accent` | N\A        |
 
 ```html
-<div class="border-color-accent border-left-lg padding-block-md border-radius">
-	<p class="margin-inline-md">Custom Color</p>
+<div class="border-color-success border-left-lg border-radius padding-block-sm">
+	<p class="margin-inline-md">Success Color</p>
 </div>
 ```


### PR DESCRIPTION
Link: [preview](http://localhost:1111/atomics/border.html)

 Adding thicker border atomic - `border-xl`, and border radius reset atomics - `border-{side}-radius-none`.

## Testing

1. `git pull; git checkout olga/border-atomics; npm start`
2. Vitis border atomics page
3. Review the new atomics 

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Did your pull request add anything to the /js/ folder? Consider adding unit tests.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [ ] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
- [ ] Does your pull request change any transforms? Did you test they work on right to left?
