### PR TITLE
Improve adaptive grid interactive example

### DIFF
--- a/site/src/components/adaptive-grid.md
+++ b/site/src/components/adaptive-grid.md
@@ -102,9 +102,12 @@ two-column class and threshold pairs with `$adaptive-grid-columns-2-variants`.
 ## Interactive container size
 
 Use the button groups to apply a column modifier and gap atomics, then use the slider to change
-this preview's outer inline size. The slider updates a CSS custom property on the demo parent
-without changing the viewport. The grid switches to two columns when its queried content box
-reaches the selected threshold; the displayed outer width also includes its border and padding.
+this preview's inline size. The slider updates a CSS custom property on the demo parent without
+changing the viewport. The grid switches to two columns when its queried content box reaches the
+selected threshold.
+
+Use this interactive example on a wide screen. On narrower screens, the slider is limited to the
+available space, so larger column thresholds may not be reachable.
 
 <div class="adaptive-grid-demo margin-top-sm" data-adaptive-grid-resizer>
 	<div class="adaptive-grid-demo-options">
@@ -166,15 +169,6 @@ reaches the selected threshold; the displayed outer width also includes its bord
 				<button
 					class="button"
 					type="button"
-					aria-pressed="true"
-					data-adaptive-grid-class=""
-					data-adaptive-grid-class-group="gap"
-				>
-					Default
-				</button>
-				<button
-					class="button"
-					type="button"
 					aria-pressed="false"
 					data-adaptive-grid-class="gap-none"
 					data-adaptive-grid-class-group="gap"
@@ -184,11 +178,11 @@ reaches the selected threshold; the displayed outer width also includes its bord
 				<button
 					class="button"
 					type="button"
-					aria-pressed="false"
+					aria-pressed="true"
 					data-adaptive-grid-class="gap-xs"
 					data-adaptive-grid-class-group="gap"
 				>
-					.gap-xs
+					.gap-xs (default)
 				</button>
 				<button
 					class="button"
@@ -202,56 +196,37 @@ reaches the selected threshold; the displayed outer width also includes its bord
 			</div>
 		</div>
 	</div>
-	<div class="adaptive-grid-demo-controls">
-		<label for="adaptive-grid-width">Preview outer width</label>
-		<input
-			class="adaptive-grid-demo-slider"
-			id="adaptive-grid-width"
-			type="range"
-			min="240"
-			max="1000"
-			value="600"
-			data-adaptive-grid-resizer-input
-		/>
-		<output for="adaptive-grid-width" data-adaptive-grid-resizer-output>600px</output>
-	</div>
 	<div
-		class="adaptive-grid adaptive-grid-columns-2 adaptive-grid-demo-preview border border-radius padding-sm"
+		class="adaptive-grid-demo-workspace background-color-body-accent border-radius padding-block-sm"
 	>
