### PR TITLE
Add adaptive grid width thresholds

### DIFF
--- a/.changeset/bright-grids-adapt.md
+++ b/.changeset/bright-grids-adapt.md
@@ -3,4 +3,4 @@
 '@microsoft/atlas-site': minor
 ---
 
-Add fixed 600px and 800px minimum-width options to the two-column adaptive grid.
+Add 600px and 800px default minimum-width options to the two-column adaptive grid.

--- a/.changeset/bright-grids-adapt.md
+++ b/.changeset/bright-grids-adapt.md
@@ -1,0 +1,6 @@
+---
+'@microsoft/atlas-css': minor
+'@microsoft/atlas-site': minor
+---
+
+Add fixed 600px and 800px minimum-width options to the two-column adaptive grid.

--- a/.changeset/kind-grids-configure.md
+++ b/.changeset/kind-grids-configure.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Replace the adaptive grid's standalone two-column threshold variable with a configurable variant map.

--- a/.github/instructions/adaptive-grid.instructions.md
+++ b/.github/instructions/adaptive-grid.instructions.md
@@ -36,10 +36,10 @@ these decisions when extending the component.
 - CSS custom properties cannot supply size-query thresholds. Do not expose a raw track-template
   custom property or weaken the zero-minimum track invariant as a workaround.
 - Literal threshold variants require design review. Use
-  `.adaptive-grid-columns-N-min-width-PX` for approved, fixed pixel thresholds; do not expose
-  literal thresholds as configurable Sass variables. Keep these variants mutually exclusive with
-  other column modifiers, and avoid ambiguous names such as `.adaptive-grid-2`,
-  `.adaptive-grid-2-800`, or `.adaptive-grid-columns-800`.
+  `.adaptive-grid-columns-N-min-width-PX` for approved pixel thresholds. Keep variants in the
+  component's configurable Sass map, mutually exclusive with other column modifiers, and avoid
+  ambiguous names such as `.adaptive-grid-2`, `.adaptive-grid-2-800`, or
+  `.adaptive-grid-columns-800`.
 - Do not overload numeric column modifiers with weighted or asymmetric layouts. Such layouts need
   separately named presets and a concrete use case.
 

--- a/.github/instructions/adaptive-grid.instructions.md
+++ b/.github/instructions/adaptive-grid.instructions.md
@@ -35,9 +35,11 @@ these decisions when extending the component.
   existing generic container-query tokens.
 - CSS custom properties cannot supply size-query thresholds. Do not expose a raw track-template
   custom property or weaken the zero-minimum track invariant as a workaround.
-- Literal threshold variants require design review. If approved, keep `columns`, encode both the
-  count and an explicit minimum-width marker, and avoid ambiguous names such as
-  `.adaptive-grid-2`, `.adaptive-grid-2-800`, or `.adaptive-grid-columns-800`.
+- Literal threshold variants require design review. Use
+  `.adaptive-grid-columns-N-min-width-PX` for approved, fixed pixel thresholds; do not expose
+  literal thresholds as configurable Sass variables. Keep these variants mutually exclusive with
+  other column modifiers, and avoid ambiguous names such as `.adaptive-grid-2`,
+  `.adaptive-grid-2-800`, or `.adaptive-grid-columns-800`.
 - Do not overload numeric column modifiers with weighted or asymmetric layouts. Such layouts need
   separately named presets and a concrete use case.
 

--- a/css/src/components/adaptive-grid.scss
+++ b/css/src/components/adaptive-grid.scss
@@ -3,6 +3,12 @@
 $adaptive-grid-gap: tokens.$layout-2 !default;
 $adaptive-grid-columns-2-min-width: 400px !default;
 
+$_adaptive-grid-columns-2-variants: (
+	adaptive-grid-columns-2: $adaptive-grid-columns-2-min-width,
+	adaptive-grid-columns-2-min-width-600: 600px,
+	adaptive-grid-columns-2-min-width-800: 800px
+);
+
 @mixin _adaptive-grid-columns-2-at($min-width) {
 	@container adaptive-grid (min-width: #{$min-width}) {
 		> .adaptive-grid-content {
@@ -24,15 +30,9 @@ $adaptive-grid-columns-2-min-width: 400px !default;
 		}
 	}
 
-	&.adaptive-grid-columns-2 {
-		@include _adaptive-grid-columns-2-at($adaptive-grid-columns-2-min-width);
-	}
-
-	&.adaptive-grid-columns-2-min-width-600 {
-		@include _adaptive-grid-columns-2-at(600px);
-	}
-
-	&.adaptive-grid-columns-2-min-width-800 {
-		@include _adaptive-grid-columns-2-at(800px);
+	@each $class-name, $min-width in $_adaptive-grid-columns-2-variants {
+		&.#{$class-name} {
+			@include _adaptive-grid-columns-2-at($min-width);
+		}
 	}
 }

