### PR TITLE
Add API link button component

### DIFF
--- a/.changeset/silly-carpets-cover.md
+++ b/.changeset/silly-carpets-cover.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-css': minor
+'@microsoft/atlas-site': minor
+---
+
+Add the API link button component for responsive HTTP method and API path links, including documentation and accessibility coverage.

--- a/css/src/components/api-link-button.scss
+++ b/css/src/components/api-link-button.scss
@@ -35,6 +35,7 @@ $color-danger: tokens.$danger;
 	&.is-hovered,
 	&:active {
 		background-color: tokens.$default-hover-invert;
+		text-decoration: none !important;
 	}
 
 	.api-link-button-method {

--- a/css/src/components/api-link-button.scss
+++ b/css/src/components/api-link-button.scss
@@ -1,0 +1,79 @@
+@use '../mixins/control.scss';
+@use '../tokens/index.scss' as tokens;
+
+$color-primary: tokens.$primary;
+$color-success: tokens.$success;
+$color-danger: tokens.$danger;
+
+.api-link-button-container {
+	container: api-link-button-container / inline-size;
+}
+
+.api-link-button {
+	@extend %control;
+
+	display: grid;
+	align-items: start;
+	width: 100%;
+	grid-template-columns: 7ch minmax(0, 1fr);
+	gap: tokens.$layout-2;
+	padding-inline: 0.75em;
+	border-color: transparent;
+	background-color: transparent;
+	color: tokens.$text;
+	font-family: tokens.$monospace-font-stack;
+	font-size: tokens.$font-size-6;
+	font-weight: tokens.$weight-semibold;
+	text-decoration: none;
+	cursor: pointer;
+
+	&:visited {
+		color: tokens.$text;
+	}
+
+	&:hover,
+	&.is-hovered,
+	&:active {
+		background-color: tokens.$default-hover-invert;
+	}
+
+	.api-link-button-method {
+		grid-area: 1 / 1;
+		text-align: start;
+		text-transform: uppercase;
+
+		&[data-method='get'] {
+			color: #{$color-primary};
+		}
+
+		&[data-method='post'] {
+			color: #{$color-success};
+		}
+
+		&[data-method='delete'] {
+			color: #{$color-danger};
+		}
+	}
+
+	.api-link-button-text {
+		grid-area: 1 / 2;
+		min-inline-size: 0;
+		overflow-wrap: anywhere;
+		text-align: start;
+	}
+}
+
+@container api-link-button-container (max-width: 300px) {
+	.api-link-button {
+		grid-template-columns: minmax(0, 1fr);
+		row-gap: tokens.$layout-1;
+
+		.api-link-button-method {
+			grid-area: 1 / 1;
+		}
+
+		.api-link-button-text {
+			grid-area: 2 / 1;
+		}
+	}
+}

--- a/css/src/components/index.scss
+++ b/css/src/components/index.scss
@@ -1,4 +1,5 @@
 @forward './accordion.scss';
+@forward './api-link-button.scss';
 @forward './badge.scss';
 @forward './banner.scss';
 @forward './breadcrumbs.scss';

--- a/integration/config/page.ts
+++ b/integration/config/page.ts
@@ -30,6 +30,7 @@ export const pages: LocalPageConfig[] = [
 	// { pathname: '/atomics/typography.html', name: 'Atomics/typography', routes },
 	// { pathname: '/atomics/width.html', name: 'Atomics/width', routes },
 	{ pathname: '/atomics/colors.html', name: 'Atomics/colors', routes },
+	{ pathname: '/components/api-link-button.html', name: 'Components/api-link-button', routes },
 	{ pathname: '/components/breadcrumbs.html', name: 'Components/breadcrumbs', routes },
 	{ pathname: '/components/button.html', name: 'Components/button', routes },
 	{ pathname: '/components/checkbox.html', name: 'Components/checkbox', routes },

--- a/integration/tests/accessibility.spec.ts
+++ b/integration/tests/accessibility.spec.ts
@@ -18,6 +18,7 @@ const pathnames = [
 	'/atomics/typography.html',
 	'/components/overview.html',
 	'/components/accordion.html',
+	'/components/api-link-button.html',
 	'/components/badge.html',
 	'/components/banner.html',
 	'/components/breadcrumbs.html',

--- a/site/src/components/api-link-button.md
+++ b/site/src/components/api-link-button.md
@@ -1,0 +1,42 @@
+---
+title: API link button
+description: The API link button component in the Atlas Design System
+template: standard
+classType: Component
+classPrefixes:
+  - api-link-button
+---
+
+# API link button
+
+The API link button presents an HTTP method and flexible API path as a full-width link. It uses standard control sizing with a clear hover treatment.
+
+Place API link buttons inside an `.api-link-button-container`. The container establishes the inline-size context used to stack the method above the path when the container is 300px wide or narrower.
+
+## Default layout
+
+```html
+<div class="api-link-button-container">
+	<a class="api-link-button" href="#default-layout" aria-label="Get a response">
+		<span class="api-link-button-method" data-method="get">get</span>
+		<span class="api-link-button-text">/openai/v1/responses/{response_id}</span>
+	</a>
+</div>
+```
+
+## Narrow layout
+
+The narrow layout reduces the vertical gap between the method and path to keep the stacked link compact.
+
+```html
+<div class="api-link-button-container width-300">
+	<a class="api-link-button" href="#narrow-layout" aria-label="Delete a response">
+		<span class="api-link-button-method" data-method="delete">delete</span>
+		<span class="api-link-button-text">/openai/v1/responses/{response_id}</span>
+	</a>
+</div>
+```
+
+## Method colors
+
+Set `data-method` on `.api-link-button-method` to apply the semantic color for `get`, `post`, or `delete`. Other methods inherit the surrounding text color.


### PR DESCRIPTION
Link: [local preview](http://localhost:1111/components/api-link-button.html)

Adds an API link button component for HTTP method and API path links. The component:

- extends Atlas's `%control` foundation without composing conflicting button classes
- uses a two-track `7ch minmax(0, 1fr)` grid by default
- stacks the method above the path at container widths of 300px or narrower
- preserves full path wrapping and uses an 8px gap in the stacked layout
- includes semantic GET, POST, and DELETE method colors
- includes documentation, accessibility coverage, and a minor changeset

The same component is temporarily mirrored in docs-ui at commit `4ac8d98d9743271f92c4a47efee096e6bf8fd500` until a published Atlas version is available.

## Testing

1. Open the API link button documentation page.
2. Confirm the default example keeps the method and path on one row.
3. Confirm the 300px example stacks the method above the path with an 8px gap.
4. Confirm long paths wrap without clipping or ellipsis.
5. Hover each link and confirm the clear control hover treatment appears.

Validation completed:

- `npm run lint`
- `npm run build:css`
- `npm run build:site`
- `npm run test --workspace=@microsoft/atlas-integration -- --grep "api-link-button"` (2 accessibility tests)
- focused Playwright layout checks for wide and narrow examples

## Additional information

The repository-wide Prettier check still reports six pre-existing files; every file changed by this PR passes the focused Prettier check.

## Contributor checklist

- [x] Did you update the description of this pull request with a review link and test steps?
- [x] Did you submit a changeset? Changesets are required for all code changes.
- [ ] Did your pull request add anything to the /js/ folder? Consider adding unit tests.
- [ ] Does your pull request implement complex UI logic (js/ts)? Consider adding an integration test to test your user flow.
- [x] Does your pull request add a new page to the documentation site? Add your new page for automated accessibility testing in /integration/tests/accessibility.
- [ ] Does your pull request change any transforms? Did you test they work on right to left?