-		<div class="adaptive-grid-content">
-			<div class="adaptive-grid-item border border-radius padding-sm">Item 1</div>
-			<div class="adaptive-grid-item border border-radius padding-sm">Item 2</div>
-			<div class="adaptive-grid-item border border-radius padding-sm">Item 3</div>
-			<div class="adaptive-grid-item border border-radius padding-sm">Item 4</div>
-			<div class="adaptive-grid-item border border-radius padding-sm">Item 5</div>
-			<div class="adaptive-grid-item border border-radius padding-sm">Item 6</div>
-			<div class="adaptive-grid-item border border-radius padding-sm">Item 7</div>
-			<div class="adaptive-grid-item border border-radius padding-sm">Item 8</div>
-			<div class="adaptive-grid-item border border-radius padding-sm">Item 9</div>
-			<div class="adaptive-grid-item border border-radius padding-sm">Item 10</div>
-			<div class="adaptive-grid-item border border-radius padding-sm">Item 11</div>
-			<div class="adaptive-grid-item border border-radius padding-sm">Item 12</div>
+		<div class="adaptive-grid-demo-controls padding-inline-sm">
+			<label for="adaptive-grid-width">Preview width</label>
+			<input
+				class="adaptive-grid-demo-slider"
+				id="adaptive-grid-width"
+				type="range"
+				min="240"
+				max="1000"
+				value="600"
+				data-adaptive-grid-resizer-input
+			/>
+			<output for="adaptive-grid-width" data-adaptive-grid-resizer-output>600px</output>
+		</div>
+		<div class="adaptive-grid adaptive-grid-columns-2 adaptive-grid-demo-preview">
+			<div class="adaptive-grid-content gap-xs">
+				<div class="adaptive-grid-item border border-radius padding-sm background-color-body">Item 1</div>
+				<div class="adaptive-grid-item border border-radius padding-sm background-color-body">Item 2</div>
+				<div class="adaptive-grid-item border border-radius padding-sm background-color-body">Item 3</div>
+				<div class="adaptive-grid-item border border-radius padding-sm background-color-body">Item 4</div>
+				<div class="adaptive-grid-item border border-radius padding-sm background-color-body">Item 5</div>
+				<div class="adaptive-grid-item border border-radius padding-sm background-color-body">Item 6</div>
+				<div class="adaptive-grid-item border border-radius padding-sm background-color-body">Item 7</div>
+				<div class="adaptive-grid-item border border-radius padding-sm background-color-body">Item 8</div>
+				<div class="adaptive-grid-item border border-radius padding-sm background-color-body">Item 9</div>
+				<div class="adaptive-grid-item border border-radius padding-sm background-color-body">Item 10</div>
+				<div class="adaptive-grid-item border border-radius padding-sm background-color-body">Item 11</div>
+				<div class="adaptive-grid-item border border-radius padding-sm background-color-body">Item 12</div>
+			</div>
 		</div>
 	</div>
 </div>
-
-The component markup used in the preview is:
-
-```html-no-example
-<div class="adaptive-grid adaptive-grid-columns-2">
-	<div class="adaptive-grid-content">
-		<div class="adaptive-grid-item border border-radius padding-sm">Item 1</div>
-		<div class="adaptive-grid-item border border-radius padding-sm">Item 2</div>
-		<div class="adaptive-grid-item border border-radius padding-sm">Item 3</div>
-		<div class="adaptive-grid-item border border-radius padding-sm">Item 4</div>
-		<div class="adaptive-grid-item border border-radius padding-sm">Item 5</div>
-		<div class="adaptive-grid-item border border-radius padding-sm">Item 6</div>
-		<div class="adaptive-grid-item border border-radius padding-sm">Item 7</div>
-		<div class="adaptive-grid-item border border-radius padding-sm">Item 8</div>
-		<div class="adaptive-grid-item border border-radius padding-sm">Item 9</div>
-		<div class="adaptive-grid-item border border-radius padding-sm">Item 10</div>
-		<div class="adaptive-grid-item border border-radius padding-sm">Item 11</div>
-		<div class="adaptive-grid-item border border-radius padding-sm">Item 12</div>
-	</div>
-</div>
-```

--- a/site/src/scaffold/scripts/adaptive-grid-demo.ts
+++ b/site/src/scaffold/scripts/adaptive-grid-demo.ts
@@ -2,7 +2,9 @@ const RESIZER_SELECTOR = '[data-adaptive-grid-resizer]';
 const INPUT_SELECTOR = '[data-adaptive-grid-resizer-input]';
 const OUTPUT_SELECTOR = '[data-adaptive-grid-resizer-output]';
 const CLASS_BUTTON_SELECTOR = '[data-adaptive-grid-class]';
+const WORKSPACE_SELECTOR = '.adaptive-grid-demo-workspace';
 const WIDTH_PROPERTY = '--adaptive-grid-demo-width';