--- a/css/src/components/adaptive-grid.scss
+++ b/css/src/components/adaptive-grid.scss
@@ -3,6 +3,14 @@
 $adaptive-grid-gap: tokens.$layout-2 !default;
 $adaptive-grid-columns-2-min-width: 400px !default;
 
+@mixin _adaptive-grid-columns-2-at($min-width) {
+	@container adaptive-grid (min-width: #{$min-width}) {
+		> .adaptive-grid-content {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+	}
+}
+
 .adaptive-grid {
 	container: adaptive-grid / inline-size;
 
@@ -17,10 +25,14 @@ $adaptive-grid-columns-2-min-width: 400px !default;
 	}
 
 	&.adaptive-grid-columns-2 {
-		@container adaptive-grid (min-width: #{$adaptive-grid-columns-2-min-width}) {
-			> .adaptive-grid-content {
-				grid-template-columns: repeat(2, minmax(0, 1fr));
-			}
-		}
+		@include _adaptive-grid-columns-2-at($adaptive-grid-columns-2-min-width);
+	}
+
+	&.adaptive-grid-columns-2-min-width-600 {
+		@include _adaptive-grid-columns-2-at(600px);
+	}
+
+	&.adaptive-grid-columns-2-min-width-800 {
+		@include _adaptive-grid-columns-2-at(800px);
 	}
 }

--- a/css/src/components/adaptive-grid.scss
+++ b/css/src/components/adaptive-grid.scss
@@ -1,13 +1,12 @@
 @use '../tokens/index.scss' as tokens;
 
 $adaptive-grid-gap: tokens.$layout-2 !default;
-$adaptive-grid-columns-2-min-width: 400px !default;
 
