### PR TITLE
Fix nested accordion chevron state

### DIFF
--- a/.changeset/kind-plums-smile.md
+++ b/.changeset/kind-plums-smile.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/atlas-css': patch
+---
+
+Fix nested accordion chevrons so each indicator follows its own open state.

--- a/css/src/components/accordion.scss
+++ b/css/src/components/accordion.scss
@@ -17,17 +17,17 @@ $accordion-transition: transform 0.15s !default;
 	$icon-before-offset-size: calc($font-size - 0.375rem);
 	$icon-after-offset-size: calc($font-size - 0.5rem);
 
-	summary {
+	> summary {
 		font-size: $font-size;
 	}
 
-	&:not(.accordion-icon-end) summary {
+	&:not(.accordion-icon-end) > summary {
 		&::before {
 			margin-block-start: $icon-before-offset-size;
 		}
 	}
 
-	&.accordion-icon-end summary {
+	&.accordion-icon-end > summary {
 		&::after {
 			margin-block-start: $icon-after-offset-size;
 		}
@@ -37,7 +37,7 @@ $accordion-transition: transform 0.15s !default;
 .accordion {
 	@include accordion-summary-sizes($accordion-font-size-md);
 
-	summary {
+	> summary {
 		display: flex;
 		line-height: 1.5;
 		list-style: none;
@@ -61,49 +61,49 @@ $accordion-transition: transform 0.15s !default;
 	}
 
 	&:not(.accordion-icon-end) {
-		summary::before {
+		> summary::before {
 			@include mixins.chevron-right;
 
 			transition: $accordion-transition;
 		}
 
-		&:dir(rtl) summary::before {
+		&:dir(rtl) > summary::before {
 			@include mixins.chevron-right-rtl;
 		}
 	}
 
 	&.accordion-icon-end {
-		summary::after {
+		> summary::after {
 			@include mixins.chevron-down;
 
 			transition: $accordion-transition;
 		}
 
-		&:dir(rtl) summary::after {
+		&:dir(rtl) > summary::after {
 			@include mixins.chevron-down-rtl;
 		}
 	}
 
 	&[open] {
 		&:not(.accordion-icon-end) {
-			summary::before {
+			> summary::before {
 				transform: mixins.$chevron-down-rotate translate(calc(mixins.$chevron-arrow-size / 2), 0);
 			}
 
 			/* stylelint-disable-next-line selector-max-specificity, rule-empty-line-before */
-			&:dir(rtl) summary::before {
+			&:dir(rtl) > summary::before {
 				transform: mixins.$chevron-down-rotate-rtl
 					translate(calc(mixins.$chevron-arrow-size / 2 * -1), 0);
 			}
 		}
 
 		&.accordion-icon-end {
-			summary::after {
+			> summary::after {
 				transform: mixins.$chevron-up-rotate-scale-xy;
 			}
 
 			/* stylelint-disable-next-line selector-max-specificity, rule-empty-line-before */
-			&:dir(rtl) summary::after {
+			&:dir(rtl) > summary::after {
 				transform: mixins.$chevron-up-rotate-scale-xy-rtl;
 			}
 		}

--- a/site/src/components/accordion.md
+++ b/site/src/components/accordion.md
@@ -46,6 +46,37 @@ Here is an example of a standard `.accordion` usage. By default, accordion items
 
 ## Attributes
 
+### Nested accordions
+
+Each nested accordion follows its own open or closed state.
+
+```html
+<details class="accordion" open>
+	<summary>
+		<div class="accordion-header">Open parent accordion</div>
+	</summary>
+	<div class="accordion-content">
+		<details class="accordion">
+			<summary>
+				<div class="accordion-header">Closed child accordion</div>
+			</summary>
+			<div class="accordion-content">
+				<p>Child accordion panel</p>
+			</div>
+		</details>
+
+		<details class="accordion" open>
+			<summary>
+				<div class="accordion-header">Open child accordion</div>
+			</summary>
+			<div class="accordion-content">
+				<p>Child accordion panel</p>
+			</div>
+		</details>
+	</div>
+</details>
+```
+
 ### Open
 
 To load the accordion component in the expanded state by default, add the `open` attribute to the `<details>` element.


### PR DESCRIPTION
## Summary

- scope accordion summary and chevron styles to each accordion's direct `<summary>`
- prevent an open parent accordion from changing nested accordion indicator states
- add a nested accordion example with open and closed children
- add a patch changeset for `@microsoft/atlas-css`

## Validation

- verified standalone and nested open/closed indicators in LTR and RTL
- verified both start-position and end-position chevrons
- Atlas lint passes
- Atlas documentation site builds successfully
- the accordion page is covered by the existing visual-diff and accessibility suites