+const MIN_PREVIEW_WIDTH = 240;
 const CLASS_GROUPS = new Map([
 	[
 		'columns',
@@ -25,6 +27,31 @@ const CLASS_GROUPS = new Map([
 ]);
 
 export function initAdaptiveGridDemos() {
+	const resizeObserver = new ResizeObserver(entries => {
+		for (const entry of entries) {
+			const workspace = entry.target;
+			const demo = workspace.closest<HTMLElement>(RESIZER_SELECTOR);
+			const input = demo?.querySelector<HTMLInputElement>(INPUT_SELECTOR);
+			const output = demo?.querySelector<HTMLOutputElement>(OUTPUT_SELECTOR);
+			const availableWidth = Math.floor(workspace.getBoundingClientRect().width);
+
+			if (!demo || !input || !output) {
+				throw new Error('Misconfigured adaptive grid demo');
+			}
+			if (availableWidth < 1) {
+				continue;
+			}
+
+			input.min = String(Math.min(MIN_PREVIEW_WIDTH, availableWidth));
+			input.max = String(availableWidth);
+			updateDemoWidth(demo, input, output, Math.min(Number(input.value), availableWidth));
+		}
+	});
+
+	for (const workspace of document.querySelectorAll<HTMLElement>(WORKSPACE_SELECTOR)) {
+		resizeObserver.observe(workspace);
+	}
+
 	window.addEventListener('input', event => {
 		const input = event.target instanceof Element && event.target.closest(INPUT_SELECTOR);
 		if (!(input instanceof HTMLInputElement)) {
@@ -39,8 +66,7 @@ export function initAdaptiveGridDemos() {
 			throw new Error('Misconfigured adaptive grid demo');
 		}
 
-		demo.style.setProperty(WIDTH_PROPERTY, `${width}px`);
-		output.value = `${width}px`;
+		updateDemoWidth(demo, input, output, width);
 	});
 
 	window.addEventListener('click', event => {
@@ -77,4 +103,15 @@ export function initAdaptiveGridDemos() {
 			);
 		}
 	});
+}
+
+function updateDemoWidth(
+	demo: HTMLElement,
+	input: HTMLInputElement,
+	output: HTMLOutputElement,
+	width: number
+) {
+	input.value = String(width);
+	demo.style.setProperty(WIDTH_PROPERTY, `${width}px`);
+	output.value = `${width}px`;
 }

--- a/site/src/scaffold/styles/adaptive-grid-demo.scss
+++ b/site/src/scaffold/styles/adaptive-grid-demo.scss
@@ -1,4 +1,5 @@
 @use '@microsoft/atlas-css/src/tokens/index.scss' as tokens;
+@use '@microsoft/atlas-css/src/mixins/index.scss' as mixins;
 @use '@microsoft/atlas-css/src/components/button.scss' as button;
 
 [data-adaptive-grid-class][aria-pressed='true'] {
@@ -13,6 +14,21 @@
 		display: grid;
 		gap: tokens.$layout-2;
 		margin-block-end: tokens.$layout-2;
+	}
+
+	.adaptive-grid-demo-workspace {
+		@include mixins.desktop {
+			--adaptive-grid-demo-available-width: min(
+				1000px,
+				calc(
+					100vw - var(--layout-menu-width) - var(--layout-menu-spacer-width) -
+						var(--layout-aside-spacer-width) - var(--layout-aside-width) - (var(--layout-gap) * 2)
+				)
+			);
+
+			inline-size: var(--adaptive-grid-demo-available-width);
+			margin-inline: calc((100% - var(--adaptive-grid-demo-available-width)) / 2);
+		}
 	}
 
 	.adaptive-grid-demo-option-label {


### PR DESCRIPTION
## Summary

- Let the interactive workspace break out of the page reading width while keeping its controls aligned with normal prose.
- Separate the visual workspace from the width-query container so slider values match the queried content width.
- Clamp the slider to the workspace width as the viewport changes.
- Represent the component's default gap with the equivalent `.gap-xs` atomic.
- Simplify the example and add narrow-screen guidance.

## Testing

- `npm run build:site`
- `npm run lint`