-$_adaptive-grid-columns-2-variants: (
-	adaptive-grid-columns-2: $adaptive-grid-columns-2-min-width,
+$adaptive-grid-columns-2-variants: (
+	adaptive-grid-columns-2: 400px,
 	adaptive-grid-columns-2-min-width-600: 600px,
 	adaptive-grid-columns-2-min-width-800: 800px
-);
+) !default;
 
 @mixin _adaptive-grid-columns-2-at($min-width) {
 	@container adaptive-grid (min-width: #{$min-width}) {
@@ -30,7 +29,7 @@ $_adaptive-grid-columns-2-variants: (
 		}
 	}
 
-	@each $class-name, $min-width in $_adaptive-grid-columns-2-variants {
+	@each $class-name, $min-width in $adaptive-grid-columns-2-variants {
 		&.#{$class-name} {
 			@include _adaptive-grid-columns-2-at($min-width);
 		}

--- a/site/src/components/adaptive-grid.md
+++ b/site/src/components/adaptive-grid.md
@@ -10,9 +10,9 @@ classPrefixes:
 # Adaptive grid
 
 The adaptive grid uses CSS container queries to arrange content according to the space available
-to the grid itself, rather than the viewport. It uses one equal-width column by default. Add
-`.adaptive-grid-columns-2` to use two equal-width columns when the query container's content box
-is at least 400px wide.
+to the grid itself, rather than the viewport. It uses one equal-width column by default. Add one
+column modifier to use two equal-width columns when the query container's content box reaches the
+modifier's minimum width.
 
 The wrapper, content, and item classes are required. `.adaptive-grid` establishes the named query
 container, its direct `.adaptive-grid-content` child receives the grid layout, and each direct
@@ -43,6 +43,19 @@ Resize the available content area to see this example switch between one and two
 	</div>
 </div>
 ```
+
+### Two-column thresholds
+
+Choose exactly one two-column modifier. Do not combine column modifiers on the same grid.
+
+| Modifier                                 | Minimum content-box width              |
+| ---------------------------------------- | -------------------------------------- |
+| `.adaptive-grid-columns-2`               | 400px by default; configurable in Sass |
+| `.adaptive-grid-columns-2-min-width-600` | 600px                                  |
+| `.adaptive-grid-columns-2-min-width-800` | 800px                                  |
+
+The numeric suffixes are fixed pixel thresholds. Borders and padding are outside the queried
+content box and do not count toward the minimum width.
 
 ## Container size, not viewport size
 
@@ -83,15 +96,17 @@ Every track uses `minmax(0, 1fr)`, and direct `.adaptive-grid-item` children hav
 shrink within a track instead of forcing the grid wider than its container. Consumers can apply
 an appropriate overflow or wrapping treatment to the content itself.
 
-Consumers compiling Atlas Sass can configure the default gap and two-column threshold with
-`$adaptive-grid-gap` and `$adaptive-grid-columns-2-min-width`.
+Consumers compiling Atlas Sass can configure the default gap and the unsuffixed two-column
+threshold with `$adaptive-grid-gap` and `$adaptive-grid-columns-2-min-width`. The
+`.adaptive-grid-columns-2-min-width-600` and `.adaptive-grid-columns-2-min-width-800` thresholds
+are fixed.
 
 ## Interactive container size
 
-Use the button groups to apply the column modifier and gap atomics, then use the slider to change
+Use the button groups to apply a column modifier and gap atomics, then use the slider to change
 this preview's outer inline size. The slider updates a CSS custom property on the demo parent
 without changing the viewport. The grid switches to two columns when its queried content box
-reaches 400px; the displayed outer width also includes its border and padding.
+reaches the selected threshold; the displayed outer width also includes its border and padding.
 
 <div class="adaptive-grid-demo margin-top-sm" data-adaptive-grid-resizer>
 	<div class="adaptive-grid-demo-options">
@@ -124,6 +139,24 @@ reaches 400px; the displayed outer width also includes its border and padding.
 					data-adaptive-grid-class-group="columns"
 				>
 					.adaptive-grid-columns-2
+				</button>
+				<button
+					class="button"
+					type="button"
+					aria-pressed="false"
+					data-adaptive-grid-class="adaptive-grid-columns-2-min-width-600"
+					data-adaptive-grid-class-group="columns"
+				>
+					.adaptive-grid-columns-2-min-width-600
+				</button>
+				<button
+					class="button"
+					type="button"
+					aria-pressed="false"
+					data-adaptive-grid-class="adaptive-grid-columns-2-min-width-800"
+					data-adaptive-grid-class-group="columns"
+				>
+					.adaptive-grid-columns-2-min-width-800
 				</button>
 			</div>
 		</div>
@@ -178,7 +211,7 @@ reaches 400px; the displayed outer width also includes its border and padding.
 			id="adaptive-grid-width"
 			type="range"
 			min="240"
-			max="800"
+			max="1000"
 			value="600"
 			data-adaptive-grid-resizer-input
 		/>

--- a/site/src/components/adaptive-grid.md
+++ b/site/src/components/adaptive-grid.md
@@ -48,14 +48,14 @@ Resize the available content area to see this example switch between one and two
 
 Choose exactly one two-column modifier. Do not combine column modifiers on the same grid.
 
-| Modifier                                 | Minimum content-box width              |
-| ---------------------------------------- | -------------------------------------- |
-| `.adaptive-grid-columns-2`               | 400px by default; configurable in Sass |
-| `.adaptive-grid-columns-2-min-width-600` | 600px                                  |
-| `.adaptive-grid-columns-2-min-width-800` | 800px                                  |
+| Modifier                                 | Minimum content-box width |
+| ---------------------------------------- | ------------------------- |
+| `.adaptive-grid-columns-2`               | 400px                     |
+| `.adaptive-grid-columns-2-min-width-600` | 600px                     |
+| `.adaptive-grid-columns-2-min-width-800` | 800px                     |
 
-The numeric suffixes are fixed pixel thresholds. Borders and padding are outside the queried
-content box and do not count toward the minimum width.
+These are the default pixel thresholds. Borders and padding are outside the queried content box
+and do not count toward the minimum width.
 
 ## Container size, not viewport size
 
@@ -96,10 +96,8 @@ Every track uses `minmax(0, 1fr)`, and direct `.adaptive-grid-item` children hav
 shrink within a track instead of forcing the grid wider than its container. Consumers can apply
 an appropriate overflow or wrapping treatment to the content itself.
 
-Consumers compiling Atlas Sass can configure the default gap and the unsuffixed two-column
-threshold with `$adaptive-grid-gap` and `$adaptive-grid-columns-2-min-width`. The
-`.adaptive-grid-columns-2-min-width-600` and `.adaptive-grid-columns-2-min-width-800` thresholds
-are fixed.
+Consumers compiling Atlas Sass can configure the default gap with `$adaptive-grid-gap` and the
+two-column class and threshold pairs with `$adaptive-grid-columns-2-variants`.
 
 ## Interactive container size
 

--- a/site/src/scaffold/scripts/adaptive-grid-demo.ts
+++ b/site/src/scaffold/scripts/adaptive-grid-demo.ts
@@ -8,7 +8,11 @@ const CLASS_GROUPS = new Map([
 		'columns',
 		{
 			selector: '.adaptive-grid-demo-preview',
-			classes: ['adaptive-grid-columns-2']
+			classes: [
+				'adaptive-grid-columns-2',
+				'adaptive-grid-columns-2-min-width-600',
+				'adaptive-grid-columns-2-min-width-800'
+			]
 		}
 	],
 	[


### PR DESCRIPTION
## Summary

- add fixed 600px and 800px minimum-width variants for the two-column adaptive grid
- document the mutually exclusive threshold API and fixed literal naming
- add both variants to the interactive adaptive-grid demo

## API

- `.adaptive-grid-columns-2` keeps its configurable 400px default
- `.adaptive-grid-columns-2-min-width-600` activates at 600px
- `.adaptive-grid-columns-2-min-width-800` activates at 800px

The literal variants intentionally remain fixed so their class names cannot diverge from their behavior.

## Validation

- `npm run lint:css`
- `npm run build:css`
- `npm run build:site`
- pre-push lint suite